### PR TITLE
feat: add v1 wp-admin app components

### DIFF
--- a/src/apps/AppearanceApp.js
+++ b/src/apps/AppearanceApp.js
@@ -1,0 +1,226 @@
+import { useEffect, useState, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	InputControl,
+	Stack,
+	Text,
+	Notice,
+} from '@wordpress/ui';
+import {
+	RadioControl,
+	SelectControl,
+	Spinner,
+	__experimentalDivider as Divider,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const DENSITY_OPTIONS = [
+	{ value: 'default', label: __( 'Comfortable', 'wp-admin-shell' ) },
+	{ value: 'compact', label: __( 'Compact', 'wp-admin-shell' ) },
+	{ value: 'spacious', label: __( 'Spacious', 'wp-admin-shell' ) },
+];
+
+const ENDPOINT = '/wp-admin-shell/v1/user-prefs';
+
+export default function AppearanceApp( { config = {} } ) {
+	const customizable = config.userCustomizable ?? true;
+	const allowedFields = Array.isArray( customizable )
+		? customizable
+		: customizable === true
+		? [ 'density', 'accent', 'defaultRoute' ]
+		: [];
+
+	const [ prefs, setPrefs ] = useState( null );
+	const [ initial, setInitial ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ notice, setNotice ] = useState( null );
+
+	useEffect( () => {
+		let cancelled = false;
+		apiFetch( { path: ENDPOINT } )
+			.then( ( res ) => {
+				if ( cancelled ) {
+					return;
+				}
+				const seed = res || {};
+				setPrefs( seed );
+				setInitial( seed );
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					// Endpoint not available yet (lands in M5). Use a local
+					// fallback so the UI renders against window state.
+					const seed = window.wpAdminShell?.userPrefs || {};
+					setPrefs( seed );
+					setInitial( seed );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [] );
+
+	const set = useCallback( ( patch ) => {
+		setPrefs( ( p ) => ( { ...( p || {} ), ...patch } ) );
+	}, [] );
+
+	const hasEdits = prefs && initial && JSON.stringify( prefs ) !== JSON.stringify( initial );
+
+	const save = async () => {
+		setIsSaving( true );
+		try {
+			await apiFetch( {
+				path: ENDPOINT,
+				method: 'POST',
+				data: prefs,
+			} );
+			setInitial( prefs );
+			setNotice( {
+				intent: 'success',
+				message: __( 'Preferences saved.', 'wp-admin-shell' ),
+			} );
+		} catch ( err ) {
+			setNotice( {
+				intent: 'error',
+				message:
+					err.message ||
+					__( 'Could not save preferences.', 'wp-admin-shell' ),
+			} );
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	if ( isLoading || ! prefs ) {
+		return (
+			<div className="wp-admin-shell-app-appearance__loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	const allows = ( field ) => allowedFields.includes( field );
+
+	return (
+		<div className="wp-admin-shell-app-appearance">
+			<Stack direction="column" gap="xl">
+				<Stack direction="column" gap="xs">
+					<Text variant="heading-xl" render={ <h2 /> }>
+						{ __( 'Appearance', 'wp-admin-shell' ) }
+					</Text>
+					<Text variant="body-md">
+						{ __(
+							'Personal preferences for this admin shell. Only the options the active shell allows are shown here.',
+							'wp-admin-shell'
+						) }
+					</Text>
+				</Stack>
+
+				{ notice && (
+					<Notice.Root intent={ notice.intent }>
+						<Notice.Description>
+							{ notice.message }
+						</Notice.Description>
+						<Notice.Actions>
+							<Notice.CloseIcon
+								onClick={ () => setNotice( null ) }
+							/>
+						</Notice.Actions>
+					</Notice.Root>
+				) }
+
+				{ allows( 'density' ) && (
+					<RadioControl
+						label={ __( 'Density', 'wp-admin-shell' ) }
+						selected={ prefs.density || 'default' }
+						options={ DENSITY_OPTIONS }
+						onChange={ ( v ) => set( { density: v } ) }
+					/>
+				) }
+
+				{ allows( 'accent' ) && (
+					<Stack direction="column" gap="xs">
+						<InputControl
+							label={ __( 'Accent color', 'wp-admin-shell' ) }
+							type="color"
+							value={ prefs.accent || '#1d4ed8' }
+							onChange={ ( e ) =>
+								set( { accent: e.target.value } )
+							}
+						/>
+						<Text variant="body-sm">
+							{ __(
+								'Overrides the shell-defined accent on links and buttons.',
+								'wp-admin-shell'
+							) }
+						</Text>
+					</Stack>
+				) }
+
+				{ allows( 'defaultRoute' ) && (
+					<SelectControl
+						label={ __( 'Open on sign-in', 'wp-admin-shell' ) }
+						value={ prefs.defaultRoute || '' }
+						options={ [
+							{
+								value: '',
+								label: __(
+									'Shell default',
+									'wp-admin-shell'
+								),
+							},
+							{
+								value: 'dashboard',
+								label: __( 'Dashboard', 'wp-admin-shell' ),
+							},
+							{
+								value: 'posts',
+								label: __( 'Posts', 'wp-admin-shell' ),
+							},
+							{
+								value: 'media',
+								label: __( 'Media', 'wp-admin-shell' ),
+							},
+							{
+								value: 'comments',
+								label: __( 'Comments', 'wp-admin-shell' ),
+							},
+						] }
+						onChange={ ( v ) => set( { defaultRoute: v } ) }
+						__nextHasNoMarginBottom
+					/>
+				) }
+
+				{ allowedFields.length === 0 && (
+					<Text variant="body-md">
+						{ __(
+							'The active shell does not expose any user-customizable preferences.',
+							'wp-admin-shell'
+						) }
+					</Text>
+				) }
+
+				<Divider />
+
+				<Stack direction="row" justify="flex-start">
+					<Button
+						tone="brand"
+						variant="solid"
+						onClick={ save }
+						disabled={ ! hasEdits || isSaving }
+						loading={ isSaving }
+					>
+						{ __( 'Save preferences', 'wp-admin-shell' ) }
+					</Button>
+				</Stack>
+			</Stack>
+		</div>
+	);
+}

--- a/src/apps/CommentsApp.js
+++ b/src/apps/CommentsApp.js
@@ -1,0 +1,324 @@
+import { useMemo, useState } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { DataViews } from '@wordpress/dataviews';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { check, closeSmall, trash, external } from '@wordpress/icons';
+
+const STATUS_LABELS = {
+	approved: __( 'Approved', 'wp-admin-shell' ),
+	hold: __( 'Pending', 'wp-admin-shell' ),
+	spam: __( 'Spam', 'wp-admin-shell' ),
+	trash: __( 'Trash', 'wp-admin-shell' ),
+};
+
+const STATUS_OPTIONS = Object.entries( STATUS_LABELS ).map(
+	( [ value, label ] ) => ( { value, label } )
+);
+
+function stripTags( html ) {
+	return ( html || '' ).replace( /<[^>]*>/g, '' ).trim();
+}
+
+export default function CommentsApp( { config = {} } ) {
+	const [ view, setView ] = useState( {
+		type: 'table',
+		search: '',
+		filters:
+			config.status && config.status !== 'all'
+				? [
+						{
+							field: 'status',
+							operator: 'is',
+							value: config.status,
+						},
+				  ]
+				: [],
+		page: 1,
+		perPage: 20,
+		sort: { field: 'date', direction: 'desc' },
+		fields: [ 'author', 'content', 'status', 'post', 'date' ],
+		layout: {},
+	} );
+
+	const queryArgs = useMemo( () => {
+		const args = {
+			per_page: view.perPage,
+			page: view.page,
+			order: view.sort?.direction || 'desc',
+			orderby: view.sort?.field || 'date',
+			context: 'edit',
+			status: 'all',
+		};
+		if ( view.search ) {
+			args.search = view.search;
+		}
+		for ( const filter of view.filters ) {
+			if ( filter.field === 'status' ) {
+				if ( filter.operator === 'isAny' && Array.isArray( filter.value ) ) {
+					args.status = filter.value.join( ',' );
+				} else if ( filter.operator === 'is' ) {
+					args.status = filter.value;
+				}
+			}
+		}
+		return args;
+	}, [ view ] );
+
+	const { records, isResolving, totalItems, totalPages } = useEntityRecords(
+		'root',
+		'comment',
+		queryArgs
+	);
+
+	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
+
+	const data = useMemo( () => {
+		if ( ! records ) {
+			return [];
+		}
+		return records.map( ( c ) => ( {
+			id: c.id,
+			author: c.author_name || __( '(unknown)', 'wp-admin-shell' ),
+			authorEmail: c.author_email || '',
+			authorUrl: c.author_url || '',
+			content: stripTags( c.content?.rendered || '' ),
+			status: c.status,
+			post: c.post,
+			date: c.date,
+			link: c.link,
+			rawRecord: c,
+		} ) );
+	}, [ records ] );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'author',
+				type: 'text',
+				label: __( 'Author', 'wp-admin-shell' ),
+				enableGlobalSearch: true,
+				render: ( { item } ) => (
+					<VStack spacing={ 1 }>
+						<Text weight={ 600 }>{ item.author }</Text>
+						{ item.authorEmail && (
+							<Text variant="muted" size={ 12 }>
+								{ item.authorEmail }
+							</Text>
+						) }
+					</VStack>
+				),
+			},
+			{
+				id: 'content',
+				type: 'text',
+				label: __( 'Comment', 'wp-admin-shell' ),
+				enableGlobalSearch: true,
+				render: ( { item } ) => (
+					<Text>
+						{ item.content.length > 200
+							? `${ item.content.slice( 0, 200 ) }…`
+							: item.content }
+					</Text>
+				),
+			},
+			{
+				id: 'status',
+				type: 'text',
+				label: __( 'Status', 'wp-admin-shell' ),
+				elements: STATUS_OPTIONS,
+				render: ( { item } ) => (
+					<Text>{ STATUS_LABELS[ item.status ] || item.status }</Text>
+				),
+				filterBy: { operators: [ 'is', 'isAny' ] },
+			},
+			{
+				id: 'post',
+				type: 'integer',
+				label: __( 'In response to', 'wp-admin-shell' ),
+				render: ( { item } ) =>
+					item.post ? <Text>#{ item.post }</Text> : null,
+			},
+			{
+				id: 'date',
+				type: 'datetime',
+				label: __( 'Submitted on', 'wp-admin-shell' ),
+			},
+		],
+		[]
+	);
+
+	const setStatus = async ( items, status ) => {
+		await Promise.all(
+			items.map( ( item ) =>
+				saveEntityRecord( 'root', 'comment', {
+					id: item.id,
+					status,
+				} )
+			)
+		);
+	};
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'approve',
+				label: __( 'Approve', 'wp-admin-shell' ),
+				icon: check,
+				isPrimary: true,
+				supportsBulk: true,
+				isEligible: ( item ) => item.status !== 'approved',
+				callback: ( items ) => setStatus( items, 'approved' ),
+			},
+			{
+				id: 'unapprove',
+				label: __( 'Unapprove', 'wp-admin-shell' ),
+				icon: closeSmall,
+				supportsBulk: true,
+				isEligible: ( item ) => item.status === 'approved',
+				callback: ( items ) => setStatus( items, 'hold' ),
+			},
+			{
+				id: 'spam',
+				label: __( 'Mark as spam', 'wp-admin-shell' ),
+				supportsBulk: true,
+				isEligible: ( item ) => item.status !== 'spam',
+				callback: ( items ) => setStatus( items, 'spam' ),
+			},
+			{
+				id: 'view',
+				label: __( 'View', 'wp-admin-shell' ),
+				icon: external,
+				isEligible: ( item ) => !! item.link,
+				callback: ( items ) =>
+					window.open( items[ 0 ].link, '_blank' ),
+			},
+			{
+				id: 'trash',
+				label: __( 'Move to Trash', 'wp-admin-shell' ),
+				icon: trash,
+				isDestructive: true,
+				supportsBulk: true,
+				isEligible: ( item ) => item.status !== 'trash',
+				RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+					<VStack spacing={ 4 } style={ { padding: '16px' } }>
+						<Text>
+							{ items.length === 1
+								? __(
+										'Move this comment to the trash?',
+										'wp-admin-shell'
+								  )
+								: __(
+										'Move these comments to the trash?',
+										'wp-admin-shell'
+								  ) }
+						</Text>
+						<HStack justify="right">
+							<Button variant="tertiary" onClick={ closeModal }>
+								{ __( 'Cancel', 'wp-admin-shell' ) }
+							</Button>
+							<Button
+								variant="primary"
+								isDestructive
+								onClick={ async () => {
+									await Promise.all(
+										items.map( ( item ) =>
+											deleteEntityRecord(
+												'root',
+												'comment',
+												item.id
+											)
+										)
+									);
+									onActionPerformed?.( items );
+									closeModal();
+								} }
+							>
+								{ __( 'Move to Trash', 'wp-admin-shell' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				),
+			},
+			{
+				id: 'delete-permanently',
+				label: __( 'Delete permanently', 'wp-admin-shell' ),
+				icon: trash,
+				isDestructive: true,
+				supportsBulk: true,
+				isEligible: ( item ) => item.status === 'trash',
+				RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+					<VStack spacing={ 4 } style={ { padding: '16px' } }>
+						<Text>
+							{ __(
+								'This cannot be undone. Continue?',
+								'wp-admin-shell'
+							) }
+						</Text>
+						<HStack justify="right">
+							<Button variant="tertiary" onClick={ closeModal }>
+								{ __( 'Cancel', 'wp-admin-shell' ) }
+							</Button>
+							<Button
+								variant="primary"
+								isDestructive
+								onClick={ async () => {
+									await Promise.all(
+										items.map( ( item ) =>
+											deleteEntityRecord(
+												'root',
+												'comment',
+												item.id,
+												{ force: true }
+											)
+										)
+									);
+									onActionPerformed?.( items );
+									closeModal();
+								} }
+							>
+								{ __( 'Delete forever', 'wp-admin-shell' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				),
+			},
+		],
+		[ deleteEntityRecord, saveEntityRecord ]
+	);
+
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems: totalItems || 0,
+			totalPages: totalPages || 0,
+		} ),
+		[ totalItems, totalPages ]
+	);
+
+	const [ selection, setSelection ] = useState( [] );
+
+	return (
+		<div className="wp-admin-shell-app-comments">
+			<DataViews
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				isLoading={ isResolving }
+				defaultLayouts={ { table: {} } }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				getItemId={ ( item ) => item.id.toString() }
+			/>
+		</div>
+	);
+}

--- a/src/apps/DashboardApp.js
+++ b/src/apps/DashboardApp.js
@@ -1,0 +1,256 @@
+import { useMemo } from '@wordpress/element';
+import { useEntityRecords, useEntityRecord } from '@wordpress/core-data';
+import {
+	Button,
+	Stack,
+	Text,
+} from '@wordpress/ui';
+import {
+	__experimentalGrid as Grid,
+	Card,
+	CardHeader,
+	CardBody,
+	Spinner,
+} from '@wordpress/components';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import { navigate } from '../routing/router';
+
+function StatCard( { label, value, isLoading } ) {
+	return (
+		<Card>
+			<CardBody>
+				<Stack direction="column" gap="xs">
+					<Text variant="body-sm">{ label }</Text>
+					{ isLoading ? (
+						<Spinner />
+					) : (
+						<Text variant="heading-xl" render={ <span /> }>
+							{ value ?? '—' }
+						</Text>
+					) }
+				</Stack>
+			</CardBody>
+		</Card>
+	);
+}
+
+export default function DashboardApp() {
+	const userId = window.wpAdminShell?.userId;
+	const { record: user } = useEntityRecord( 'root', 'user', userId );
+
+	const postsQuery = { per_page: 1, status: 'publish', context: 'edit' };
+	const draftQuery = { per_page: 5, status: 'draft', context: 'edit', orderby: 'modified', order: 'desc' };
+	const pendingComments = { per_page: 5, status: 'hold', context: 'edit' };
+	const recentMedia = { per_page: 1 };
+	const pagesQuery = { per_page: 1, status: 'publish', context: 'edit' };
+	const usersQuery = { per_page: 1 };
+
+	const posts = useEntityRecords( 'postType', 'post', postsQuery );
+	const drafts = useEntityRecords( 'postType', 'post', draftQuery );
+	const pages = useEntityRecords( 'postType', 'page', pagesQuery );
+	const comments = useEntityRecords( 'root', 'comment', pendingComments );
+	const media = useEntityRecords( 'root', 'media', recentMedia );
+	const users = useEntityRecords( 'root', 'user', usersQuery );
+
+	const greeting = useMemo( () => {
+		const hour = new Date().getHours();
+		if ( hour < 12 ) {
+			return __( 'Good morning', 'wp-admin-shell' );
+		}
+		if ( hour < 18 ) {
+			return __( 'Good afternoon', 'wp-admin-shell' );
+		}
+		return __( 'Good evening', 'wp-admin-shell' );
+	}, [] );
+
+	const displayName = user?.name || user?.first_name || '';
+
+	return (
+		<div className="wp-admin-shell-app-dashboard">
+			<Stack direction="column" gap="xl">
+				<Stack direction="column" gap="xs">
+					<Text variant="heading-xl" render={ <h1 /> }>
+						{ displayName
+							? sprintf(
+									/* translators: 1: greeting, 2: user display name */
+									__( '%1$s, %2$s', 'wp-admin-shell' ),
+									greeting,
+									displayName
+							  )
+							: greeting }
+					</Text>
+					<Text variant="body-md">
+						{ __(
+							'Here is a snapshot of your site.',
+							'wp-admin-shell'
+						) }
+					</Text>
+				</Stack>
+
+				<Stack direction="row" gap="sm" wrap>
+					<Button
+						tone="brand"
+						variant="solid"
+						onClick={ () => navigate( 'editor', 'post', 'new' ) }
+					>
+						{ __( 'Write a post', 'wp-admin-shell' ) }
+					</Button>
+					<Button
+						variant="outline"
+						onClick={ () => navigate( 'editor', 'page', 'new' ) }
+					>
+						{ __( 'Add a page', 'wp-admin-shell' ) }
+					</Button>
+					<Button
+						variant="outline"
+						onClick={ () => navigate( 'media' ) }
+					>
+						{ __( 'Upload media', 'wp-admin-shell' ) }
+					</Button>
+				</Stack>
+
+				<Grid columns={ 4 } gap={ 4 }>
+					<StatCard
+						label={ __( 'Published posts', 'wp-admin-shell' ) }
+						value={ posts.totalItems }
+						isLoading={ posts.isResolving }
+					/>
+					<StatCard
+						label={ __( 'Published pages', 'wp-admin-shell' ) }
+						value={ pages.totalItems }
+						isLoading={ pages.isResolving }
+					/>
+					<StatCard
+						label={ __( 'Pending comments', 'wp-admin-shell' ) }
+						value={ comments.totalItems }
+						isLoading={ comments.isResolving }
+					/>
+					<StatCard
+						label={ __( 'Users', 'wp-admin-shell' ) }
+						value={ users.totalItems }
+						isLoading={ users.isResolving }
+					/>
+				</Grid>
+
+				<Grid columns={ 2 } gap={ 4 }>
+					<Card>
+						<CardHeader>
+							<Text variant="heading-md" render={ <h2 /> }>
+								{ __( 'Recent drafts', 'wp-admin-shell' ) }
+							</Text>
+						</CardHeader>
+						<CardBody>
+							{ drafts.isResolving && ! drafts.records ? (
+								<Spinner />
+							) : drafts.records?.length ? (
+								<Stack direction="column" gap="sm">
+									{ drafts.records.map( ( draft ) => (
+										<Stack
+											key={ draft.id }
+											direction="row"
+											justify="space-between"
+											align="center"
+										>
+											<Button
+												variant="ghost"
+												onClick={ () =>
+													navigate(
+														'editor',
+														'post',
+														draft.id
+													)
+												}
+											>
+												{ draft.title?.raw ||
+													draft.title?.rendered ||
+													__(
+														'(no title)',
+														'wp-admin-shell'
+													) }
+											</Button>
+											<Text variant="body-sm">
+												{ new Date(
+													draft.modified
+												).toLocaleDateString() }
+											</Text>
+										</Stack>
+									) ) }
+								</Stack>
+							) : (
+								<Text variant="body-sm">
+									{ __(
+										'No drafts yet. Start writing!',
+										'wp-admin-shell'
+									) }
+								</Text>
+							) }
+						</CardBody>
+					</Card>
+
+					<Card>
+						<CardHeader>
+							<Text variant="heading-md" render={ <h2 /> }>
+								{ __(
+									'Comments awaiting moderation',
+									'wp-admin-shell'
+								) }
+							</Text>
+						</CardHeader>
+						<CardBody>
+							{ comments.isResolving && ! comments.records ? (
+								<Spinner />
+							) : comments.records?.length ? (
+								<Stack direction="column" gap="sm">
+									{ comments.records.map( ( c ) => (
+										<Stack
+											key={ c.id }
+											direction="column"
+											gap="xs"
+										>
+											<Text variant="body-sm">
+												<strong>
+													{ c.author_name }
+												</strong>
+											</Text>
+											<Text
+												variant="body-sm"
+												render={ <span /> }
+											>
+												{ stripTags(
+													c.content?.rendered || ''
+												).slice( 0, 120 ) }
+											</Text>
+										</Stack>
+									) ) }
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={ () =>
+											navigate( 'comments' )
+										}
+									>
+										{ __(
+											'Moderate all',
+											'wp-admin-shell'
+										) }
+									</Button>
+								</Stack>
+							) : (
+								<Text variant="body-sm">
+									{ __(
+										'Inbox zero. Nothing pending.',
+										'wp-admin-shell'
+									) }
+								</Text>
+							) }
+						</CardBody>
+					</Card>
+				</Grid>
+			</Stack>
+		</div>
+	);
+}
+
+function stripTags( html ) {
+	return html.replace( /<[^>]*>/g, '' ).trim();
+}

--- a/src/apps/PluginsApp.js
+++ b/src/apps/PluginsApp.js
@@ -1,0 +1,296 @@
+import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { DataViews } from '@wordpress/dataviews';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { trash, external, check, closeSmall } from '@wordpress/icons';
+
+const STATUS_LABELS = {
+	active: __( 'Active', 'wp-admin-shell' ),
+	inactive: __( 'Inactive', 'wp-admin-shell' ),
+	'network-active': __( 'Network active', 'wp-admin-shell' ),
+};
+
+export default function PluginsApp() {
+	const [ records, setRecords ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ error, setError ] = useState( null );
+	const [ refreshKey, setRefreshKey ] = useState( 0 );
+
+	useEffect( () => {
+		let cancelled = false;
+		setIsLoading( true );
+		apiFetch( { path: '/wp/v2/plugins?context=edit' } )
+			.then( ( res ) => {
+				if ( ! cancelled ) {
+					setRecords( res );
+					setError( null );
+				}
+			} )
+			.catch( ( err ) => {
+				if ( ! cancelled ) {
+					setError( err.message || __( 'Failed to load plugins.', 'wp-admin-shell' ) );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ refreshKey ] );
+
+	const refresh = useCallback( () => setRefreshKey( ( k ) => k + 1 ), [] );
+
+	const setPluginStatus = useCallback(
+		async ( items, status ) => {
+			await Promise.all(
+				items.map( ( item ) =>
+					apiFetch( {
+						path: `/wp/v2/plugins/${ encodeURIComponent(
+							item.plugin
+						) }`,
+						method: 'POST',
+						data: { status },
+					} )
+				)
+			);
+			refresh();
+		},
+		[ refresh ]
+	);
+
+	const deletePlugins = useCallback(
+		async ( items ) => {
+			await Promise.all(
+				items.map( ( item ) =>
+					apiFetch( {
+						path: `/wp/v2/plugins/${ encodeURIComponent(
+							item.plugin
+						) }`,
+						method: 'DELETE',
+					} )
+				)
+			);
+			refresh();
+		},
+		[ refresh ]
+	);
+
+	const [ view, setView ] = useState( {
+		type: 'table',
+		search: '',
+		filters: [],
+		page: 1,
+		perPage: 50,
+		sort: { field: 'name', direction: 'asc' },
+		fields: [ 'name', 'status', 'version', 'author' ],
+		layout: {},
+	} );
+
+	const data = useMemo( () => {
+		if ( ! records ) {
+			return [];
+		}
+		const search = view.search?.toLowerCase() || '';
+		const statusFilter = view.filters.find( ( f ) => f.field === 'status' );
+		return records
+			.filter( ( r ) => {
+				if (
+					search &&
+					! r.name?.toLowerCase().includes( search ) &&
+					! stripTags( r.description?.raw || '' )
+						.toLowerCase()
+						.includes( search )
+				) {
+					return false;
+				}
+				if ( statusFilter ) {
+					const list = Array.isArray( statusFilter.value )
+						? statusFilter.value
+						: [ statusFilter.value ];
+					if ( ! list.includes( r.status ) ) {
+						return false;
+					}
+				}
+				return true;
+			} )
+			.map( ( r ) => ( {
+				id: r.plugin,
+				plugin: r.plugin,
+				name: r.name,
+				description: stripTags( r.description?.raw || '' ),
+				status: r.status,
+				version: r.version,
+				author: stripTags( r.author || '' ),
+				authorUri: r.author_uri,
+				pluginUri: r.plugin_uri,
+				rawRecord: r,
+			} ) );
+	}, [ records, view ] );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'name',
+				type: 'text',
+				label: __( 'Plugin', 'wp-admin-shell' ),
+				enableGlobalSearch: true,
+				enableHiding: false,
+				render: ( { item } ) => (
+					<VStack spacing={ 1 }>
+						<Text weight={ 600 }>{ item.name }</Text>
+						<Text variant="muted" size={ 12 }>
+							{ item.description.length > 160
+								? `${ item.description.slice( 0, 160 ) }…`
+								: item.description }
+						</Text>
+					</VStack>
+				),
+			},
+			{
+				id: 'status',
+				type: 'text',
+				label: __( 'Status', 'wp-admin-shell' ),
+				elements: Object.entries( STATUS_LABELS ).map(
+					( [ value, label ] ) => ( { value, label } )
+				),
+				render: ( { item } ) => (
+					<Text>{ STATUS_LABELS[ item.status ] || item.status }</Text>
+				),
+				filterBy: { operators: [ 'isAny' ] },
+			},
+			{
+				id: 'version',
+				type: 'text',
+				label: __( 'Version', 'wp-admin-shell' ),
+				render: ( { item } ) => <Text>{ item.version }</Text>,
+			},
+			{
+				id: 'author',
+				type: 'text',
+				label: __( 'Author', 'wp-admin-shell' ),
+				render: ( { item } ) => <Text>{ item.author }</Text>,
+			},
+		],
+		[]
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'activate',
+				label: __( 'Activate', 'wp-admin-shell' ),
+				icon: check,
+				isPrimary: true,
+				supportsBulk: true,
+				isEligible: ( item ) => item.status === 'inactive',
+				callback: ( items ) => setPluginStatus( items, 'active' ),
+			},
+			{
+				id: 'deactivate',
+				label: __( 'Deactivate', 'wp-admin-shell' ),
+				icon: closeSmall,
+				supportsBulk: true,
+				isEligible: ( item ) =>
+					item.status === 'active' ||
+					item.status === 'network-active',
+				callback: ( items ) => setPluginStatus( items, 'inactive' ),
+			},
+			{
+				id: 'visit',
+				label: __( 'Visit plugin site', 'wp-admin-shell' ),
+				icon: external,
+				isEligible: ( item ) => !! item.pluginUri,
+				callback: ( items ) => window.open( items[ 0 ].pluginUri, '_blank' ),
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete', 'wp-admin-shell' ),
+				icon: trash,
+				isDestructive: true,
+				supportsBulk: true,
+				isEligible: ( item ) => item.status === 'inactive',
+				RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+					<VStack spacing={ 4 } style={ { padding: '16px' } }>
+						<Text>
+							{ items.length === 1
+								? __(
+										'Permanently delete this plugin? This cannot be undone.',
+										'wp-admin-shell'
+								  )
+								: __(
+										'Permanently delete these plugins? This cannot be undone.',
+										'wp-admin-shell'
+								  ) }
+						</Text>
+						<HStack justify="right">
+							<Button variant="tertiary" onClick={ closeModal }>
+								{ __( 'Cancel', 'wp-admin-shell' ) }
+							</Button>
+							<Button
+								variant="primary"
+								isDestructive
+								onClick={ async () => {
+									await deletePlugins( items );
+									onActionPerformed?.( items );
+									closeModal();
+								} }
+							>
+								{ __( 'Delete', 'wp-admin-shell' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				),
+			},
+		],
+		[ deletePlugins, setPluginStatus ]
+	);
+
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems: data.length,
+			totalPages: Math.max( 1, Math.ceil( data.length / view.perPage ) ),
+		} ),
+		[ data.length, view.perPage ]
+	);
+
+	const [ selection, setSelection ] = useState( [] );
+
+	if ( error ) {
+		return (
+			<div className="wp-admin-shell-app-plugins__error">
+				<Text>{ error }</Text>
+			</div>
+		);
+	}
+
+	return (
+		<div className="wp-admin-shell-app-plugins">
+			<DataViews
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				isLoading={ isLoading }
+				defaultLayouts={ { table: {} } }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				getItemId={ ( item ) => item.id }
+			/>
+		</div>
+	);
+}
+
+function stripTags( html ) {
+	return ( html || '' ).replace( /<[^>]*>/g, '' ).trim();
+}

--- a/src/apps/SettingsDiscussionApp.js
+++ b/src/apps/SettingsDiscussionApp.js
@@ -1,0 +1,124 @@
+import { useState } from '@wordpress/element';
+import { useEntityRecord } from '@wordpress/core-data';
+import {
+	Button,
+	Stack,
+	Text,
+	Notice,
+} from '@wordpress/ui';
+import {
+	CheckboxControl,
+	Spinner,
+	__experimentalDivider as Divider,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function SettingsDiscussionApp() {
+	const { record, editedRecord, edit, save, hasEdits, isSaving } =
+		useEntityRecord( 'root', 'site' );
+
+	const [ notice, setNotice ] = useState( null );
+
+	if ( ! record ) {
+		return (
+			<div className="wp-admin-shell-app-settings-discussion__loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	const handleSave = async () => {
+		try {
+			await save();
+			setNotice( {
+				intent: 'success',
+				message: __( 'Settings saved.', 'wp-admin-shell' ),
+			} );
+		} catch ( err ) {
+			setNotice( {
+				intent: 'error',
+				message:
+					err.message ||
+					__( 'Failed to save settings.', 'wp-admin-shell' ),
+			} );
+		}
+	};
+
+	return (
+		<div className="wp-admin-shell-app-settings-discussion">
+			<Stack direction="column" gap="xl">
+				<Text variant="heading-xl" render={ <h2 /> }>
+					{ __( 'Discussion', 'wp-admin-shell' ) }
+				</Text>
+
+				{ notice && (
+					<Notice.Root intent={ notice.intent }>
+						<Notice.Description>
+							{ notice.message }
+						</Notice.Description>
+						<Notice.Actions>
+							<Notice.CloseIcon
+								onClick={ () => setNotice( null ) }
+							/>
+						</Notice.Actions>
+					</Notice.Root>
+				) }
+
+				<Stack direction="column" gap="md">
+					<Text variant="heading-md" render={ <h3 /> }>
+						{ __( 'Default post settings', 'wp-admin-shell' ) }
+					</Text>
+					<CheckboxControl
+						label={ __(
+							'Allow people to submit comments on new posts',
+							'wp-admin-shell'
+						) }
+						checked={
+							editedRecord.default_comment_status === 'open'
+						}
+						onChange={ ( v ) =>
+							edit( {
+								default_comment_status: v ? 'open' : 'closed',
+							} )
+						}
+						__nextHasNoMarginBottom
+					/>
+					<CheckboxControl
+						label={ __(
+							'Allow link notifications from other blogs (pingbacks and trackbacks)',
+							'wp-admin-shell'
+						) }
+						checked={ editedRecord.default_ping_status === 'open' }
+						onChange={ ( v ) =>
+							edit( {
+								default_ping_status: v ? 'open' : 'closed',
+							} )
+						}
+						__nextHasNoMarginBottom
+					/>
+				</Stack>
+
+				<Divider />
+
+				<Text variant="body-sm">
+					{ __(
+						'The fine-grained discussion settings (comment moderation rules, blocklists, avatars) are not exposed by the WordPress REST API. Use the legacy Discussion Settings screen for those fields.',
+						'wp-admin-shell'
+					) }
+				</Text>
+
+				<Stack direction="row" justify="flex-start">
+					<Button
+						tone="brand"
+						variant="solid"
+						onClick={ handleSave }
+						disabled={ ! hasEdits || isSaving }
+						loading={ isSaving }
+					>
+						{ __( 'Save Changes', 'wp-admin-shell' ) }
+					</Button>
+				</Stack>
+			</Stack>
+		</div>
+	);
+}

--- a/src/apps/SettingsReadingApp.js
+++ b/src/apps/SettingsReadingApp.js
@@ -1,0 +1,234 @@
+import { useState } from '@wordpress/element';
+import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import {
+	Button,
+	InputControl,
+	Stack,
+	Text,
+	Notice,
+} from '@wordpress/ui';
+import {
+	SelectControl,
+	RadioControl,
+	CheckboxControl,
+	Spinner,
+	__experimentalDivider as Divider,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export default function SettingsReadingApp() {
+	const { record, editedRecord, edit, save, hasEdits, isSaving } =
+		useEntityRecord( 'root', 'site' );
+
+	const pages = useEntityRecords( 'postType', 'page', {
+		per_page: 100,
+		status: 'publish',
+		orderby: 'title',
+		order: 'asc',
+		_fields: 'id,title',
+		context: 'edit',
+	} );
+
+	const [ notice, setNotice ] = useState( null );
+
+	if ( ! record ) {
+		return (
+			<div className="wp-admin-shell-app-settings-reading__loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	const handleSave = async () => {
+		try {
+			await save();
+			setNotice( {
+				intent: 'success',
+				message: __( 'Settings saved.', 'wp-admin-shell' ),
+			} );
+		} catch ( err ) {
+			setNotice( {
+				intent: 'error',
+				message:
+					err.message ||
+					__( 'Failed to save settings.', 'wp-admin-shell' ),
+			} );
+		}
+	};
+
+	const eventValue = ( e ) => e.target.value;
+
+	const pageOptions = [
+		{ value: '0', label: __( '— Select —', 'wp-admin-shell' ) },
+		...( pages.records || [] ).map( ( p ) => ( {
+			value: String( p.id ),
+			label: p.title?.rendered || p.title?.raw || `#${ p.id }`,
+		} ) ),
+	];
+
+	const showOnFront = editedRecord.show_on_front || 'posts';
+
+	return (
+		<div className="wp-admin-shell-app-settings-reading">
+			<Stack direction="column" gap="xl">
+				<Text variant="heading-xl" render={ <h2 /> }>
+					{ __( 'Reading', 'wp-admin-shell' ) }
+				</Text>
+
+				{ notice && (
+					<Notice.Root intent={ notice.intent }>
+						<Notice.Description>
+							{ notice.message }
+						</Notice.Description>
+						<Notice.Actions>
+							<Notice.CloseIcon
+								onClick={ () => setNotice( null ) }
+							/>
+						</Notice.Actions>
+					</Notice.Root>
+				) }
+
+				<RadioControl
+					label={ __( 'Your homepage displays', 'wp-admin-shell' ) }
+					selected={ showOnFront }
+					options={ [
+						{
+							value: 'posts',
+							label: __(
+								'Your latest posts',
+								'wp-admin-shell'
+							),
+						},
+						{
+							value: 'page',
+							label: __(
+								'A static page',
+								'wp-admin-shell'
+							),
+						},
+					] }
+					onChange={ ( val ) => edit( { show_on_front: val } ) }
+				/>
+
+				{ showOnFront === 'page' && (
+					<Stack direction="column" gap="md">
+						<SelectControl
+							label={ __( 'Homepage', 'wp-admin-shell' ) }
+							value={ String( editedRecord.page_on_front ?? 0 ) }
+							options={ pageOptions }
+							onChange={ ( val ) =>
+								edit( { page_on_front: parseInt( val, 10 ) } )
+							}
+							__nextHasNoMarginBottom
+						/>
+						<SelectControl
+							label={ __( 'Posts page', 'wp-admin-shell' ) }
+							value={ String( editedRecord.page_for_posts ?? 0 ) }
+							options={ pageOptions }
+							onChange={ ( val ) =>
+								edit( { page_for_posts: parseInt( val, 10 ) } )
+							}
+							__nextHasNoMarginBottom
+						/>
+					</Stack>
+				) }
+
+				<Divider />
+
+				<InputControl
+					label={ __(
+						'Blog pages show at most',
+						'wp-admin-shell'
+					) }
+					type="number"
+					value={ String( editedRecord.posts_per_page ?? 10 ) }
+					onChange={ ( e ) =>
+						edit( {
+							posts_per_page:
+								parseInt( eventValue( e ), 10 ) || 10,
+						} )
+					}
+				/>
+
+				<InputControl
+					label={ __(
+						'Syndication feeds show the most recent',
+						'wp-admin-shell'
+					) }
+					type="number"
+					value={ String( editedRecord.posts_per_rss ?? 10 ) }
+					onChange={ ( e ) =>
+						edit( {
+							posts_per_rss:
+								parseInt( eventValue( e ), 10 ) || 10,
+						} )
+					}
+				/>
+
+				<RadioControl
+					label={ __( 'For each post in a feed, include', 'wp-admin-shell' ) }
+					selected={ editedRecord.rss_use_excerpt ? '1' : '0' }
+					options={ [
+						{
+							value: '0',
+							label: __( 'Full text', 'wp-admin-shell' ),
+						},
+						{
+							value: '1',
+							label: __( 'Excerpt', 'wp-admin-shell' ),
+						},
+					] }
+					onChange={ ( val ) =>
+						edit( { rss_use_excerpt: val === '1' } )
+					}
+				/>
+
+				<Divider />
+
+				<CheckboxControl
+					label={ __(
+						'Allow people to submit comments on new posts',
+						'wp-admin-shell'
+					) }
+					checked={ editedRecord.default_comment_status === 'open' }
+					onChange={ ( v ) =>
+						edit( {
+							default_comment_status: v ? 'open' : 'closed',
+						} )
+					}
+					__nextHasNoMarginBottom
+				/>
+				<CheckboxControl
+					label={ __(
+						'Allow link notifications from other blogs (pingbacks and trackbacks) on new posts',
+						'wp-admin-shell'
+					) }
+					checked={ editedRecord.default_ping_status === 'open' }
+					onChange={ ( v ) =>
+						edit( { default_ping_status: v ? 'open' : 'closed' } )
+					}
+					__nextHasNoMarginBottom
+				/>
+
+				<Text variant="body-sm">
+					{ __(
+						'Search-engine visibility (the “discourage search engines” toggle) is not exposed by the REST API. Use the legacy Reading Settings screen for that field.',
+						'wp-admin-shell'
+					) }
+				</Text>
+
+				<Stack direction="row" justify="flex-start">
+					<Button
+						tone="brand"
+						variant="solid"
+						onClick={ handleSave }
+						disabled={ ! hasEdits || isSaving }
+						loading={ isSaving }
+					>
+						{ __( 'Save Changes', 'wp-admin-shell' ) }
+					</Button>
+				</Stack>
+			</Stack>
+		</div>
+	);
+}

--- a/src/apps/SettingsWritingApp.js
+++ b/src/apps/SettingsWritingApp.js
@@ -1,0 +1,142 @@
+import { useEffect, useState } from '@wordpress/element';
+import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import {
+	Button,
+	Stack,
+	Text,
+	Notice,
+} from '@wordpress/ui';
+import {
+	SelectControl,
+	Spinner,
+	__experimentalDivider as Divider,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const POST_FORMAT_OPTIONS = [
+	{ value: 'standard', label: __( 'Standard', 'wp-admin-shell' ) },
+	{ value: 'aside', label: __( 'Aside', 'wp-admin-shell' ) },
+	{ value: 'chat', label: __( 'Chat', 'wp-admin-shell' ) },
+	{ value: 'gallery', label: __( 'Gallery', 'wp-admin-shell' ) },
+	{ value: 'link', label: __( 'Link', 'wp-admin-shell' ) },
+	{ value: 'image', label: __( 'Image', 'wp-admin-shell' ) },
+	{ value: 'quote', label: __( 'Quote', 'wp-admin-shell' ) },
+	{ value: 'status', label: __( 'Status', 'wp-admin-shell' ) },
+	{ value: 'video', label: __( 'Video', 'wp-admin-shell' ) },
+	{ value: 'audio', label: __( 'Audio', 'wp-admin-shell' ) },
+];
+
+export default function SettingsWritingApp() {
+	const { record, editedRecord, edit, save, hasEdits, isSaving } =
+		useEntityRecord( 'root', 'site' );
+
+	const categories = useEntityRecords( 'taxonomy', 'category', {
+		per_page: 100,
+		orderby: 'name',
+		order: 'asc',
+		hide_empty: false,
+	} );
+
+	const [ notice, setNotice ] = useState( null );
+
+	if ( ! record ) {
+		return (
+			<div className="wp-admin-shell-app-settings-writing__loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	const handleSave = async () => {
+		try {
+			await save();
+			setNotice( {
+				intent: 'success',
+				message: __( 'Settings saved.', 'wp-admin-shell' ),
+			} );
+		} catch ( err ) {
+			setNotice( {
+				intent: 'error',
+				message:
+					err.message ||
+					__( 'Failed to save settings.', 'wp-admin-shell' ),
+			} );
+		}
+	};
+
+	const categoryOptions = ( categories.records || [] ).map( ( c ) => ( {
+		value: c.id,
+		label: c.name,
+	} ) );
+
+	return (
+		<div className="wp-admin-shell-app-settings-writing">
+			<Stack direction="column" gap="xl">
+				<Text variant="heading-xl" render={ <h2 /> }>
+					{ __( 'Writing', 'wp-admin-shell' ) }
+				</Text>
+
+				{ notice && (
+					<Notice.Root intent={ notice.intent }>
+						<Notice.Description>
+							{ notice.message }
+						</Notice.Description>
+						<Notice.Actions>
+							<Notice.CloseIcon
+								onClick={ () => setNotice( null ) }
+							/>
+						</Notice.Actions>
+					</Notice.Root>
+				) }
+
+				<SelectControl
+					label={ __( 'Default Post Category', 'wp-admin-shell' ) }
+					value={ String( editedRecord.default_category ?? '' ) }
+					options={ categoryOptions.map( ( o ) => ( {
+						...o,
+						value: String( o.value ),
+					} ) ) }
+					onChange={ ( val ) =>
+						edit( { default_category: parseInt( val, 10 ) } )
+					}
+					help={ __(
+						'New posts get this category if you do not pick one.',
+						'wp-admin-shell'
+					) }
+					__nextHasNoMarginBottom
+				/>
+
+				<SelectControl
+					label={ __( 'Default Post Format', 'wp-admin-shell' ) }
+					value={ editedRecord.default_post_format || 'standard' }
+					options={ POST_FORMAT_OPTIONS }
+					onChange={ ( val ) =>
+						edit( { default_post_format: val } )
+					}
+					__nextHasNoMarginBottom
+				/>
+
+				<Divider />
+
+				<Text variant="body-sm">
+					{ __(
+						'Post via email and remote-publishing settings are not exposed by the WordPress REST API. Use the legacy Writing Settings screen for those fields.',
+						'wp-admin-shell'
+					) }
+				</Text>
+
+				<Stack direction="row" justify="flex-start">
+					<Button
+						tone="brand"
+						variant="solid"
+						onClick={ handleSave }
+						disabled={ ! hasEdits || isSaving }
+						loading={ isSaving }
+					>
+						{ __( 'Save Changes', 'wp-admin-shell' ) }
+					</Button>
+				</Stack>
+			</Stack>
+		</div>
+	);
+}

--- a/src/apps/SiteHealthApp.js
+++ b/src/apps/SiteHealthApp.js
@@ -1,0 +1,184 @@
+import { useEffect, useState, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	Spinner,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { update } from '@wordpress/icons';
+
+const ASYNC_TESTS = [
+	{ id: 'dotorg-communication', label: __( 'WordPress.org communication', 'wp-admin-shell' ) },
+	{ id: 'background-updates', label: __( 'Background updates', 'wp-admin-shell' ) },
+	{ id: 'loopback-requests', label: __( 'Loopback requests', 'wp-admin-shell' ) },
+	{ id: 'https-status', label: __( 'HTTPS status', 'wp-admin-shell' ) },
+	{ id: 'authorization-header', label: __( 'Authorization header', 'wp-admin-shell' ) },
+];
+
+const STATUS_TO_INTENT = {
+	good: 'success',
+	recommended: 'warning',
+	critical: 'error',
+};
+
+function StatusPill( { status } ) {
+	const label =
+		{
+			good: __( 'Good', 'wp-admin-shell' ),
+			recommended: __( 'Recommended', 'wp-admin-shell' ),
+			critical: __( 'Critical', 'wp-admin-shell' ),
+		}[ status ] || status;
+	const colors = {
+		good: { bg: '#d1fae5', fg: '#065f46' },
+		recommended: { bg: '#fef3c7', fg: '#92400e' },
+		critical: { bg: '#fee2e2', fg: '#991b1b' },
+	}[ status ] || { bg: '#e5e7eb', fg: '#111827' };
+	return (
+		<span
+			style={ {
+				display: 'inline-block',
+				background: colors.bg,
+				color: colors.fg,
+				padding: '2px 8px',
+				borderRadius: '4px',
+				fontSize: '12px',
+				fontWeight: 600,
+			} }
+		>
+			{ label }
+		</span>
+	);
+}
+
+export default function SiteHealthApp() {
+	const [ results, setResults ] = useState( {} );
+	const [ isRunning, setIsRunning ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const runTests = useCallback( async () => {
+		setIsRunning( true );
+		setError( null );
+		setResults( {} );
+		try {
+			await Promise.all(
+				ASYNC_TESTS.map( async ( t ) => {
+					try {
+						const res = await apiFetch( {
+							path: `/wp-site-health/v1/tests/${ t.id }`,
+						} );
+						setResults( ( prev ) => ( {
+							...prev,
+							[ t.id ]: res,
+						} ) );
+					} catch ( err ) {
+						setResults( ( prev ) => ( {
+							...prev,
+							[ t.id ]: {
+								status: 'critical',
+								label: t.label,
+								description: err.message,
+							},
+						} ) );
+					}
+				} )
+			);
+		} catch ( err ) {
+			setError( err.message );
+		} finally {
+			setIsRunning( false );
+		}
+	}, [] );
+
+	useEffect( () => {
+		runTests();
+	}, [ runTests ] );
+
+	const counts = Object.values( results ).reduce(
+		( acc, r ) => {
+			if ( r?.status && acc[ r.status ] !== undefined ) {
+				acc[ r.status ] += 1;
+			}
+			return acc;
+		},
+		{ good: 0, recommended: 0, critical: 0 }
+	);
+
+	return (
+		<div className="wp-admin-shell-app-site-health">
+			<HStack
+				className="wp-admin-shell-app-site-health__toolbar"
+				alignment="center"
+			>
+				<VStack spacing={ 1 }>
+					<Text size={ 20 } weight={ 600 }>
+						{ __( 'Site Health', 'wp-admin-shell' ) }
+					</Text>
+					<Text variant="muted" size={ 12 }>
+						{ counts.good }{ ' ' }
+						{ __( 'good', 'wp-admin-shell' ) } ·{ ' ' }
+						{ counts.recommended }{ ' ' }
+						{ __( 'recommended', 'wp-admin-shell' ) } ·{ ' ' }
+						{ counts.critical }{ ' ' }
+						{ __( 'critical', 'wp-admin-shell' ) }
+					</Text>
+				</VStack>
+				<Button
+					variant="secondary"
+					icon={ update }
+					onClick={ runTests }
+					disabled={ isRunning }
+					isBusy={ isRunning }
+					size="compact"
+				>
+					{ __( 'Re-run tests', 'wp-admin-shell' ) }
+				</Button>
+			</HStack>
+
+			{ error && (
+				<Text>{ error }</Text>
+			) }
+
+			<VStack spacing={ 3 }>
+				{ ASYNC_TESTS.map( ( t ) => {
+					const res = results[ t.id ];
+					return (
+						<Card key={ t.id }>
+							<CardHeader>
+								<HStack
+									alignment="left"
+									justify="space-between"
+								>
+									<Text weight={ 600 }>
+										{ res?.label || t.label }
+									</Text>
+									{ res ? (
+										<StatusPill status={ res.status } />
+									) : (
+										<Spinner />
+									) }
+								</HStack>
+							</CardHeader>
+							{ res?.description && (
+								<CardBody>
+									<div
+										// site-health returns trusted HTML.
+										// eslint-disable-next-line react/no-danger
+										dangerouslySetInnerHTML={ {
+											__html: res.description,
+										} }
+									/>
+								</CardBody>
+							) }
+						</Card>
+					);
+				} ) }
+			</VStack>
+		</div>
+	);
+}

--- a/src/apps/TaxonomyApp.js
+++ b/src/apps/TaxonomyApp.js
@@ -1,0 +1,318 @@
+import { useMemo, useState } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { DataViews } from '@wordpress/dataviews';
+import {
+	Button,
+	Modal,
+	TextControl,
+	TextareaControl,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { plus, trash, pencil } from '@wordpress/icons';
+
+const DEFAULT_TAXONOMY_LABEL = {
+	category: __( 'Categories', 'wp-admin-shell' ),
+	post_tag: __( 'Tags', 'wp-admin-shell' ),
+};
+
+export default function TaxonomyApp( { config = {} } ) {
+	const taxonomy = config.taxonomy || 'category';
+	const heading =
+		config.title ||
+		DEFAULT_TAXONOMY_LABEL[ taxonomy ] ||
+		taxonomy;
+
+	const [ view, setView ] = useState( {
+		type: 'table',
+		search: '',
+		filters: [],
+		page: 1,
+		perPage: 20,
+		sort: { field: 'name', direction: 'asc' },
+		fields: [ 'name', 'slug', 'count', 'description' ],
+		layout: {},
+	} );
+
+	const queryArgs = useMemo( () => {
+		const args = {
+			per_page: view.perPage,
+			page: view.page,
+			order: view.sort?.direction || 'asc',
+			orderby: view.sort?.field || 'name',
+			context: 'edit',
+			hide_empty: false,
+		};
+		if ( view.search ) {
+			args.search = view.search;
+		}
+		return args;
+	}, [ view ] );
+
+	const { records, isResolving, totalItems, totalPages } = useEntityRecords(
+		'taxonomy',
+		taxonomy,
+		queryArgs
+	);
+
+	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
+
+	const [ editTerm, setEditTerm ] = useState( null );
+	const [ isCreating, setIsCreating ] = useState( false );
+
+	const data = useMemo( () => {
+		if ( ! records ) {
+			return [];
+		}
+		return records.map( ( t ) => ( {
+			id: t.id,
+			name: t.name,
+			slug: t.slug,
+			count: t.count,
+			description: t.description || '',
+			parent: t.parent || 0,
+			rawRecord: t,
+		} ) );
+	}, [ records ] );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'name',
+				type: 'text',
+				label: __( 'Name', 'wp-admin-shell' ),
+				enableGlobalSearch: true,
+				enableHiding: false,
+				render: ( { item } ) => (
+					<Button
+						variant="link"
+						onClick={ () => setEditTerm( item.rawRecord ) }
+					>
+						{ item.name }
+					</Button>
+				),
+			},
+			{
+				id: 'slug',
+				type: 'text',
+				label: __( 'Slug', 'wp-admin-shell' ),
+				render: ( { item } ) => <Text>{ item.slug }</Text>,
+			},
+			{
+				id: 'count',
+				type: 'integer',
+				label: __( 'Count', 'wp-admin-shell' ),
+				render: ( { item } ) => <Text>{ item.count }</Text>,
+			},
+			{
+				id: 'description',
+				type: 'text',
+				label: __( 'Description', 'wp-admin-shell' ),
+				render: ( { item } ) => (
+					<Text>{ stripTags( item.description ) }</Text>
+				),
+			},
+		],
+		[]
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit', 'wp-admin-shell' ),
+				icon: pencil,
+				isPrimary: true,
+				callback: ( items ) => setEditTerm( items[ 0 ].rawRecord ),
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete', 'wp-admin-shell' ),
+				icon: trash,
+				isDestructive: true,
+				supportsBulk: true,
+				RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+					<VStack spacing={ 4 } style={ { padding: '16px' } }>
+						<Text>
+							{ items.length === 1
+								? __( 'Delete this term?', 'wp-admin-shell' )
+								: __(
+										'Delete these terms? Posts assigned to them will lose this term.',
+										'wp-admin-shell'
+								  ) }
+						</Text>
+						<HStack justify="right">
+							<Button variant="tertiary" onClick={ closeModal }>
+								{ __( 'Cancel', 'wp-admin-shell' ) }
+							</Button>
+							<Button
+								variant="primary"
+								isDestructive
+								onClick={ async () => {
+									await Promise.all(
+										items.map( ( item ) =>
+											deleteEntityRecord(
+												'taxonomy',
+												taxonomy,
+												item.id,
+												{ force: true }
+											)
+										)
+									);
+									onActionPerformed?.( items );
+									closeModal();
+								} }
+							>
+								{ __( 'Delete', 'wp-admin-shell' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				),
+			},
+		],
+		[ deleteEntityRecord, taxonomy ]
+	);
+
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems: totalItems || 0,
+			totalPages: totalPages || 0,
+		} ),
+		[ totalItems, totalPages ]
+	);
+
+	const [ selection, setSelection ] = useState( [] );
+
+	return (
+		<div className="wp-admin-shell-app-taxonomy">
+			<HStack
+				className="wp-admin-shell-app-taxonomy__toolbar"
+				alignment="center"
+			>
+				<Text size={ 20 } weight={ 600 }>
+					{ heading }
+				</Text>
+				<Button
+					variant="primary"
+					icon={ plus }
+					onClick={ () => setIsCreating( true ) }
+					size="compact"
+				>
+					{ __( 'Add new', 'wp-admin-shell' ) }
+				</Button>
+			</HStack>
+
+			<DataViews
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				isLoading={ isResolving }
+				defaultLayouts={ { table: {} } }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				getItemId={ ( item ) => item.id.toString() }
+			/>
+
+			{ ( editTerm || isCreating ) && (
+				<TermEditModal
+					term={ editTerm }
+					taxonomy={ taxonomy }
+					onClose={ () => {
+						setEditTerm( null );
+						setIsCreating( false );
+					} }
+					onSave={ saveEntityRecord }
+				/>
+			) }
+		</div>
+	);
+}
+
+function stripTags( html ) {
+	return ( html || '' ).replace( /<[^>]*>/g, '' ).trim();
+}
+
+function TermEditModal( { term, taxonomy, onClose, onSave } ) {
+	const isNew = ! term;
+	const [ name, setName ] = useState( term?.name || '' );
+	const [ slug, setSlug ] = useState( term?.slug || '' );
+	const [ description, setDescription ] = useState( term?.description || '' );
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const handleSave = async () => {
+		setIsSaving( true );
+		try {
+			const payload = {
+				name,
+				slug,
+				description,
+			};
+			if ( ! isNew ) {
+				payload.id = term.id;
+			}
+			await onSave( 'taxonomy', taxonomy, payload );
+			onClose();
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	return (
+		<Modal
+			title={
+				isNew
+					? __( 'Add term', 'wp-admin-shell' )
+					: __( 'Edit term', 'wp-admin-shell' )
+			}
+			onRequestClose={ onClose }
+		>
+			<VStack spacing={ 3 }>
+				<TextControl
+					label={ __( 'Name', 'wp-admin-shell' ) }
+					value={ name }
+					onChange={ setName }
+					__nextHasNoMarginBottom
+				/>
+				<TextControl
+					label={ __( 'Slug', 'wp-admin-shell' ) }
+					value={ slug }
+					onChange={ setSlug }
+					help={ __(
+						'URL-friendly version of the name. Auto-generated if blank.',
+						'wp-admin-shell'
+					) }
+					__nextHasNoMarginBottom
+				/>
+				<TextareaControl
+					label={ __( 'Description', 'wp-admin-shell' ) }
+					value={ description }
+					onChange={ setDescription }
+					rows={ 4 }
+					__nextHasNoMarginBottom
+				/>
+				<HStack justify="right">
+					<Button variant="tertiary" onClick={ onClose }>
+						{ __( 'Cancel', 'wp-admin-shell' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ handleSave }
+						isBusy={ isSaving }
+						disabled={ ! name || isSaving }
+					>
+						{ isNew
+							? __( 'Add term', 'wp-admin-shell' )
+							: __( 'Save', 'wp-admin-shell' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}

--- a/src/apps/ThemesApp.js
+++ b/src/apps/ThemesApp.js
@@ -1,0 +1,254 @@
+import { useEffect, useState, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	__experimentalGrid as Grid,
+	Card,
+	CardBody,
+	CardFooter,
+	CardMedia,
+	Spinner,
+	Modal,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { check, external } from '@wordpress/icons';
+
+function stripTags( html ) {
+	return ( html || '' ).replace( /<[^>]*>/g, '' ).trim();
+}
+
+export default function ThemesApp() {
+	const [ themes, setThemes ] = useState( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ error, setError ] = useState( null );
+	const [ activeStylesheet, setActiveStylesheet ] = useState( null );
+	const [ details, setDetails ] = useState( null );
+	const [ refreshKey, setRefreshKey ] = useState( 0 );
+
+	useEffect( () => {
+		let cancelled = false;
+		setIsLoading( true );
+		Promise.all( [
+			apiFetch( { path: '/wp/v2/themes?context=edit&status=active,inactive' } ),
+			// stylesheet of the currently active theme; pulled from the
+			// shell's bootstrap data with a fallback fetch when missing.
+			Promise.resolve( window.wpAdminShell?.activeTheme ).then(
+				( v ) =>
+					v ??
+					apiFetch( { path: '/wp/v2/themes?status=active' } ).then(
+						( res ) => res?.[ 0 ]?.stylesheet
+					)
+			),
+		] )
+			.then( ( [ list, active ] ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setThemes( list );
+				setActiveStylesheet( active );
+				setError( null );
+			} )
+			.catch( ( err ) => {
+				if ( ! cancelled ) {
+					setError( err.message || __( 'Failed to load themes.', 'wp-admin-shell' ) );
+				}
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ refreshKey ] );
+
+	const activate = useCallback(
+		async ( theme ) => {
+			// REST does not expose theme switching directly. Fall back to a
+			// custom endpoint when available, otherwise navigate to wp-admin.
+			try {
+				await apiFetch( {
+					path: '/wp-admin-shell/v1/activate-theme',
+					method: 'POST',
+					data: { stylesheet: theme.stylesheet },
+				} );
+				setRefreshKey( ( k ) => k + 1 );
+				setDetails( null );
+			} catch ( err ) {
+				const target =
+					( window.wpAdminShell?.adminUrl || '/wp-admin/' ) +
+					`themes.php?action=activate&stylesheet=${ encodeURIComponent(
+						theme.stylesheet
+					) }`;
+				window.location.href = target;
+			}
+		},
+		[]
+	);
+
+	if ( error ) {
+		return (
+			<div className="wp-admin-shell-app-themes__error">
+				<Text>{ error }</Text>
+			</div>
+		);
+	}
+
+	if ( isLoading || ! themes ) {
+		return (
+			<div className="wp-admin-shell-app-themes__loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	const sorted = [ ...themes ].sort( ( a, b ) => {
+		if ( a.stylesheet === activeStylesheet ) return -1;
+		if ( b.stylesheet === activeStylesheet ) return 1;
+		return ( a.name?.rendered || '' ).localeCompare( b.name?.rendered || '' );
+	} );
+
+	return (
+		<div className="wp-admin-shell-app-themes">
+			<HStack alignment="left" className="wp-admin-shell-app-themes__header">
+				<Text size={ 20 } weight={ 600 }>
+					{ __( 'Themes', 'wp-admin-shell' ) }
+				</Text>
+				<Text variant="muted">
+					{ themes.length }{ ' ' }
+					{ __( 'installed', 'wp-admin-shell' ) }
+				</Text>
+			</HStack>
+
+			<Grid columns={ 3 } gap={ 4 }>
+				{ sorted.map( ( theme ) => {
+					const isActive = theme.stylesheet === activeStylesheet;
+					const screenshot = theme.screenshot || '';
+					return (
+						<Card key={ theme.stylesheet }>
+							{ screenshot && (
+								<CardMedia>
+									<img
+										src={ screenshot }
+										alt={ theme.name?.rendered || '' }
+									/>
+								</CardMedia>
+							) }
+							<CardBody>
+								<VStack spacing={ 2 }>
+									<HStack
+										alignment="left"
+										justify="space-between"
+									>
+										<Text weight={ 600 }>
+											{ theme.name?.rendered }
+										</Text>
+										{ isActive && (
+											<Text variant="muted" size={ 12 }>
+												{ __(
+													'Active',
+													'wp-admin-shell'
+												) }
+											</Text>
+										) }
+									</HStack>
+									<Text variant="muted" size={ 12 }>
+										{ stripTags(
+											theme.description?.rendered || ''
+										).slice( 0, 140 ) }
+									</Text>
+								</VStack>
+							</CardBody>
+							<CardFooter>
+								<HStack justify="space-between">
+									<Button
+										variant="tertiary"
+										size="compact"
+										onClick={ () =>
+											setDetails( {
+												theme,
+												isActive,
+											} )
+										}
+									>
+										{ __( 'Details', 'wp-admin-shell' ) }
+									</Button>
+									{ ! isActive && (
+										<Button
+											variant="primary"
+											size="compact"
+											icon={ check }
+											onClick={ () => activate( theme ) }
+										>
+											{ __(
+												'Activate',
+												'wp-admin-shell'
+											) }
+										</Button>
+									) }
+								</HStack>
+							</CardFooter>
+						</Card>
+					);
+				} ) }
+			</Grid>
+
+			{ details && (
+				<Modal
+					title={ details.theme.name?.rendered }
+					onRequestClose={ () => setDetails( null ) }
+					size="medium"
+				>
+					<VStack spacing={ 3 }>
+						{ details.theme.screenshot && (
+							<img
+								src={ details.theme.screenshot }
+								alt=""
+								style={ { maxWidth: '100%' } }
+							/>
+						) }
+						<Text>
+							{ stripTags(
+								details.theme.description?.rendered || ''
+							) }
+						</Text>
+						<Text variant="muted" size={ 12 }>
+							{ __( 'Version', 'wp-admin-shell' ) }:{ ' ' }
+							{ details.theme.version } ·{ ' ' }
+							{ __( 'Author', 'wp-admin-shell' ) }:{ ' ' }
+							{ stripTags( details.theme.author?.rendered || '' ) }
+						</Text>
+						<HStack justify="right">
+							{ details.theme.theme_uri && (
+								<Button
+									icon={ external }
+									variant="tertiary"
+									onClick={ () =>
+										window.open(
+											details.theme.theme_uri,
+											'_blank'
+										)
+									}
+								>
+									{ __( 'Theme site', 'wp-admin-shell' ) }
+								</Button>
+							) }
+							{ ! details.isActive && (
+								<Button
+									variant="primary"
+									onClick={ () => activate( details.theme ) }
+								>
+									{ __( 'Activate', 'wp-admin-shell' ) }
+								</Button>
+							) }
+						</HStack>
+					</VStack>
+				</Modal>
+			) }
+		</div>
+	);
+}

--- a/src/apps/ToolsApp.js
+++ b/src/apps/ToolsApp.js
@@ -1,0 +1,132 @@
+import {
+	Button,
+	Stack,
+	Text,
+} from '@wordpress/ui';
+import {
+	Card,
+	CardBody,
+	CardHeader,
+	__experimentalGrid as Grid,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { external } from '@wordpress/icons';
+import { navigate } from '../routing/router';
+
+const TOOLS = [
+	{
+		id: 'site-health',
+		title: __( 'Site Health', 'wp-admin-shell' ),
+		description: __(
+			'Check that your site is running on the latest WordPress and that key services are reachable.',
+			'wp-admin-shell'
+		),
+		appId: 'site-health',
+	},
+	{
+		id: 'import',
+		title: __( 'Import', 'wp-admin-shell' ),
+		description: __(
+			'Pull content into this site from another WordPress install or a third-party platform.',
+			'wp-admin-shell'
+		),
+		legacy: 'import.php',
+	},
+	{
+		id: 'export',
+		title: __( 'Export', 'wp-admin-shell' ),
+		description: __(
+			'Download an XML archive of posts, pages, comments, custom fields, terms, and authors.',
+			'wp-admin-shell'
+		),
+		legacy: 'export.php',
+	},
+	{
+		id: 'export-personal-data',
+		title: __( 'Export personal data', 'wp-admin-shell' ),
+		description: __(
+			'Generate a privacy-compliant export of a user’s personal data on request.',
+			'wp-admin-shell'
+		),
+		legacy: 'export-personal-data.php',
+	},
+	{
+		id: 'erase-personal-data',
+		title: __( 'Erase personal data', 'wp-admin-shell' ),
+		description: __(
+			'Delete a user’s personal data on request.',
+			'wp-admin-shell'
+		),
+		legacy: 'erase-personal-data.php',
+	},
+];
+
+function adminUrl( legacy ) {
+	const base = window.wpAdminShell?.adminUrl || '/wp-admin/';
+	return base + legacy;
+}
+
+export default function ToolsApp() {
+	return (
+		<div className="wp-admin-shell-app-tools">
+			<Stack direction="column" gap="xl">
+				<Stack direction="column" gap="xs">
+					<Text variant="heading-xl" render={ <h1 /> }>
+						{ __( 'Tools', 'wp-admin-shell' ) }
+					</Text>
+					<Text variant="body-md">
+						{ __(
+							'Routine maintenance tasks. Some still link out to the legacy WordPress screens.',
+							'wp-admin-shell'
+						) }
+					</Text>
+				</Stack>
+
+				<Grid columns={ 2 } gap={ 4 }>
+					{ TOOLS.map( ( tool ) => (
+						<Card key={ tool.id }>
+							<CardHeader>
+								<Text variant="heading-md" render={ <h2 /> }>
+									{ tool.title }
+								</Text>
+							</CardHeader>
+							<CardBody>
+								<Stack direction="column" gap="md">
+									<Text variant="body-sm">
+										{ tool.description }
+									</Text>
+									{ tool.appId ? (
+										<Button
+											variant="outline"
+											onClick={ () =>
+												navigate( tool.appId )
+											}
+										>
+											{ __(
+												'Open',
+												'wp-admin-shell'
+											) }
+										</Button>
+									) : (
+										<Button
+											variant="outline"
+											onClick={ () =>
+												( window.location.href =
+													adminUrl( tool.legacy ) )
+											}
+										>
+											{ __(
+												'Open',
+												'wp-admin-shell'
+											) }
+										</Button>
+									) }
+								</Stack>
+							</CardBody>
+						</Card>
+					) ) }
+				</Grid>
+			</Stack>
+		</div>
+	);
+}

--- a/src/apps/UsersApp.js
+++ b/src/apps/UsersApp.js
@@ -1,0 +1,247 @@
+import { useMemo, useState } from '@wordpress/element';
+import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { DataViews } from '@wordpress/dataviews';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { trash, pencil, external } from '@wordpress/icons';
+import { navigate } from '../routing/router';
+
+const ROLE_LABELS = {
+	administrator: __( 'Administrator', 'wp-admin-shell' ),
+	editor: __( 'Editor', 'wp-admin-shell' ),
+	author: __( 'Author', 'wp-admin-shell' ),
+	contributor: __( 'Contributor', 'wp-admin-shell' ),
+	subscriber: __( 'Subscriber', 'wp-admin-shell' ),
+};
+
+export default function UsersApp( { config = {} } ) {
+	const [ view, setView ] = useState( {
+		type: 'table',
+		search: '',
+		filters: [],
+		page: 1,
+		perPage: 20,
+		sort: { field: 'registered_date', direction: 'desc' },
+		fields: [ 'name', 'email', 'roles', 'posts' ],
+		layout: {},
+	} );
+
+	const queryArgs = useMemo( () => {
+		const args = {
+			per_page: view.perPage,
+			page: view.page,
+			order: view.sort?.direction || 'desc',
+			orderby: view.sort?.field || 'registered_date',
+			context: 'edit',
+		};
+		if ( view.search ) {
+			args.search = view.search;
+		}
+		for ( const filter of view.filters ) {
+			if ( filter.field === 'roles' ) {
+				if ( filter.operator === 'isAny' && Array.isArray( filter.value ) ) {
+					args.roles = filter.value.join( ',' );
+				} else if ( filter.operator === 'is' ) {
+					args.roles = filter.value;
+				}
+			}
+		}
+		if ( config.role ) {
+			args.roles = config.role;
+		}
+		return args;
+	}, [ view, config.role ] );
+
+	const { records, isResolving, totalItems, totalPages } = useEntityRecords(
+		'root',
+		'user',
+		queryArgs
+	);
+
+	const { deleteEntityRecord } = useDispatch( coreStore );
+
+	const data = useMemo( () => {
+		if ( ! records ) {
+			return [];
+		}
+		return records.map( ( u ) => ( {
+			id: u.id,
+			name: u.name,
+			username: u.username,
+			email: u.email,
+			roles: u.roles || [],
+			posts: u.post_count ?? 0,
+			avatar: u.avatar_urls?.[ 48 ] || u.avatar_urls?.[ 96 ] || '',
+			rawRecord: u,
+		} ) );
+	}, [ records ] );
+
+	const fields = useMemo(
+		() => [
+			{
+				id: 'name',
+				type: 'text',
+				label: __( 'Name', 'wp-admin-shell' ),
+				enableGlobalSearch: true,
+				enableHiding: false,
+				render: ( { item } ) => (
+					<HStack spacing={ 2 } expanded={ false } alignment="left">
+						{ item.avatar && (
+							<img
+								src={ item.avatar }
+								alt=""
+								width={ 28 }
+								height={ 28 }
+								style={ { borderRadius: '50%' } }
+							/>
+						) }
+						<VStack spacing={ 0 }>
+							<Text weight={ 600 }>{ item.name }</Text>
+							{ item.username && item.username !== item.name && (
+								<Text variant="muted" size={ 12 }>
+									@{ item.username }
+								</Text>
+							) }
+						</VStack>
+					</HStack>
+				),
+			},
+			{
+				id: 'email',
+				type: 'text',
+				label: __( 'Email', 'wp-admin-shell' ),
+				enableGlobalSearch: true,
+				render: ( { item } ) => <Text>{ item.email }</Text>,
+			},
+			{
+				id: 'roles',
+				type: 'text',
+				label: __( 'Role', 'wp-admin-shell' ),
+				elements: Object.entries( ROLE_LABELS ).map(
+					( [ value, label ] ) => ( { value, label } )
+				),
+				render: ( { item } ) => (
+					<Text>
+						{ item.roles
+							.map( ( r ) => ROLE_LABELS[ r ] || r )
+							.join( ', ' ) }
+					</Text>
+				),
+				filterBy: { operators: [ 'isAny' ] },
+			},
+			{
+				id: 'posts',
+				type: 'integer',
+				label: __( 'Posts', 'wp-admin-shell' ),
+				render: ( { item } ) => <Text>{ item.posts }</Text>,
+			},
+		],
+		[]
+	);
+
+	const actions = useMemo(
+		() => [
+			{
+				id: 'edit',
+				label: __( 'Edit', 'wp-admin-shell' ),
+				icon: pencil,
+				isPrimary: true,
+				callback: ( items ) => {
+					navigate( 'user-edit', items[ 0 ].id );
+				},
+			},
+			{
+				id: 'view-posts',
+				label: __( 'View posts', 'wp-admin-shell' ),
+				icon: external,
+				isEligible: ( item ) => item.posts > 0,
+				callback: ( items ) => {
+					navigate( 'posts', { author: items[ 0 ].id } );
+				},
+			},
+			{
+				id: 'delete',
+				label: __( 'Delete', 'wp-admin-shell' ),
+				icon: trash,
+				isDestructive: true,
+				supportsBulk: true,
+				RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+					<VStack spacing={ 4 } style={ { padding: '16px' } }>
+						<Text>
+							{ items.length === 1
+								? __(
+										'Delete this user? Their content will be reassigned to the network admin or removed depending on site policy.',
+										'wp-admin-shell'
+								  )
+								: __(
+										'Delete these users? Their content will be reassigned or removed.',
+										'wp-admin-shell'
+								  ) }
+						</Text>
+						<HStack justify="right">
+							<Button variant="tertiary" onClick={ closeModal }>
+								{ __( 'Cancel', 'wp-admin-shell' ) }
+							</Button>
+							<Button
+								variant="primary"
+								isDestructive
+								onClick={ async () => {
+									await Promise.all(
+										items.map( ( item ) =>
+											deleteEntityRecord(
+												'root',
+												'user',
+												item.id,
+												{ force: true, reassign: 0 }
+											)
+										)
+									);
+									onActionPerformed?.( items );
+									closeModal();
+								} }
+							>
+								{ __( 'Delete', 'wp-admin-shell' ) }
+							</Button>
+						</HStack>
+					</VStack>
+				),
+			},
+		],
+		[ deleteEntityRecord ]
+	);
+
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems: totalItems || 0,
+			totalPages: totalPages || 0,
+		} ),
+		[ totalItems, totalPages ]
+	);
+
+	const [ selection, setSelection ] = useState( [] );
+
+	return (
+		<div className="wp-admin-shell-app-users">
+			<DataViews
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				isLoading={ isResolving }
+				defaultLayouts={ { table: {}, grid: {} } }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				getItemId={ ( item ) => item.id.toString() }
+			/>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Adds 12 standalone React app components covering the wp-admin screens called out in `docs/wp-admin-shell-v1-plan.md` (M4) and `docs/wp-admin-screen-inventory.md`, built from the WPDS system components per `CLAUDE.md`. Block editor and site editor are intentionally left as iframed escape hatches per the user's direction and the v1 plan.

The components live in `src/apps/` next to the existing MVP apps. They are **not** wired into the MVP source registry — they're meant to be registered by the v1 kernel in M1 `registry/builtins.js`. This PR is purely additive; nothing in the existing MVP shell changes.

## Apps added

| File | Source id | Pattern |
|---|---|---|
| `DashboardApp.js` | `core:dashboard` | Greeting + 4 stat cards + recent drafts + pending comments |
| `CommentsApp.js` | `core:comments` | DataViews moderation (approve / unapprove / spam / trash / delete-permanently) |
| `UsersApp.js` | `core:users` | DataViews user list with role filter, edit + bulk delete |
| `TaxonomyApp.js` | `core:taxonomy` | DataViews term list + add/edit modal (categories, tags, custom taxonomies) |
| `PluginsApp.js` | `core:plugins` | DataViews list with activate / deactivate / delete |
| `ThemesApp.js` | `core:themes` | Card grid with details modal and activate |
| `SettingsWritingApp.js` | `core:settings-writing` | Default category + post format |
| `SettingsReadingApp.js` | `core:settings-reading` | Front-page config, posts-per-page, RSS, default comment status |
| `SettingsDiscussionApp.js` | `core:settings-discussion` | Default comment / ping status (REST-bounded) |
| `SiteHealthApp.js` | `core:site-health` | Runs `/wp-site-health/v1/tests/*` async tests with status pills |
| `ToolsApp.js` | `core:tools` | Landing cards linking to native + legacy tools |
| `AppearanceApp.js` | `core:appearance` | User-prefs UI honoring `userCustomizable` (density / accent / default route) |

## Stack

- `@wordpress/ui` first; `@wordpress/components` for primitives `ui` doesn't ship (`SelectControl`, `RadioControl`, `CheckboxControl`, `Spinner`, `Card.*`, `Modal`, etc.)
- `@wordpress/core-data` (`useEntityRecord`, `useEntityRecords`) for entity data
- `@wordpress/api-fetch` for non-entity endpoints (plugins, themes, site-health, user-prefs)
- `@wordpress/dataviews` for list screens

Settings panels respect the REST coverage boundary in `docs/admin-json-api-validation.md` — fields that aren't exposed by `GET/PUT /wp/v2/settings` (search-engine visibility, fine-grained discussion rules, post-via-email) are noted in-panel rather than silently omitted, so a shell author knows to fall back to `iframe:options-*.php` for those.

## Why merge first

These files are additive and don't touch shell scaffolding. Merging now gives v1's M1 milestone concrete components to wire into `registry/builtins.js` instead of writing them in tandem with the kernel rebuild. The only MVP coupling is `import { navigate } from '../routing/router'` in a few apps — v1 has to rename that path across `src/apps/*` anyway when `src/runtime/routing/*` lands, so doing it once over the full set is cheaper than twice.

## Test plan

- [ ] `npm run build` succeeds (verified locally; only the bundle-size warnings remain — expected with DataViews + this many new apps, documented as an M5 item in the v1 plan)
- [ ] Each app renders in isolation when temporarily registered against the MVP source registry (verified locally)
- [ ] Settings panels load existing site values and save round-trip via `useEntityRecord('root', 'site')`
- [ ] DataViews apps (Comments, Users, Taxonomy, Plugins) paginate, search, filter, and execute row + bulk actions
- [ ] SiteHealth runs the five async tests and reports status pills

https://claude.ai/code/session_01RyC5VnFWh1xPN4JNzpRZEg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyC5VnFWh1xPN4JNzpRZEg)_