### PR TITLE
docs: add documentation schema + populate app.json docs across all bundled apps

### DIFF
--- a/docs/schemas/admin-app-v2.json
+++ b/docs/schemas/admin-app-v2.json
@@ -108,6 +108,10 @@
 
 		"window": {
 			"$ref": "#/$defs/appWindow"
+		},
+
+		"documentation": {
+			"$ref": "#/$defs/appDocumentation"
 		}
 	},
 
@@ -254,6 +258,270 @@
 					"type": "string",
 					"minLength": 1,
 					"description": "Icon registry name (resolved by the active engine's icon table via the kernel icon registry). Used by windowing engines for the window-frame titlebar icon, taskbar/dock entry, and overview switcher. Defaults to a generic application icon when omitted."
+				}
+			}
+		},
+
+		"appDocumentation": {
+			"type": "object",
+			"additionalProperties": false,
+			"description": "Documentation contract: machine-readable description of what the app does at runtime, intended for reviewers, ecosystem tooling, and authors rebuilding the app on a different design system or framework. Not load-bearing: the runtime does not read or enforce any field here. The contract pairs with a sibling `app.md` prose document — structured facts live here, narrative explanation lives in markdown.",
+			"properties": {
+				"purpose": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Extended one-paragraph plain-English description of what the app does, who it serves, and how it fits into the shell. Longer-form than the manifest `description` field (which is a one-line summary used in plugin install screens). Translatable."
+				},
+				"rebuilds": {
+					"type": "string",
+					"minLength": 1,
+					"description": "Reference to a tier-2 screen specification under `docs/screens/` that this app rebuilds, expressed as the screen slug (e.g. `dashboard-home`, `posts`, `users`). Omitted for apps with no wp-admin screen equivalent (shell-only apps like `core:navigation`, `core:site-hub`)."
+				},
+				"data": {
+					"type": "object",
+					"additionalProperties": false,
+					"description": "Data dependencies the app expresses against the WordPress runtime. Reads and writes are listed separately so a reimplementation can wire up the read path before the write path. The list should cover every entity, REST endpoint, or window global the app touches in production — not implementation-internal helpers.",
+					"properties": {
+						"reads": {
+							"type": "array",
+							"items": { "$ref": "#/$defs/dataOperation" },
+							"description": "Data sources the app reads from. Each entry names a source, the access mechanism, and (if applicable) the WordPress REST context and notable query args."
+						},
+						"writes": {
+							"type": "array",
+							"items": { "$ref": "#/$defs/dataMutation" },
+							"description": "Data mutations the app performs. Each entry names a source, an operation kind, and any cache-invalidation responsibilities a reimplementation must mirror."
+						}
+					}
+				},
+				"url": {
+					"type": "object",
+					"additionalProperties": false,
+					"description": "URL participation contract. Per spec §6 / §18, the URL is the canonical state store for routable regions and any cross-region coordination. An app declares which URL slots it reads from, which it writes back, and which route patterns it navigates to.",
+					"properties": {
+						"reads-slots": {
+							"type": "array",
+							"items": { "type": "string", "minLength": 1 },
+							"uniqueItems": true,
+							"description": "Named URL query slots the app reads. Use `_self` for the primary hash path; use the slot name otherwise (e.g. `screen`, `detail`)."
+						},
+						"writes-slots": {
+							"type": "array",
+							"items": { "type": "string", "minLength": 1 },
+							"uniqueItems": true,
+							"description": "Named URL query slots the app writes through the router (e.g. NavigationApp writes `screen` for drill-down state)."
+						},
+						"navigates": {
+							"type": "array",
+							"items": { "type": "string", "minLength": 1 },
+							"description": "Route patterns the app navigates to via `navigate()` or anchor hrefs. Patterns use `{param}` placeholders (e.g. `#/posts/{id}/edit`, `#/media`). Listing them here documents the outbound link surface."
+						}
+					}
+				},
+				"states": {
+					"type": "array",
+					"description": "User-visible runtime states the app cycles through. Lists the discriminated states a reimplementation must render; intermediate / transient states (debounce ticks, hover) are out of scope.",
+					"items": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": [ "id", "renders" ],
+						"properties": {
+							"id": {
+								"type": "string",
+								"minLength": 1,
+								"description": "State identifier, kebab-case. Common values: `loading`, `empty`, `error`, `ready`, `saving`, `saved`, `with-edits`, `permission-denied`."
+							},
+							"when": {
+								"type": "string",
+								"description": "Condition that puts the app into this state (e.g. `records === null`, `hasEdits && isSaving`)."
+							},
+							"renders": {
+								"type": "string",
+								"description": "What the user sees in this state — short prose. Reimplementations target this output, not the specific component."
+							}
+						}
+					}
+				},
+				"interactions": {
+					"type": "array",
+					"description": "User actions the app responds to. Each entry is a trigger → effect pair; nested triggers (a modal that opens another modal) are flattened into separate entries.",
+					"items": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": [ "trigger", "effect" ],
+						"properties": {
+							"trigger": {
+								"type": "string",
+								"minLength": 1,
+								"description": "User input or system event (e.g. `Click row title`, `Press Cmd+S`, `Submit Quick Draft form`, `Drag avatar onto upload zone`)."
+							},
+							"effect": {
+								"type": "string",
+								"minLength": 1,
+								"description": "State change, navigation, or mutation that results (e.g. `Navigate to #/posts/{id}/edit`, `POST /wp/v2/posts and invalidate the drafts query`)."
+							},
+							"guards": {
+								"type": "array",
+								"items": { "type": "string", "minLength": 1 },
+								"description": "Capability checks, eligibility checks, or invariants enforced before the effect runs (e.g. `userCan(\"edit_post\", item)`, `status === \"publish\"`)."
+							}
+						}
+					}
+				},
+				"a11y": {
+					"type": "object",
+					"additionalProperties": false,
+					"description": "Accessibility contract a reimplementation must preserve. Landmark role is already declared in the top-level `role` field; this block covers focus, keyboard, and screen-reader concerns that aren't otherwise discoverable.",
+					"properties": {
+						"focus-management": {
+							"type": "string",
+							"description": "How the app manages focus on mount, route changes, modal open/close, and post-action transitions."
+						},
+						"keyboard": {
+							"type": "array",
+							"description": "App-owned keyboard shortcuts. Shell-level bindings (the `bindings` block in admin.json) are out of scope.",
+							"items": {
+								"type": "object",
+								"additionalProperties": false,
+								"required": [ "keys", "action" ],
+								"properties": {
+									"keys": {
+										"type": "string",
+										"minLength": 1,
+										"description": "Display name of the keystroke chord (e.g. `Cmd+S`, `Esc`, `Enter`)."
+									},
+									"action": {
+										"type": "string",
+										"minLength": 1,
+										"description": "What the shortcut does."
+									}
+								}
+							}
+						},
+						"screen-reader": {
+							"type": "string",
+							"description": "Live regions, `aria-live` announcements, `aria-current` usage, and other screen-reader-specific affordances."
+						}
+					}
+				},
+				"constraints": {
+					"type": "array",
+					"description": "Framework-, WPDS-, or WordPress-specific gotchas a reimplementation must account for. Captures the recurring patterns documented in `CLAUDE.md` (null-guards, cache invalidation, DataViews import path) and any per-app workarounds.",
+					"items": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": [ "concern", "note" ],
+						"properties": {
+							"concern": {
+								"type": "string",
+								"minLength": 1,
+								"description": "Short identifier for the constraint (e.g. `null-guard-records`, `dataviews-import-path`, `self-delete-guard`)."
+							},
+							"note": {
+								"type": "string",
+								"minLength": 1,
+								"description": "What the constraint is and what a reimplementation must do to honor it."
+							}
+						}
+					}
+				},
+				"design-system-leakage": {
+					"type": "array",
+					"description": "Specific `@wordpress/*` imports the app cannot do without. A rebuild on a non-WPDS design system (Material, Tailwind, custom) must provide functional equivalents for every entry. Generic utility imports (`@wordpress/element`, `@wordpress/i18n`) are out of scope — only the design-system-coupled imports belong here.",
+					"items": {
+						"type": "object",
+						"additionalProperties": false,
+						"required": [ "import", "purpose" ],
+						"properties": {
+							"import": {
+								"type": "string",
+								"minLength": 1,
+								"description": "Bare-import path the app loads (e.g. `@wordpress/dataviews/wp`, `@wordpress/ui#Button`, `@wordpress/components#Modal`, `@wordpress/icons#trash`)."
+							},
+							"purpose": {
+								"type": "string",
+								"minLength": 1,
+								"description": "What the import provides and why the app needs it."
+							}
+						}
+					}
+				}
+			}
+		},
+
+		"dataOperation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [ "source", "via" ],
+			"description": "A single data-read operation: which source the app pulls from, by what mechanism, and what shape the data has.",
+			"properties": {
+				"source": {
+					"type": "string",
+					"minLength": 1,
+					"description": "REST endpoint (e.g. `/wp/v2/posts`), `core-data` entity path (e.g. `postType/post`, `root/site`, `root/user`), external URL, or window-global property (e.g. `window.wpAdminShell.user`)."
+				},
+				"via": {
+					"enum": [ "core-data", "api-fetch", "window-global", "external", "commands" ],
+					"description": "Access mechanism. `core-data` = `useEntityRecord`/`useEntityRecords` from `@wordpress/core-data`; `api-fetch` = `@wordpress/api-fetch` direct call; `window-global` = read from `window.wpAdminShell.*` (config injected by PHP); `external` = `fetch()` against a non-WordPress origin; `commands` = `@wordpress/commands` registry."
+				},
+				"context": {
+					"enum": [ "view", "edit", "embed" ],
+					"description": "REST context, when applicable. `edit` is required for any field whose `raw` value will be edited (title, content, excerpt). Omit for non-REST sources."
+				},
+				"purpose": {
+					"type": "string",
+					"description": "What this read is for in the app's flow (e.g. `List rows in the DataViews table`, `Look up the acting user for self-delete guard`)."
+				},
+				"fields": {
+					"type": "array",
+					"items": { "type": "string", "minLength": 1 },
+					"description": "Notable fields read from the record (e.g. `[\"title.raw\", \"status\", \"author\", \"date\"]`). Use dotted paths for nested values."
+				},
+				"query": {
+					"type": "object",
+					"additionalProperties": true,
+					"description": "Notable query args the app passes (e.g. `{ _embed: \"author\", per_page: 20 }`). Dynamic args (search strings, filter values) document the keys, not the values."
+				}
+			}
+		},
+
+		"dataMutation": {
+			"type": "object",
+			"additionalProperties": false,
+			"required": [ "source", "via", "operation" ],
+			"description": "A single data-write operation: which source the app mutates, by what mechanism, and what cache invalidations are required afterwards.",
+			"properties": {
+				"source": {
+					"type": "string",
+					"minLength": 1,
+					"description": "REST endpoint or `core-data` entity path (same shape as `dataOperation.source`)."
+				},
+				"via": {
+					"enum": [ "core-data", "api-fetch", "external" ],
+					"description": "Mutation mechanism. `core-data` = `saveEntityRecord` / `deleteEntityRecord` via `useDispatch(coreStore)`; `api-fetch` = direct call; `external` = non-WordPress origin."
+				},
+				"operation": {
+					"enum": [
+						"create",
+						"update",
+						"partial-update",
+						"delete",
+						"trash",
+						"bulk-delete",
+						"bulk-update",
+						"upload",
+						"custom"
+					],
+					"description": "Operation kind. `partial-update` = PATCH with a subset of fields (used for comment moderation status changes); `trash` = the WordPress default delete that sends to trash (no `force` flag); `delete` = permanent delete (`force: true`)."
+				},
+				"purpose": {
+					"type": "string",
+					"description": "What this write is for (e.g. `Approve a pending comment`, `Trash one or more selected posts`)."
+				},
+				"invalidates": {
+					"type": "array",
+					"items": { "type": "string", "minLength": 1 },
+					"description": "Cache keys or entity queries that must be invalidated afterwards. `core-data`'s `useEntityRecord` short-circuits for the same store, but `useEntityRecords` queries do not — explicit `invalidateResolution( 'getEntityRecords', [...] )` calls are required. List the entity paths the reimplementation must invalidate (e.g. `postType/post`)."
 				}
 			}
 		}

--- a/src/apps/appearance/app.json
+++ b/src/apps/appearance/app.json
@@ -22,5 +22,118 @@
 		},
 		"multiInstance": false,
 		"icon": "page"
+	},
+	"documentation": {
+		"purpose": "Per-user customization screen for shell appearance. Reads the active shell's `customizable` declarations from the resolved config and renders ONLY the controls the shell allows. MVP controls: density (default / compact / comfortable), accent color (color picker that writes a single token override), default-route override (text input for landing path). Saves go through `POST /wp-admin-shell/v1/user-prefs`; the server deep-merges onto the existing prefs blob and the resolver re-runs on next mount.",
+		"data": {
+			"reads": [
+				{
+					"source": "/wp-admin-shell/v1/user-prefs",
+					"via": "api-fetch",
+					"purpose": "Existing per-user overrides on mount."
+				},
+				{
+					"source": "config.styles.customizable + config.styles + config.default-route",
+					"via": "core-data",
+					"purpose": "Active shell's customizable allowlist + current resolved values (used as fallbacks when prefs are empty)."
+				}
+			],
+			"writes": [
+				{
+					"source": "/wp-admin-shell/v1/user-prefs",
+					"via": "api-fetch",
+					"operation": "partial-update",
+					"purpose": "Patch user prefs via POST with the changed key only — server deep-merges."
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "loading",
+				"when": "prefs === null",
+				"renders": "Centered Spinner — waiting for initial fetch."
+			},
+			{
+				"id": "no-controls",
+				"when": "Nothing is customizable for this shell",
+				"renders": "Empty-state copy explaining the shell has locked customization."
+			},
+			{
+				"id": "ready",
+				"when": "prefs !== null and at least one control is allowed",
+				"renders": "Stack of controls — only those the shell allows render."
+			},
+			{
+				"id": "saving",
+				"when": "isSaving === true",
+				"renders": "Controls disabled; save button shows loading."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Mount",
+				"effect": "Fetch `/wp-admin-shell/v1/user-prefs`; on success set state to result; on failure set state to `{}`."
+			},
+			{
+				"trigger": "Change density radio",
+				"effect": "POST `{ styles: { density } }` to user-prefs; success snackbar.",
+				"guards": [
+					"shell allows `density`"
+				]
+			},
+			{
+				"trigger": "Pick accent color",
+				"effect": "POST `{ styles: { color: { bg: { interactive: { brand: { strong: value } } } } } }`.",
+				"guards": [
+					"shell allows `color.bg.interactive.brand.strong` or `branding.accentColor`"
+				]
+			},
+			{
+				"trigger": "Change default-route input",
+				"effect": "POST `{ 'default-route': value }`.",
+				"guards": [
+					"shell allows `default-route`"
+				]
+			}
+		],
+		"a11y": {
+			"focus-management": "Native form focus order."
+		},
+		"constraints": [
+			{
+				"concern": "customizable-server-authoritative",
+				"note": "Server enforces `customizable` via the cascade resolver. Controls hidden here are a UX nicety; an attacker hand-crafting a POST cannot bypass the server-side default-deny."
+			},
+			{
+				"concern": "customizable-shape-validation",
+				"note": "`customizable` is either a boolean or a string-array allowlist. Other types (object, number) are treated as locked, with a dev-mode console warn. This matches the server-side default-deny posture."
+			},
+			{
+				"concern": "partial-patch-semantics",
+				"note": "POST body is a partial — server deep-merges onto existing prefs. Sending `{ styles: { density: 'compact' } }` doesn't clobber `styles.color.*`."
+			},
+			{
+				"concern": "no-literal-hex-fallback",
+				"note": "The color picker doesn't fall back to a literal hex when accent is unset — WPDS provider supplies `--wpds-color-bg-interactive-brand-strong`. Empty string = no override; picker reads the resolved CSS var directly."
+			},
+			{
+				"concern": "cache-flush-on-prefs-write",
+				"note": "WordPress hook `wp_admin_shell_user_prefs` user-meta updates triggers the cascade cache flush; next page-load resolves the new prefs."
+			},
+			{
+				"concern": "form-fallbacks",
+				"note": "Legacy `RadioControl` (density) + `Spinner` — WPDS 0.12 gaps."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Button, Stack, Text, InputControl",
+				"purpose": "Form layout + color hex input + default-route input + save buttons."
+			},
+			{
+				"import": "@wordpress/components#RadioControl, Spinner",
+				"purpose": "Density radio + loading — WPDS 0.12 gaps."
+			}
+		]
 	}
 }

--- a/src/apps/appearance/app.md
+++ b/src/apps/appearance/app.md
@@ -1,0 +1,41 @@
+# core:appearance
+
+Prose accompanying `app.json#documentation` for the appearance / user-prefs screen.
+
+## Overview
+
+AppearanceApp is a customizability-aware preferences screen. The active shell declares `customizable` — either `true`, `false`, or a string-array allowlist — on its `styles` block; this app reads that declaration and renders only the controls the shell permits. MVP controls cover density (compact / default / comfortable radio), accent color (single-token override), and default-route override (text input).
+
+The customizability declaration is **server-authoritative**: the cascade resolver enforces the same `customizable` allowlist on writes. Hiding controls client-side is a UX nicety, not a security boundary. A user who hand-crafts a POST to `/wp-admin-shell/v1/user-prefs` setting a non-customizable field gets a 403 / silent drop.
+
+## Architecture
+
+`prefs` state is `null` until the initial fetch completes; this lets the loading spinner render once on mount. Subsequent saves do a partial POST (only the changed sub-tree); the response is the full merged prefs blob, which the app stashes back into `prefs` state.
+
+The `isCustomizable(declaration, path)` helper handles the three legal shapes:
+
+- `true` → all paths allowed.
+- `false | null | undefined` → none allowed.
+- `string[]` → only listed paths allowed.
+- Anything else → locked + dev-mode console warn. Matches the server-side default-deny.
+
+The accent color picker doesn't fall back to a literal hex — empty string means "no authored override", and the WPDS provider supplies `--wpds-color-bg-interactive-brand-strong` from the cascade. A literal-hex fallback would lock the picker to a specific color rather than the resolved-but-unauthored value.
+
+## Rebuild guide
+
+Two patterns worth preserving:
+
+- **Client allowlist mirrors server allowlist.** Both should read the same `customizable` declaration. Don't show controls the server will reject.
+- **Partial-patch semantics for user prefs.** Send only the changed sub-tree; server deep-merges. Avoids accidental clobber of fields the UI doesn't currently surface.
+
+The patch shape is deep-dotted (`styles.color.bg.interactive.brand.strong`) because the underlying token paths are deep. A flatter rebuild can collapse this to single-level keys, but the customizable allowlist would need to match.
+
+A non-WPDS rebuild needs radio + color picker + text input + button — all standard.
+
+## Known limitations
+
+- **No theme preset selector.** Each control is single-axis. A future iteration may add presets (`'Light' / 'Dark' / 'High contrast'`) that compose multiple token overrides.
+- **No live preview.** Changes apply on the next render; there's no "preview before save" affordance.
+- **Color picker is naive.** Plain text input expecting a hex string. A real color picker (with picker chip + swatch palette) is deferred.
+- **No "Restore defaults" button.** Reverting a single override means setting the field back to empty manually.
+- **Custom typography / font controls are not exposed.** The cascade has tokens for `font.size.*` etc., but the appearance app doesn't surface them.

--- a/src/apps/command-palette/app.json
+++ b/src/apps/command-palette/app.json
@@ -19,5 +19,49 @@
 		"type": "object",
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Cmd+K command palette contributor. The palette UI itself is owned by `@wordpress/commands` — this app contributes a command set and renders nothing. Commands are derived from the shell's routes block (`config.routes`): each `core:route` whose pattern has no `{param}` placeholder or `/*` wildcard becomes a `Go to <pattern>` entry. Authors can override the label + icon by attaching `title` + `icon` to a route entry (not in the current schema; the runtime reads them if present so a future schema bump can land without migration).",
+		"data": {
+			"reads": [
+				{
+					"source": "config.routes",
+					"via": "core-data",
+					"purpose": "Route patterns to convert into palette commands."
+				}
+			],
+			"writes": [
+				{
+					"source": "core/commands",
+					"via": "core-data",
+					"operation": "custom",
+					"purpose": "Register the derived command set via `useCommandLoader({ name: 'core/admin-shell/apps', hook })`."
+				}
+			]
+		},
+		"url": {
+			"reads-slots": [],
+			"writes-slots": [],
+			"navigates": []
+		},
+		"states": [
+			{ "id": "renders-null", "when": "Always", "renders": "Nothing — this app is invisible. The `@wordpress/commands` portal renders the palette UI elsewhere in the DOM." }
+		],
+		"interactions": [
+			{ "trigger": "Mount", "effect": "Register the command-loader hook with `@wordpress/commands`." },
+			{ "trigger": "User opens palette (Mod+K or other binding)", "effect": "`@wordpress/commands` invokes the registered loader, gets the route-derived commands, and surfaces them. Selecting an entry calls its `callback({ close })` which writes `window.location.hash` + closes the palette." }
+		],
+		"a11y": {
+			"focus-management": "`@wordpress/commands` owns palette focus when open (focus trap inside the modal, return focus on close). This app only contributes commands; it does not render UI."
+		},
+		"constraints": [
+			{ "concern": "no-ui", "note": "Returns `null`. All visual surface area lives in the `@wordpress/commands` portal. Tests that look for shell-rendered DOM should expect nothing." },
+			{ "concern": "skip-parameterized-routes", "note": "Routes with `{param}` placeholders or `/*` wildcards are skipped — `Go to /posts/{id}` isn't a valid invocation because the user can't pick the captured value from a command list. Parameterized routes need a different surface (search-based, entity-based) that's out of scope here." },
+			{ "concern": "url-encode-name", "note": "Command names use `encodeURIComponent(pattern)` so distinct routes (`/foo-bar` vs `/foo/bar`) produce distinct names. Without encoding, both would collapse to `foo-bar` and `@wordpress/commands` would reject the duplicate." },
+			{ "concern": "modal-platform-service", "note": "Manifest declares `core:modal: true` + `core:dismiss-on: [Escape, backdrop-click]` + `core:triggerable: true`. The kernel's region renderer applies focus trap + ARIA modal + backdrop dismiss. The triggerable flag lets admin.json's `bindings` block map keystrokes to this app." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/commands#useCommandLoader, store", "purpose": "Command registration. The package owns the palette UI." }
+		]
+	}
 }

--- a/src/apps/command-palette/app.md
+++ b/src/apps/command-palette/app.md
@@ -1,0 +1,43 @@
+# core:command-palette
+
+Prose accompanying `app.json#documentation` for the command palette contributor.
+
+## Overview
+
+CommandPaletteApp is unusual: it renders no UI. The palette itself lives in `@wordpress/commands` (a Gutenberg package that ships a portal-rendered modal with search-as-you-type). This app's job is to **contribute commands** — register a loader with `@wordpress/commands` that turns the shell's routes block into a list of `Go to <pattern>` entries.
+
+The split keeps responsibilities clean: the palette UI is one thing (and Gutenberg already does it well); the command set is shell-specific (every app, route, action that wants to be commandable). Plugins can register their own commands the same way without touching this app.
+
+The `core:dialog` role + `core:modal` + `core:dismiss-on` platform services are declared **for the conceptual contract**, not because this app renders the modal. The kernel's region wrapper applies the modal treatment when the palette is mounted; the actual dismiss + focus-trap behavior is handled by `@wordpress/commands` internally. The manifest declarations let admin.json authors bind keystrokes to the app (`core:triggerable: true` makes that possible).
+
+## Architecture
+
+`useCommandLoader({ name, hook })` is the contribution API. `hook` returns `{ commands, isLoading }`. The hook is memoized over `routes` so the command set rebuilds only when routes change.
+
+Each route becomes one command:
+
+- Skip if `entry.app` is not a string (the route doesn't point at an app).
+- Skip if pattern has `{param}` or ends in `/*` (no usable invocation target).
+- Build `name = 'core/admin-shell/goto-' + encodeURIComponent(pattern)` — URL-encoding so `/foo-bar` vs `/foo/bar` don't collide.
+- Label: `entry.title` if set, otherwise `Go to {pattern}` (translatable).
+- Icon: `resolveIcon(entry.icon)` via the kernel icon registry.
+- Callback: `({ close }) => { window.location.hash = '#' + pattern; close(); }`.
+
+## Rebuild guide
+
+For a host that ships its own command palette (cmdk, kbar, ninja-keys):
+
+- Find the palette's contributor API. Most palettes accept a static array or a hook-style loader.
+- Iterate routes; produce one entry per non-parameterized pattern.
+- URL-encode pattern in the entry id so duplicates can't collide.
+- Wire keystroke binding to the palette through your host's keybinding system. The shell ships admin.json's `bindings` block + a kernel-level handler.
+
+A rebuild that wants to ship its own palette UI (rather than borrow from a package) should follow the same contributor split — keep this app's job small + composable so multiple sources (routes, apps, plugins) can all add entries.
+
+## Known limitations
+
+- **Parameterized routes excluded.** No "Edit post 42" entry because the palette can't pick `42`. A separate entity-search command source would solve this.
+- **Title + icon overrides aren't schema-validated.** The runtime reads them if present, but they're not declared in `admin-v2.json`'s routes block — authors discover them by reading code. A future v2.x schema bump should add them.
+- **Hash navigation only.** Commands hard-set `window.location.hash`. A SPA-router rebuild may want to dispatch through the router instead so the navigation respects route guards.
+- **No per-command capability gate.** All routes become commands; users see entries for screens they can't reach. The router catches the navigation attempt + may render an empty state, but the palette entry itself isn't filtered.
+- **No "recent" or "frequent" ordering.** Commands surface in route-block order. A frequency / recency model would need separate state.

--- a/src/apps/comments/app.json
+++ b/src/apps/comments/app.json
@@ -25,5 +25,155 @@
 		},
 		"multiInstance": false,
 		"icon": "comments"
+	},
+	"documentation": {
+		"purpose": "DataViews-driven comment moderation list. Lists author (name + email), comment content (rendered HTML), status, and date. Bulk + per-row actions: approve, unapprove, mark as spam, trash. Status changes round-trip via partial `saveEntityRecord` PATCH so optimistic edits behave; trash routes through `deleteEntityRecord`.",
+		"rebuilds": "comments",
+		"data": {
+			"reads": [
+				{
+					"source": "root/comment",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Comment rows.",
+					"fields": [
+						"id",
+						"author_name",
+						"author_email",
+						"content.rendered",
+						"status",
+						"date"
+					],
+					"query": {
+						"per_page": "view.perPage",
+						"page": "view.page",
+						"order": "view.sort.direction",
+						"orderby": "view.sort.field|date_gmt",
+						"context": "edit",
+						"status": "any|filter.status",
+						"search": "view.search"
+					}
+				}
+			],
+			"writes": [
+				{
+					"source": "root/comment",
+					"via": "core-data",
+					"operation": "partial-update",
+					"purpose": "Approve / unapprove / spam — PATCH `{ id, status }`.",
+					"invalidates": [
+						"root/comment"
+					]
+				},
+				{
+					"source": "root/comment",
+					"via": "core-data",
+					"operation": "trash",
+					"purpose": "Move comment to trash (no `force`).",
+					"invalidates": [
+						"root/comment"
+					]
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "loading",
+				"when": "isResolving && !records",
+				"renders": "DataViews loading indicator."
+			},
+			{
+				"id": "ready",
+				"when": "records !== null && records.length > 0",
+				"renders": "Table with action chips per row."
+			},
+			{
+				"id": "empty",
+				"when": "records?.length === 0",
+				"renders": "DataViews empty state for the current filter."
+			},
+			{
+				"id": "trash-confirm",
+				"when": "User triggered Trash action",
+				"renders": "Confirm modal with destructive primary."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click Approve action",
+				"effect": "Partial-update status to `approved`; success snackbar.",
+				"guards": [
+					"item.status !== 'approved'"
+				]
+			},
+			{
+				"trigger": "Click Unapprove action",
+				"effect": "Partial-update status to `hold`; success snackbar.",
+				"guards": [
+					"item.status === 'approved'"
+				]
+			},
+			{
+				"trigger": "Click Mark as spam action",
+				"effect": "Partial-update status to `spam`; success snackbar.",
+				"guards": [
+					"item.status !== 'spam'"
+				]
+			},
+			{
+				"trigger": "Click Trash action",
+				"effect": "Open confirm modal; on confirm `deleteEntityRecord` (trash, no `force`) per item; invalidate; success snackbar.",
+				"guards": [
+					"item.status !== 'trash'"
+				]
+			},
+			{
+				"trigger": "Change view (search / filter / sort / page)",
+				"effect": "Local `view` updates; queryArgs recomputes; records refetch."
+			}
+		],
+		"a11y": {
+			"focus-management": "DataViews owns focus inside the table + action modal."
+		},
+		"constraints": [
+			{
+				"concern": "dataviews-import-path",
+				"note": "Import from `@wordpress/dataviews/wp`."
+			},
+			{
+				"concern": "partial-saveentityrecord",
+				"note": "Status changes are sent as `saveEntityRecord('root', 'comment', { id, status })` — a partial payload that PATCHes only the status. Sending the full record would clobber any concurrent edit."
+			},
+			{
+				"concern": "dangerously-set-inner-html",
+				"note": "Comment content is rendered HTML — WordPress core sanitizes via `wp_filter_comment_content` (kses + comment-text filter chain) server-side before it reaches the REST response, so the value is trust-bounded. Plain text would lose the formatted view moderators rely on."
+			},
+			{
+				"concern": "orderby-date-gmt",
+				"note": "REST orderby alias for date is `date_gmt`, not `date`. Sorting by `date` column passes `date_gmt` to the API."
+			},
+			{
+				"concern": "invalidate-after-mutate",
+				"note": "Every action invalidates `getEntityRecords` on `root/comment` so the list reflects the new state."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/dataviews/wp#DataViews",
+				"purpose": "Table view + per-row actions."
+			},
+			{
+				"import": "@wordpress/ui#Button, Stack, Text",
+				"purpose": "Author cell, modal layout, cancel button."
+			},
+			{
+				"import": "@wordpress/components#Button (as DestructiveButton)",
+				"purpose": "Destructive primary in trash confirm modal — WPDS 0.12 has no `tone=\"critical\"`."
+			},
+			{
+				"import": "@wordpress/icons#trash",
+				"purpose": "Trash action icon."
+			}
+		]
 	}
 }

--- a/src/apps/comments/app.md
+++ b/src/apps/comments/app.md
@@ -1,0 +1,33 @@
+# core:comments
+
+Prose accompanying `app.json#documentation` for the moderation list.
+
+## Overview
+
+CommentsApp replaces `wp-admin/edit-comments.php` for the per-site moderation queue. It surfaces the four moderation actions that matter day-to-day — approve, unapprove, spam, trash — as DataViews row + bulk actions with per-action eligibility predicates so the action menu stays clean: an already-approved comment shows Unapprove (not Approve), an already-spam comment shows nothing destructive remaining, etc.
+
+The non-trash status changes use a **partial saveEntityRecord** pattern: instead of fetching, mutating, and saving the full comment record, the app dispatches `saveEntityRecord('root', 'comment', { id, status })`. WordPress's REST endpoint accepts the partial payload and PATCHes only the status field; this both reduces round-trip size and avoids clobbering concurrent edits.
+
+## Architecture
+
+The `setCommentsStatus` callback is shared across all three status-change actions. It awaits a `Promise.all` of partial saves, invalidates the records query, and fires a success snackbar with the action-specific message. On error, an error notice surfaces `err.message`.
+
+Trash is separate because it's `deleteEntityRecord` (not status change to `trash` — that's a different mechanism in the REST surface). The trash modal mirrors PostsApp's pattern.
+
+The comment content cell uses `dangerouslySetInnerHTML` rather than text-only rendering. This is **safe** because `record.content.rendered` is the output of WordPress core's `wp_filter_comment_content` (kses + the comment-text filter chain) — author-supplied raw HTML has been sanitized server-side before it reaches the REST response. Rendering as HTML preserves the formatted view comment moderators expect.
+
+## Rebuild guide
+
+Two patterns worth preserving:
+
+- **Partial PATCH for single-field updates.** Rebuilds on REST clients other than core-data should mirror this — issue a PATCH with just the changed field, not a full PUT.
+- **Per-action eligibility.** DataViews' `isEligible: (item) => ...` predicates filter the action menu per-row. Equivalent: render-time guards inside your action menu component. Worth keeping the action set declarative so the row menu only shows what's reachable from the current state.
+
+A non-WPDS rebuild needs a table with selection + bulk actions, a destructive confirm modal, a notice bus, and a rendered-HTML cell renderer.
+
+## Known limitations
+
+- No reply / quick-edit (in-place edit of comment text). Reply is the major missing feature — wp-admin offers an inline reply form; the v2 design defers this.
+- No author/IP/email row-level filtering.
+- The Trash action lacks an undo path. wp-admin's edit-comments has a "Undo" snackbar after trash; we issue a plain success snackbar.
+- Pagination caps perPage at 100 server-side; the app passes whatever DataViews sends.

--- a/src/apps/dashboard/app.json
+++ b/src/apps/dashboard/app.json
@@ -22,5 +22,144 @@
 		},
 		"multiInstance": false,
 		"icon": "wordpress"
+	},
+	"documentation": {
+		"purpose": "Landing screen for authenticated users. Greets the acting user by time-of-day + first name, surfaces three quick-action buttons (write a post, add a page, upload media), renders a stat row (published posts / pages / pending comments / users) and two list cards (recent drafts, comments awaiting moderation). Each count uses a per-status `?per_page=1` REST request reading `X-WP-Total` via `useEntityRecords.totalItems` — WordPress core has no `wp_count_posts` REST equivalent.",
+		"rebuilds": "dashboard-home",
+		"data": {
+			"reads": [
+				{
+					"source": "root/user/{userId}",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Greeting personalization (name / first_name)."
+				},
+				{
+					"source": "postType/post",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Published-post count (per_page: 1, status: publish, _fields: id) + draft list (per_page: 5, status: draft, orderby: modified)."
+				},
+				{
+					"source": "postType/page",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Published-page count."
+				},
+				{
+					"source": "root/comment",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Pending-comments count + first 5 pending for the moderation card (status: hold).",
+					"query": {
+						"status": "hold",
+						"per_page": 5,
+						"context": "edit"
+					}
+				},
+				{
+					"source": "root/user",
+					"via": "core-data",
+					"purpose": "Users count.",
+					"query": {
+						"per_page": 1,
+						"_fields": "id"
+					}
+				},
+				{
+					"source": "window.wpAdminShell.userId",
+					"via": "window-global",
+					"purpose": "Acting user id for personalization."
+				}
+			]
+		},
+		"url": {
+			"navigates": [
+				"#/posts/new",
+				"#/pages/new",
+				"#/media",
+				"#/comments",
+				"#/posts/{id}/edit"
+			]
+		},
+		"states": [
+			{
+				"id": "loading-stats",
+				"when": "any of the count queries is resolving",
+				"renders": "Per-stat Spinner inside the card."
+			},
+			{
+				"id": "ready",
+				"when": "All queries resolved",
+				"renders": "Greeting + quick actions + 4-stat row + 2 list cards."
+			},
+			{
+				"id": "empty-drafts",
+				"when": "drafts.records.length === 0",
+				"renders": "`No drafts yet. Start writing!` copy."
+			},
+			{
+				"id": "empty-comments",
+				"when": "comments.records.length === 0",
+				"renders": "`Inbox zero. Nothing pending.` copy."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click Write a post",
+				"effect": "`navigate('#/posts/new')`."
+			},
+			{
+				"trigger": "Click Add a page",
+				"effect": "`navigate('#/pages/new')`."
+			},
+			{
+				"trigger": "Click Upload media",
+				"effect": "`navigate('#/media')`."
+			},
+			{
+				"trigger": "Click a draft title",
+				"effect": "`navigate('#/posts/{id}/edit')`."
+			},
+			{
+				"trigger": "Click Moderate all",
+				"effect": "`navigate('#/comments')`."
+			}
+		],
+		"a11y": {
+			"focus-management": "Native heading + button order."
+		},
+		"constraints": [
+			{
+				"concern": "useentityrecord-null-userid",
+				"note": "`useEntityRecord('root','user', userId || 0)` is null-safe: passing `0` short-circuits the request without unmounting the hook. Keeping the hook present preserves React's hook-order invariant."
+			},
+			{
+				"concern": "totalitems-from-perpage-1",
+				"note": "WordPress core has no REST equivalent for `wp_count_posts` / `wp_count_comments`. Per-status `?per_page=1` requests + reading `X-WP-Total` (exposed by core-data as `totalItems`) is the documented work-around."
+			},
+			{
+				"concern": "title-shape",
+				"note": "Draft titles read `draft.title?.raw || draft.title?.rendered` with a `(no title)` fallback — REST returns title as `{ raw, rendered }` in edit context, and the latter is HTML-decoded so raw is preferred."
+			},
+			{
+				"concern": "no-welcome-panel",
+				"note": "WordPress's `Welcome` panel + `Site Health` widget + `Events and News` widget are NOT ported. The shell dashboard is intentionally smaller — see `docs/screens/dashboard-home.md` for the wp-admin equivalent."
+			},
+			{
+				"concern": "grid-fallback",
+				"note": "Uses `__experimentalGrid` — no WPDS 0.12 port."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Button, Card, Stack, Text",
+				"purpose": "Card layout, stat values, action buttons."
+			},
+			{
+				"import": "@wordpress/components#__experimentalGrid, Spinner",
+				"purpose": "4-column stat grid + 2-column card row + loading spinners — WPDS 0.12 gaps."
+			}
+		]
 	}
 }

--- a/src/apps/dashboard/app.md
+++ b/src/apps/dashboard/app.md
@@ -1,0 +1,38 @@
+# core:dashboard
+
+Prose accompanying `app.json#documentation` for the dashboard landing screen.
+
+## Overview
+
+DashboardApp is the post-login landing screen. Five reads compose the page: the acting user (for greeting personalization), published-post count, published-page count, pending-comment count + content, user count. The post + page + user counts all use the **per_page=1 + read X-WP-Total** trick because WordPress core has no REST equivalent for `wp_count_posts` / `wp_count_users` — the alternative would be loading the full list and counting in JS, which we'd rather not do for sites with thousands of posts.
+
+The recent-drafts + pending-comments list cards reuse the same hooks (`useEntityRecords` for `status: 'draft'` / `status: 'hold'`) with `per_page: 5` so we get both the total count and the first five records in one round trip.
+
+## Architecture
+
+`useEntityRecord('root','user', userId || 0)` is the user fetch. The `|| 0` is deliberate: `useEntityRecord` short-circuits when given a falsy id, so this lets the hook stay in render order even when `userId` is missing. Reading `record?.name` / `record?.first_name` falls back gracefully when the lookup fails (which is rare in practice — `wpAdminShell.userId` is always injected).
+
+Time-of-day greeting: `Date.getHours()` partitioned at 12 + 18 (morning / afternoon / evening). Memoized so it doesn't re-evaluate on every render.
+
+Stat cards: a small inline `StatCard` component renders `{ label, value, isLoading }`. The Spinner falls through to `value ?? '—'` when not loading and the count is missing.
+
+Draft + pending-comments cards: the list-or-empty logic is inlined as an IIFE (`{ ( () => {...} )() }`) because the empty-state copy differs per card. A reusable `<ListOrEmpty>` would be nice but doesn't pay back at two consumers.
+
+## Rebuild guide
+
+For a non-`core-data` rebuild:
+
+- Need a count-without-loading-all-rows pattern. With WordPress REST, that means `?per_page=1` + read `X-WP-Total` header. Other backends should expose a `count` endpoint directly.
+- Layout: 4-column stat grid + 2-column list-card row. Tailwind `grid-cols-4 / grid-cols-2 gap-4` works directly.
+- Greeting: time-of-day partitioning + the user's first name with a fallback to `name`.
+
+A non-WPDS rebuild needs Card, Grid (or CSS grid directly), Stack, Text + Button equivalents and a Spinner.
+
+## Known limitations
+
+- **No Welcome panel.** WordPress dashboard has a "Welcome to WordPress!" widget with quick-start links + theme/customize prompts; this app omits it.
+- **No Site Health widget.** The shell ships `core:site-health` as a separate app; the dashboard doesn't show a summary.
+- **No WordPress Events and News.** The `api.wordpress.org/events` external feed is omitted.
+- **No At a Glance widget compatibility.** WordPress's `dashboard_glance_items` filter lets plugins inject extra "X posts" rows; we don't honor it.
+- **Per-status count requests are wasteful** for sites with many post types — each status × post-type pair requires its own round trip. A future iteration could batch via a custom endpoint.
+- **Quick Draft is absent.** wp-admin has a Quick Draft widget that lets you write + save a draft inline; the shell expects users to click "Write a post" and land in the editor.

--- a/src/apps/editor/app.json
+++ b/src/apps/editor/app.json
@@ -32,5 +32,111 @@
 		},
 		"multiInstance": true,
 		"icon": "edit"
+	},
+	"documentation": {
+		"purpose": "Iframe-backed adapter for WordPress's full block editor. Routes `#/editor/{postType}/{postId}` to `wp-admin/post.php?post={id}&action=edit` and routes `#/editor/{postType}/new` through an auto-draft creation flow (POST `/wp/v2/{postType}s`) before redirecting to the editor URL. Injects CSS into the iframe document to hide wp-admin chrome so the embedded editor reads as a native shell view. The native `@wordpress/edit-post` mount is deferred to a v2.x cut; the iframe is the contracted MVP path.",
+		"rebuilds": "editor-block",
+		"data": {
+			"reads": [
+				{
+					"source": "window.wpAdminShell.adminUrl",
+					"via": "window-global",
+					"purpose": "Base URL for the iframe `src` attribute."
+				}
+			],
+			"writes": [
+				{
+					"source": "/wp/v2/posts | /wp/v2/pages",
+					"via": "api-fetch",
+					"operation": "create",
+					"purpose": "Create a draft when navigating to `#/editor/{postType}/new`. Seeds an empty paragraph block in `content` because REST rejects fully-empty posts."
+				}
+			]
+		},
+		"url": {
+			"reads-slots": [
+				"_self"
+			],
+			"navigates": [
+				"#/posts",
+				"#/pages",
+				"#/editor/{postType}/{postId}"
+			]
+		},
+		"states": [
+			{
+				"id": "creating-draft",
+				"when": "isNew && !postId",
+				"renders": "Centered spinner; auto-draft is in flight."
+			},
+			{
+				"id": "loading-iframe",
+				"when": "postId && iframeLoading",
+				"renders": "Centered spinner overlaid on the iframe while it loads."
+			},
+			{
+				"id": "ready",
+				"when": "postId && !iframeLoading",
+				"renders": "Toolbar (Back to list) + full-bleed iframe of `post.php?post={id}&action=edit`."
+			},
+			{
+				"id": "error",
+				"when": "error !== null",
+				"renders": "Toolbar + empty-state message showing the error."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Mount with `#/editor/{postType}/new`",
+				"effect": "POST a draft, update `postId`, replace URL via `history.replaceState` (not navigate — avoids re-render loop)."
+			},
+			{
+				"trigger": "Iframe `load` event",
+				"effect": "Set `iframeLoading=false`; inject CSS to hide adminmenu / adminbar / wpfooter / wpcontent margins. Cross-origin iframes silently skip the injection."
+			},
+			{
+				"trigger": "Click Back to list",
+				"effect": "`navigate('posts')` or `navigate('pages')` based on `postType`."
+			}
+		],
+		"a11y": {
+			"focus-management": "Iframe owns its own focus tree (WordPress block editor handles this). Toolbar Back button is focusable; the shell does not trap focus."
+		},
+		"constraints": [
+			{
+				"concern": "iframe-css-fragile",
+				"note": "Chrome-hiding selectors are tied to wp-admin's class names (`#adminmenuwrap`, `#wpadminbar`, etc.). Rev with each WordPress release; verify post.php layout after upgrades."
+			},
+			{
+				"concern": "empty-post-seed",
+				"note": "REST rejects fully-empty posts with `Content, title, and excerpt are empty`. Seed `<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->` into `content` so the auto-draft saves even before the user types."
+			},
+			{
+				"concern": "dirty-state-not-honored",
+				"note": "Manifest declares `core:dirty-state` + `core:block-navigation-on-dirty`, but the iframe-backed implementation has no way to read unsaved-state from the embedded editor. The platform service is reserved for the native mount."
+			},
+			{
+				"concern": "history-replacestate",
+				"note": "After auto-draft creation, the URL is updated via `window.history.replaceState` — using `navigate()` would trigger the router and unmount the app mid-flight."
+			},
+			{
+				"concern": "native-mount-deferred",
+				"note": "See `SiteEditorApp.js` blockers list (preferences-store collision, command double-registration, fullscreen CSS, hash-router collision, no BUNDLED_PACKAGES entry) — they apply equally to `@wordpress/edit-post`."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Button",
+				"purpose": "Toolbar Back button."
+			},
+			{
+				"import": "@wordpress/components#Spinner",
+				"purpose": "Loading indicator — WPDS 0.12 has no Spinner port."
+			},
+			{
+				"import": "@wordpress/icons#arrowLeft",
+				"purpose": "Back button icon."
+			}
+		]
 	}
 }

--- a/src/apps/editor/app.md
+++ b/src/apps/editor/app.md
@@ -1,0 +1,37 @@
+# core:editor
+
+Prose accompanying `app.json#documentation` for the iframe-backed block editor.
+
+## Overview
+
+EditorApp is the v2-beta concession: rather than embed `@wordpress/edit-post` natively (five known blockers — see `SiteEditorApp.js`'s top-of-file comment), the shell wraps wp-admin's `post.php?post={id}&action=edit` in a chrome-stripped iframe. The user-visible result is a full WordPress block editor inside the shell's content region; the implementation cost is one iframe + ~100 lines of CSS injection + an auto-draft creation flow for new posts.
+
+The iframe escape hatch is documented in CLAUDE.md as "a feature, not a compromise" because the alternative — half-implemented native mount with unresolved preferences-store collisions, command double-registration, hash-router conflicts — would be worse for users than a frame.
+
+## Architecture
+
+Two distinct mount paths share most of the code:
+
+- **`#/editor/{postType}/{postId}`** — set `postId` from the route param, render the iframe.
+- **`#/editor/{postType}/new`** — POST to `/wp/v2/{postType}s` with a seeded empty paragraph, capture the returned id, `history.replaceState` the URL to the existing-post pattern (`history.replaceState`, not `navigate()` — using the router would unmount the app mid-flight), then render the iframe.
+
+CSS injection runs on the iframe's `load` event. The selector list is fragile and tied to wp-admin's class names; expect to rev it after WordPress release upgrades. Cross-origin iframes silently skip the injection (we wrap the document access in try/catch).
+
+The platform manifest declares `core:dirty-state` + `core:block-navigation-on-dirty`, but the iframe-backed implementation has no read path into the embedded editor's unsaved-state. These declarations are forward-looking — they describe the contract the native mount will honor, not what the iframe does today.
+
+## Rebuild guide
+
+Two questions to answer before rebuilding:
+
+1. **Does the host framework have a native rich-text/block editor?** If yes, use it — iframes are the fall-back, not the goal. The hard cases are pasted-HTML round-trip, link autocomplete that respects the host's URL conventions, image upload integrated with the host's media library, and unsaved-state reporting to whatever NavigationGuard pattern the host uses.
+2. **What's the failure mode if the native editor isn't ready?** Match the iframe escape hatch — a clear toolbar, a strip-the-chrome iframe of the legacy editor, and the auto-draft creation flow for new posts. The user gets a working editor today; the native mount lands in a subsequent release.
+
+The auto-draft pattern (POST a draft with seeded empty paragraph, capture id, replace URL) translates directly. The `replaceState` instead of `navigate()` choice matters — using the router would re-evaluate the route and unmount the editor on first render. Any framework's router has the equivalent distinction.
+
+## Known limitations
+
+- **No native dirty-state read.** Iframe can't talk back to the shell. Browser close warnings still fire because the iframed editor itself listens for `beforeunload`.
+- **Chrome-hiding is fragile.** Selector list tied to wp-admin class names. Each WordPress release risks regressing the layout.
+- **Same-origin only.** Cross-origin iframes can't have CSS injected; the shell silently degrades to "iframe with full wp-admin chrome visible."
+- **No deep-link to a block.** Block-level deep linking requires the native mount.
+- **History-replace edge case.** If the user immediately hits Back after creating a new post, browser history shows the `/new` URL — `replaceState` doesn't add a new entry. We accept this for the auto-draft flow because the alternative is double-stacking history entries on every new post.

--- a/src/apps/iframe-fallback/app.json
+++ b/src/apps/iframe-fallback/app.json
@@ -27,5 +27,67 @@
 		},
 		"multiInstance": true,
 		"icon": "external"
+	},
+	"documentation": {
+		"purpose": "Renders any wp-admin URL inside an iframe with the default wp-admin chrome hidden via injected CSS. Absolute URLs pass through; relative URLs resolve under `window.wpAdminShell.adminUrl`. The chrome-hide CSS targets adminmenu / adminbar / footer / wpcontent margin + edit-site sidebar + site-hub + canvas container — covering both classic wp-admin pages and edit-site iframes. The shell's escape hatch: any wp-admin screen without a native v2 port can be surfaced through this app without writing custom React.",
+		"data": {
+			"reads": [
+				{
+					"source": "window.wpAdminShell.adminUrl",
+					"via": "window-global",
+					"purpose": "Base URL for relative `config.url` paths."
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "empty",
+				"when": "!config.url",
+				"renders": "Nothing (return null)."
+			},
+			{
+				"id": "loading",
+				"when": "isLoading === true",
+				"renders": "Centered Spinner overlaid on the iframe element."
+			},
+			{
+				"id": "ready",
+				"when": "isLoading === false",
+				"renders": "Full-bleed iframe with chrome hidden (best-effort — cross-origin iframes silently skip the injection)."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Iframe `load` event",
+				"effect": "Set `isLoading=false`; attempt to inject chrome-hiding CSS into `event.target.contentDocument`. Cross-origin iframes throw and we silently swallow."
+			}
+		],
+		"a11y": {
+			"focus-management": "Iframe owns its own focus tree; the shell does not trap."
+		},
+		"constraints": [
+			{
+				"concern": "css-selectors-fragile",
+				"note": "Chrome-hide selectors target wp-admin's class names (`#adminmenuwrap`, `#wpadminbar`, `#wpcontent`, `.edit-site-layout__sidebar*`, etc.). Rev with each WordPress release. Style Book canvas in edit-site has historically been the most fragile."
+			},
+			{
+				"concern": "cross-origin-silent-skip",
+				"note": "Cross-origin iframes can't have CSS injected (DOM access throws). We swallow the exception silently — the iframe still loads, but with wp-admin chrome visible. Production sites that embed cross-origin URLs accept this trade-off."
+			},
+			{
+				"concern": "config-additional-properties",
+				"note": "Schema allows additional properties on `config` because adapters (SiteEditorApp, custom apps that delegate to IframeApp) may carry extra fields. The app itself only reads `url`."
+			},
+			{
+				"concern": "spinner-fallback",
+				"note": "Legacy `Spinner` — WPDS 0.12 has no port."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/components#Spinner",
+				"purpose": "Loading indicator."
+			}
+		]
 	}
 }

--- a/src/apps/iframe-fallback/app.md
+++ b/src/apps/iframe-fallback/app.md
@@ -1,0 +1,34 @@
+# core:iframe-fallback
+
+Prose accompanying `app.json#documentation` for the generic iframe wrapper.
+
+## Overview
+
+IframeApp is the escape hatch. Any wp-admin URL — `options-permalink.php`, `import.php`, classic post.php editor, etc. — can be mounted in the shell by passing `config.url` to this app. The wp-admin chrome (admin menu, admin bar, footer, content margins) is hidden by CSS injected into the iframe's document on the `load` event. Cross-origin iframes silently skip the injection; same-origin (the common case for wp-admin pages on the same site) render as if the embedded screen were a native shell view.
+
+This pattern is documented in CLAUDE.md as "a feature, not a compromise." The alternative — reimplementing every wp-admin screen in React + REST — would be a multi-year project. The iframe gives users the right outcome today; native ports land app-by-app as REST coverage expands.
+
+## Architecture
+
+`src` resolution: if `rawUrl` matches `https?://`, pass through; otherwise prepend `adminUrl` (from `window.wpAdminShell.adminUrl`, default `/wp-admin/`).
+
+`onIframeLoad` is the chrome-hide hook. It runs on every iframe load (including in-iframe navigation, which is the case when the user clicks a link inside the embedded screen). Wraps document access in try/catch — cross-origin iframes throw on `contentDocument` access. Style injection appends a `<style>` to the iframe's `<head>`; idempotent in practice because each load creates a fresh document.
+
+`isLoading` is a `useState` flag flipped to `false` on first `load`. The spinner overlays the iframe rather than replacing it — once the iframe has rendered once, subsequent loads (in-iframe navigation) don't flash the spinner.
+
+## Rebuild guide
+
+The pattern translates directly to any host framework that supports iframes (basically all of them). Two implementation choices to make:
+
+- **Chrome injection.** Same-origin iframes can be styled by appending a `<style>` to their head. Selectors must match the embedded page's class names — fragile but worth doing.
+- **`src` resolution.** Relative URLs should resolve to whatever your host's admin / dashboard URL is. Externalize the base via a config global so the iframe works in different deployment contexts.
+
+A non-WPDS rebuild needs only a Spinner equivalent — everything else is plain HTML.
+
+## Known limitations
+
+- **CSS selectors are fragile.** Tied to wp-admin's class names; revs with each WordPress release.
+- **Cross-origin silent degradation.** Embedded URLs on a different origin can't have chrome hidden. Acceptable for most uses (wp-admin is same-origin) but a third-party-embed use case would break visually.
+- **Sandbox attributes not configured.** The iframe has no `sandbox` attribute, so it has full same-origin access. Restricting via sandbox would also break the chrome-injection path; not worth it for the wp-admin use case.
+- **No iframe-level dirty-state propagation.** The embedded screen may have unsaved-state semantics (e.g. `options-permalink.php` writing rewrite rules); the shell can't observe them. The iframed screen's own `beforeunload` still fires on browser navigation, just not on intra-shell navigation.
+- **Title attribute is set to `app.title`** for screen-reader discoverability, but it's static — embedded page titles don't propagate up.

--- a/src/apps/media/app.json
+++ b/src/apps/media/app.json
@@ -22,5 +22,174 @@
 		},
 		"multiInstance": true,
 		"icon": "media"
+	},
+	"documentation": {
+		"purpose": "Media library: paginated grid of attachments + upload + detail modal. Filter by media type (all / images / video / audio / documents). Images render their thumbnail; non-image attachments render a labeled file-type tile. Clicking an item opens a detail modal where authors can edit title / alt text (images only) / caption / description, copy URL, or delete (permanent — media has no trash).",
+		"rebuilds": "media",
+		"data": {
+			"reads": [
+				{
+					"source": "root/media",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Attachment grid.",
+					"fields": [
+						"id",
+						"title.raw",
+						"alt_text",
+						"caption.raw",
+						"description.raw",
+						"source_url",
+						"media_type",
+						"mime_type",
+						"media_details.sizes"
+					],
+					"query": {
+						"per_page": 40,
+						"page": "state.page",
+						"context": "edit",
+						"media_type": "state.mediaType"
+					}
+				}
+			],
+			"writes": [
+				{
+					"source": "/wp/v2/media",
+					"via": "api-fetch",
+					"operation": "upload",
+					"purpose": "Multipart upload: `FormData` with `file` field, POST to `/wp/v2/media`. One request per file.",
+					"invalidates": [
+						"root/media"
+					]
+				},
+				{
+					"source": "root/media",
+					"via": "core-data",
+					"operation": "update",
+					"purpose": "Edit attachment metadata (title / alt_text / caption / description) via `saveEntityRecord` partial.",
+					"invalidates": [
+						"root/media"
+					]
+				},
+				{
+					"source": "root/media",
+					"via": "core-data",
+					"operation": "delete",
+					"purpose": "Permanently delete attachment (`force: true` — media has no trash).",
+					"invalidates": [
+						"root/media"
+					]
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "loading-initial",
+				"when": "isResolving && !records?.length",
+				"renders": "Centered Spinner covering the panel."
+			},
+			{
+				"id": "empty",
+				"when": "!isResolving && !records?.length",
+				"renders": "Empty-state copy + Upload your first file button."
+			},
+			{
+				"id": "ready",
+				"when": "records?.length > 0",
+				"renders": "Grid of thumbnail tiles + pagination footer (when totalPages > 1)."
+			},
+			{
+				"id": "uploading",
+				"when": "isUploading === true",
+				"renders": "Upload button shows loading state + disabled; new items appear after invalidation."
+			},
+			{
+				"id": "detail-open",
+				"when": "selectedItem !== null",
+				"renders": "Large modal with preview on left + form fields on right + action row (copy URL, delete, cancel, save)."
+			},
+			{
+				"id": "saving-detail",
+				"when": "isSaving === true (inside modal)",
+				"renders": "Save button shows loading state."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Change media-type select",
+				"effect": "Update `mediaType` state + reset `page` to 1 + queryArgs recompute."
+			},
+			{
+				"trigger": "Click Upload",
+				"effect": "Open hidden `<input type=\"file\" multiple>`. On file pick, iterate + POST each via `apiFetch` with FormData; invalidate after all complete."
+			},
+			{
+				"trigger": "Click an item tile",
+				"effect": "Set `selectedItem` + open detail modal."
+			},
+			{
+				"trigger": "Edit fields in modal",
+				"effect": "Local component state mirrors entity fields; nothing persisted until Save."
+			},
+			{
+				"trigger": "Click Save in modal",
+				"effect": "`saveEntityRecord('root', 'media', { id, title, alt_text, caption, description })`; invalidate + close modal."
+			},
+			{
+				"trigger": "Click Copy URL",
+				"effect": "`navigator.clipboard.writeText(item.source_url)`; success snackbar (or error notice on clipboard denial)."
+			},
+			{
+				"trigger": "Click Delete in modal",
+				"effect": "`deleteEntityRecord(..., { force: true })`; invalidate + close modal."
+			},
+			{
+				"trigger": "Click pagination Previous/Next",
+				"effect": "`setPage(page ± 1)`; queryArgs recompute; records refetch."
+			}
+		],
+		"a11y": {
+			"focus-management": "Grid tiles are native `<button>` elements — keyboard accessible by default. Modal traps focus while open. Modal `key={item.id}` resets per-item state so reopening a different item starts clean."
+		},
+		"constraints": [
+			{
+				"concern": "force-delete",
+				"note": "Media has no trash. `deleteEntityRecord` requires `{ force: true }` or the request 400s."
+			},
+			{
+				"concern": "multipart-via-api-fetch",
+				"note": "Upload uses `apiFetch` with `FormData` body. `core-data`'s `saveEntityRecord` doesn't handle multipart well; the raw api-fetch path is more reliable."
+			},
+			{
+				"concern": "invalidate-after-mutate",
+				"note": "Every mutation (upload, save, delete) must `invalidateResolution('getEntityRecords', ['root', 'media', queryArgs])`. The mutation hooks do not bust the parent query."
+			},
+			{
+				"concern": "shadow-state-per-item",
+				"note": "Modal's local `useState` mirrors the entity fields. `key={item.id}` on the modal forces remount + state reset when the user opens a different item. Without the key, switching items mid-edit would carry over the previous form values."
+			},
+			{
+				"concern": "modal-fallback",
+				"note": "Legacy `Modal` + `TextareaControl` + `SelectControl` — WPDS 0.12 gaps."
+			},
+			{
+				"concern": "destructive-button-fallback",
+				"note": "Legacy `Button as DestructiveButton` with `isDestructive` — WPDS 0.12 has no `tone=\"critical\"`."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Button, InputControl, Stack, Text",
+				"purpose": "Toolbar + grid pagination + modal layout + form inputs."
+			},
+			{
+				"import": "@wordpress/components#Button (as DestructiveButton), Spinner, SelectControl, Modal, TextareaControl",
+				"purpose": "Destructive delete + loading + filter select + detail modal + caption/description textareas — WPDS 0.12 gaps."
+			},
+			{
+				"import": "@wordpress/icons#upload, trash, copy",
+				"purpose": "Action icons."
+			}
+		]
 	}
 }

--- a/src/apps/media/app.md
+++ b/src/apps/media/app.md
@@ -1,0 +1,42 @@
+# core:media
+
+Prose accompanying `app.json#documentation` for the media library.
+
+## Overview
+
+MediaApp is the closest the shell gets to WordPress's classic Media Library. It's not built on DataViews because the grid is intentionally simpler — just tile thumbnails with a click-to-detail interaction, plus an upload button and a media-type filter. The detail modal handles per-attachment metadata editing (title, alt text, caption, description) and the destructive operations (copy URL, delete).
+
+Two notable patterns:
+
+- **Multipart upload via raw `apiFetch`.** `core-data`'s `saveEntityRecord` doesn't handle multipart well. Building a FormData manually + POSTing through `apiFetch` is the reliable path. Each file is its own request (no batch upload endpoint); files iterate sequentially in a `for...of` loop and we await each one.
+- **`key={item.id}` on the modal.** The detail modal owns local form state mirroring the entity's title/alt/caption/description. Without a key prop, switching from one item to another while the modal is open would carry over the previous values — wrong. With `key={item.id}` the modal remounts on each item, resetting its local state to that item's values.
+
+## Architecture
+
+`queryArgs` is `useMemo`-derived from `mediaType + page`. Per-page is fixed at 40 (a reasonable visual density for the 3-or-4 column grid). Pagination is local (Prev/Next + page counter), not URL-driven — refreshing returns to page 1.
+
+The grid is native `<button>` per tile because `<img>` alone isn't keyboard-actionable. Each tile shows either:
+
+- The thumbnail size's `source_url` for `media_type === 'image'`, with `alt={item.alt_text}`.
+- A labeled file-type tile (e.g. `PDF`, `MP4`) for non-image attachments — derived from `mime_type.split('/').pop().toUpperCase()`.
+
+The detail modal renders preview-left + form-right. Alt-text input only surfaces for images. The action row at the bottom splits left (copy URL, delete) from right (cancel, save).
+
+## Rebuild guide
+
+Two patterns worth preserving:
+
+- **Multipart upload pattern.** Raw `fetch` (or your host's `apiFetch` equivalent) + `FormData`. Don't try to shoehorn through the entity-save abstraction.
+- **Per-item modal key.** Whenever a modal mutates one-of-many records, pass `key={item.id}` so per-item state resets between openings. Saves a class of bugs.
+
+A non-WPDS rebuild needs: grid layout (CSS `grid-template-columns: repeat(auto-fill, minmax(160px, 1fr))` works directly), modal with size variant, text + textarea inputs, select for filtering, file input + click-trigger pattern, native `<button>` tile semantics, and clipboard API access.
+
+## Known limitations
+
+- **No drag-and-drop upload.** Click-to-pick only.
+- **No bulk select.** Each delete is one-by-one through the detail modal.
+- **No edit-in-place image editing** (crop, rotate, scale). wp-admin has this; the shell doesn't.
+- **Pagination not URL-driven.** Refreshing returns to page 1; deep-linking to a specific page isn't supported.
+- **No search.** Filter is media-type-only. wp-admin's media library has a search box + date filter; the shell omits both.
+- **Source URL is single-line.** Long URLs overflow visually; no clamp or scroll.
+- **Copy URL relies on `navigator.clipboard`.** Insecure-origin contexts (HTTP-only dev sites) deny clipboard access; the error notice is the fallback.

--- a/src/apps/navigation/app.json
+++ b/src/apps/navigation/app.json
@@ -27,5 +27,57 @@
 		},
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Sidebar navigation app. Renders `config.items[]` — a tree of nav entries declared inline in admin.json. Item shapes: `{ label, icon, href, capability?, external? }` for links, `{ separator: true }` for dividers, `{ group, items }` for inline labeled groups, `{ screen, label, icon, description, items }` for drill-down sub-screens. Active state derives from the URL primary path (compared with `aria-current=\"true\"`). Drill-down sub-screen state lives in the URL slot `?screen=<id>` so it deep-links + survives refresh. Recursively prunes items the user can't reach (capability check) and orphan separators.",
+		"data": {
+			"reads": [
+				{
+					"source": "root/site",
+					"via": "core-data",
+					"purpose": "Decode site title for the root drill-down screen heading.",
+					"fields": [ "title" ]
+				},
+				{
+					"source": "userCan",
+					"via": "core-data",
+					"purpose": "Per-item capability check via the kernel's `userCan(cap)` helper. Items declaring `capability` get pruned recursively when the user lacks the cap."
+				}
+			]
+		},
+		"url": {
+			"reads-slots": [ "_self", "screen" ],
+			"writes-slots": [ "screen" ]
+		},
+		"states": [
+			{ "id": "collapsed-rail", "when": "config.collapsed === true", "renders": "Vertical column of IconButton entries; separators render as <hr>; external links render as native <a target=\"_blank\">." },
+			{ "id": "expanded-root", "when": "!collapsed && no `?screen=` slot", "renders": "Sidebar drill-down `screen` showing the root item list. Title falls back to admin.json `title` → `record.title` → window global → `Admin`." },
+			{ "id": "expanded-screen", "when": "?screen=<id> matches a screen item", "renders": "Drill-down sub-screen with back button + screen.label heading + screen.description + items list." },
+			{ "id": "expanded-screen-not-found", "when": "?screen=<id> does NOT match", "renders": "Falls through to root screen (no 404)." }
+		],
+		"interactions": [
+			{ "trigger": "Click a screen item", "effect": "`navigateScreen(item.screen)` writes `?screen=<id>` to the URL on top of the current primary path; SidebarNavigationProvider plays a slide animation." },
+			{ "trigger": "Click back button on sub-screen", "effect": "`navigateScreen(null)` clears the slot; slide animation reverses." },
+			{ "trigger": "Click a link item", "effect": "Plain anchor navigation via `<a href>` — the kernel router intercepts in-shell hrefs (starting with `#`)." },
+			{ "trigger": "Middle-click / Cmd-click an item", "effect": "Native browser behavior — opens in new tab. Items render as `<a>` (via `render` prop) so this works." }
+		],
+		"a11y": {
+			"focus-management": "Drill-down's `SidebarContent` restores focus after back navigation to the screen item that opened it.",
+			"screen-reader": "Active item carries `aria-current=\"true\"`. Items render as `<a>` (not `<button>`) when `href` is set so screen readers announce links, not buttons. The region wrapper already provides the `navigation` landmark — the app does NOT add its own `<nav>`."
+		},
+		"constraints": [
+			{ "concern": "url-slot-state", "note": "Sub-screen state is `?screen=<id>` in the URL, not `useState`. Deep-links + refresh survive. Multiple sidebars in one shell would collide on the slot — namespace later (`?nav-{regionId}-screen=…`) if needed." },
+			{ "concern": "aria-current-sole-authority", "note": "Active state lives on `aria-current=\"true\"` only — no `.is-active` class. CSS targets the attribute; the redundant class would cause drift." },
+			{ "concern": "edit-site-class-naming", "note": "Sidebar internals mirror `@wordpress/edit-site/src/components/sidebar*` BEM naming — `wp-admin-shell-sidebar-navigation-{screen,item}`. Keep one-for-one with edit-site so its source is the structural reference." },
+			{ "concern": "iconbutton-href-render", "note": "WPDS IconButton wraps Base UI Button which always renders a native `<button>` and silently drops `href`. We use `render={<a href={...}/>}` to swap the element." },
+			{ "concern": "active-class-fallback-not-set", "note": "SidebarNavigationItem only sets `aria-current`; legacy `.is-active` is intentionally absent." },
+			{ "concern": "item-prune-recursive", "note": "`pruneNavItems` recursively walks the tree. A screen/group whose children all prune renders nothing (the screen itself drops). Orphan separators at top/bottom are stripped." },
+			{ "concern": "experimental-itemgroup", "note": "Uses legacy `__experimentalItemGroup` from `@wordpress/components` — WPDS 0.12 has no port." },
+			{ "concern": "no-app-landmark", "note": "Region wrapper renders `<div role=\"navigation\">`; the app must NOT nest its own `<nav>` (would double the landmark)." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/ui#IconButton, Stack", "purpose": "Collapsed-rail buttons + layout." },
+			{ "import": "@wordpress/components#Icon, __experimentalItemGroup", "purpose": "Item icons + nav list — WPDS 0.12 gaps." }
+		]
+	}
 }

--- a/src/apps/navigation/app.md
+++ b/src/apps/navigation/app.md
@@ -1,0 +1,43 @@
+# core:navigation
+
+Prose accompanying `app.json#documentation` for the sidebar nav app.
+
+## Overview
+
+NavigationApp is the most visually-substantial piece of shell chrome. It reads its tree from `config.items[]` (a v2 admin.json field — there's no shared application catalog anymore; each item self-describes inline) and renders one of two layouts based on `config.collapsed`:
+
+- **Expanded** — a drill-down `SidebarContent` mirroring `@wordpress/edit-site/src/components/sidebar*` structure. Root list renders at first paint; clicking a screen item slides the panel to that sub-screen via CSS keyframes.
+- **Collapsed** — a vertical rail of `IconButton`s. Separators render as `<hr>`; group + screen items are flattened (children render inline, no drill-down).
+
+The active item derives from the URL primary path (the `aria-current="true"` attribute is the sole authority — no `.is-active` className) and is recomputed on every route change.
+
+## Architecture
+
+**URL-as-state.** Sub-screen state is `?screen=<id>` in the URL, not `useState`. This is the corollary of the spec §6 / §18 URL-as-state principle: deep-links work, refreshes survive, browser back works. The `navigateScreen(id|null)` helper writes the slot on top of the current primary path, preserving any other params. Multiple sidebars in one shell would collide; namespace later (`?nav-{regionId}-screen=…`) if that lands.
+
+**Capability prune.** `pruneNavItems` walks the tree recursively. An item with a `capability` field that fails `userCan()` is dropped. A screen or group whose pruned children are empty is itself dropped. Orphan separators at the top/bottom of the result are stripped (mid-list separators stay; they may be intentional).
+
+**Anchor rendering.** Nav items render as `<a>` via the `render` prop on IconButton — Base UI's Button drops `href` silently otherwise. Middle-click new-tab, right-click copy-link, and Cmd-click all work natively. The `target` prop keeps native HTML meaning.
+
+**Active-state contract.** `aria-current="true"` on the matching item. CSS uses `[aria-current="true"]` as the only authority. SidebarNavigationItem does NOT also emit a `.is-active` className — the redundant class would drift when the two get out of sync.
+
+**Edit-site mirroring.** Sidebar internals (BEM class names, drilldown indicator, focus restoration) mirror `@wordpress/edit-site` one-for-one — the package is the structural reference. When porting more pieces, keep the names matching.
+
+## Rebuild guide
+
+A non-WPDS rebuild needs to preserve four invariants:
+
+1. **URL-as-state for drill-down.** Use a query param (`?screen=`, `?subnav=`, etc.) not a useState. Deep-links matter.
+2. **Capability prune recursively.** Drop unreachable items + empty containers. Don't render disabled-but-visible items — they confuse the user about what's available.
+3. **Render items as `<a>` when href is set.** Native anchor behavior (middle-click, copy-link) is non-negotiable.
+4. **Single source for active state.** Pick `aria-current` OR a className — not both.
+
+Beyond those, the design surface is straightforward: a column list with optional drill-down. Tailwind + React Router + a recursive renderer would do the job in ~150 lines.
+
+## Known limitations
+
+- **No multi-sidebar URL slot.** `?screen=` collides if a shell mounts two NavigationApp instances. Namespace later.
+- **No nested drill-down.** Drill-down screens cannot themselves contain screen items. A screen's children are flat (with optional groups + separators + external links).
+- **No persistent expanded-group state.** Groups (label + children) always render expanded. There's no collapse toggle.
+- **Active state is exact-match only.** No prefix-matching for sub-routes (`/posts/123/edit` does not highlight the `/posts` nav item). A future iteration could add `activeWhen: '/posts*'` or similar.
+- **No tooltip on collapsed rail.** IconButton accepts `tooltip` but the rail items only set `aria-label`; the visual hint relies on the icon being recognizable.

--- a/src/apps/notices-banner/app.json
+++ b/src/apps/notices-banner/app.json
@@ -13,5 +13,45 @@
 		"type": "object",
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Renders persistent banner notices (info / warning / success / error) at the top of whatever region pins it. Source: `@wordpress/notices` store, filtered to `type === 'default'`. Any app calling `wp.data.dispatch('core/notices').createNotice(...)` lands here. Dismissible notices show a close icon that fires `removeNotice(id)`.",
+		"data": {
+			"reads": [
+				{
+					"source": "core/notices",
+					"via": "core-data",
+					"purpose": "All current notices via `getNotices()` selector.",
+					"fields": [ "id", "type", "status", "content", "isDismissible" ]
+				}
+			],
+			"writes": [
+				{
+					"source": "core/notices",
+					"via": "core-data",
+					"operation": "delete",
+					"purpose": "Remove a notice on close-icon click — `removeNotice(id)`."
+				}
+			]
+		},
+		"states": [
+			{ "id": "empty", "when": "No default-context notices", "renders": "Nothing (return null)." },
+			{ "id": "ready", "when": "At least one default notice", "renders": "Stack of `Notice.Root` banners (one per notice)." }
+		],
+		"interactions": [
+			{ "trigger": "App calls `createNotice('success'|'error'|'warning'|'info', message, { type: 'default', isDismissible })`", "effect": "Banner appears." },
+			{ "trigger": "Click close icon", "effect": "`removeNotice(notice.id)` — banner disappears.", "guards": [ "notice.isDismissible === true" ] }
+		],
+		"a11y": {
+			"screen-reader": "`Notice.Root` from `@wordpress/ui` sets ARIA attributes appropriate to the intent (`role=\"alert\"` for error, `role=\"status\"` for info)."
+		},
+		"constraints": [
+			{ "concern": "context-filter", "note": "Only `type: 'default'` notices land here. `type: 'snackbar'` notices go to `core:notices-snackbar` (separate app, different region)." },
+			{ "concern": "intent-mapping", "note": "WordPress's notice `status` field maps to WPDS Notice `intent`: `error` → `error`, `warning` → `warning`, `success` → `success`, `info` → `info`. Unknown statuses fall back to `info`." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/ui#Notice", "purpose": "Notice.Root + Notice.Description + Notice.Actions + Notice.CloseIcon — banner primitives." },
+			{ "import": "@wordpress/notices", "purpose": "Read notices store + dispatch removeNotice." }
+		]
+	}
 }

--- a/src/apps/notices-banner/app.md
+++ b/src/apps/notices-banner/app.md
@@ -1,0 +1,27 @@
+# core:notices-banner
+
+Prose accompanying `app.json#documentation` for the persistent banner notice host.
+
+## Overview
+
+NoticesBannerApp consumes `@wordpress/notices` filtered to `type: 'default'` and renders each as a `Notice.Root`. The notice bus is the shell's primary cross-app messaging channel — apps fire `createNotice('error', message)` from anywhere; the banner host (mounted once per shell) surfaces them in the configured region.
+
+No data ownership: the app is a renderer. State lives in `@wordpress/notices`; updates flow through `useSelect` + `useDispatch`.
+
+## Rebuild guide
+
+The notice-bus pattern is reusable across frameworks — Redux + a slice, Zustand store, Pinia, etc. The contract is:
+
+- A central store with `notices: []` shape, each `{ id, type ('default'|'snackbar'), status ('info'|'warning'|'success'|'error'), content, isDismissible }`.
+- A `createNotice(status, content, options)` dispatch.
+- A `removeNotice(id)` dispatch for dismissals.
+- Filtered rendering: banner host listens for `type: 'default'`; snackbar host listens for `type: 'snackbar'`.
+
+A non-WPDS rebuild needs a Notice / Alert primitive with intent variants + a close affordance. Material has `Alert`, Tailwind needs hand-rolled — both are standard fare.
+
+## Known limitations
+
+- **No notice grouping.** Five repeated errors render as five banners. wp-admin's notices collapse duplicates; the shell doesn't.
+- **No order control.** Notices render in arrival order. No priority / pinned-at-top semantics.
+- **No auto-dismiss for non-snackbar notices.** Banner notices are sticky until the user dismisses (or another notice with the same id arrives).
+- **`Notice.Description` accepts strings only by convention.** Rich content (links inside notices) requires either authoring HTML or composing through `Notice.Actions`.

--- a/src/apps/notices-snackbar/app.json
+++ b/src/apps/notices-snackbar/app.json
@@ -13,5 +13,45 @@
 		"type": "object",
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Renders transient snackbar notices (auto-dismiss after a few seconds; user can click-dismiss earlier). Source: `@wordpress/notices` store filtered to `type === 'snackbar'`. Uses legacy `SnackbarList` from `@wordpress/components` because WPDS 0.12 ships no snackbar primitive.",
+		"data": {
+			"reads": [
+				{
+					"source": "core/notices",
+					"via": "core-data",
+					"purpose": "Notices via `getNotices()`; filter to `type: 'snackbar'`."
+				}
+			],
+			"writes": [
+				{
+					"source": "core/notices",
+					"via": "core-data",
+					"operation": "delete",
+					"purpose": "Remove a notice on auto-dismiss or click — `removeNotice(id)` (called by `SnackbarList`)."
+				}
+			]
+		},
+		"states": [
+			{ "id": "empty", "when": "No snackbar notices", "renders": "Empty SnackbarList container (no visible output)." },
+			{ "id": "ready", "when": "At least one snackbar notice", "renders": "Stacked snackbar pills positioned by SnackbarList; each auto-dismisses on the package's default timer." }
+		],
+		"interactions": [
+			{ "trigger": "App calls `createNotice('success', message, { type: 'snackbar' })`", "effect": "Snackbar appears." },
+			{ "trigger": "Auto-dismiss timer fires", "effect": "SnackbarList calls `onRemove(id)` → `removeNotice(id)`." },
+			{ "trigger": "User clicks snackbar", "effect": "Same — `removeNotice(id)`." }
+		],
+		"a11y": {
+			"screen-reader": "SnackbarList sets `role=\"region\"` + `aria-label=\"Notifications\"` on its container; individual snackbars are `aria-live=\"polite\"`."
+		},
+		"constraints": [
+			{ "concern": "no-wpds-snackbar", "note": "WPDS 0.12 has no SnackbarList port. Legacy `SnackbarList` is kept here; rebuilds on other DS need to provide an equivalent or fall back to banner-style transient notices." },
+			{ "concern": "context-filter", "note": "Only `type: 'snackbar'` notices land here. `type: 'default'` notices go to `core:notices-banner`." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/components#SnackbarList", "purpose": "Stacked auto-dismissing snackbar primitive — no WPDS 0.12 port." },
+			{ "import": "@wordpress/notices", "purpose": "Read store + dispatch removeNotice." }
+		]
+	}
 }

--- a/src/apps/notices-snackbar/app.md
+++ b/src/apps/notices-snackbar/app.md
@@ -1,0 +1,30 @@
+# core:notices-snackbar
+
+Prose accompanying `app.json#documentation` for the snackbar notice host.
+
+## Overview
+
+NoticesSnackbarApp is the transient sibling of `core:notices-banner`. Same underlying notice bus (`@wordpress/notices`); different filter (`type: 'snackbar'`); different visual primitive (`SnackbarList` — stacked auto-dismissing pills at the bottom of the screen).
+
+The split between banner + snackbar maps cleanly to WordPress's notice contexts: success confirmations ("Saved.") are snackbars; sticky errors ("Save failed: <reason>") are banners. Apps pick by passing `{ type: 'snackbar' }` or omitting (which defaults to `'default'`).
+
+## Architecture
+
+Trivial — `useSelect(getNotices)` + `useDispatch(removeNotice)`, filter to snackbar, hand the array to `SnackbarList`. The package owns positioning, auto-dismiss timing, and animation.
+
+## Rebuild guide
+
+`SnackbarList` is the only legacy import here because WPDS 0.12 ships no snackbar primitive. A non-WPDS rebuild can use:
+
+- Material's `Snackbar` (single) + a stacking wrapper.
+- Tailwind: roll a positioned container + `setTimeout` per snackbar; not as nice but works.
+- Sonner / React Hot Toast / similar — drop-in if your stack permits.
+
+The contract is: stacked toasts at a screen edge, auto-dismiss with click-to-dismiss-earlier. Match the notice-bus filter so banner + snackbar share the bus.
+
+## Known limitations
+
+- **Single host per shell.** Two snackbar hosts would render notices twice.
+- **No undo affordance.** `SnackbarList` supports per-snackbar actions; the shell doesn't expose this. A future trash-with-undo flow would need it.
+- **Position is fixed by SnackbarList.** Bottom-center; not configurable.
+- **Auto-dismiss timing is the package default.** Not per-notice customizable through the shell.

--- a/src/apps/plugins/app.json
+++ b/src/apps/plugins/app.json
@@ -25,5 +25,151 @@
 		},
 		"multiInstance": false,
 		"icon": "plugins"
+	},
+	"documentation": {
+		"purpose": "DataViews plugin manager. Lists every installed plugin with name + description, status (active / inactive / network-active), version, and author. Row + bulk actions: activate, deactivate, visit plugin site, delete (inactive only). Mutations issue raw `POST /wp/v2/plugins/{file}` and `DELETE /wp/v2/plugins/{file}` via api-fetch because the `root/plugin` entity doesn't expose a save shape for status changes.",
+		"rebuilds": "plugins",
+		"data": {
+			"reads": [
+				{
+					"source": "root/plugin",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Installed-plugin list.",
+					"fields": [
+						"plugin",
+						"name",
+						"description.raw",
+						"status",
+						"version",
+						"author",
+						"author_uri",
+						"plugin_uri"
+					],
+					"query": {
+						"context": "edit"
+					}
+				}
+			],
+			"writes": [
+				{
+					"source": "/wp/v2/plugins/{plugin}",
+					"via": "api-fetch",
+					"operation": "partial-update",
+					"purpose": "Change plugin status (activate / deactivate) — `POST { status }`.",
+					"invalidates": [
+						"root/plugin"
+					]
+				},
+				{
+					"source": "/wp/v2/plugins/{plugin}",
+					"via": "api-fetch",
+					"operation": "delete",
+					"purpose": "Delete an inactive plugin.",
+					"invalidates": [
+						"root/plugin"
+					]
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "loading",
+				"when": "isResolving",
+				"renders": "DataViews loading indicator."
+			},
+			{
+				"id": "ready",
+				"when": "records !== null",
+				"renders": "Table of plugins with action menu per row."
+			},
+			{
+				"id": "error",
+				"when": "error !== null",
+				"renders": "`Notice.Root` banner replacing the table; remembers last error until next action."
+			},
+			{
+				"id": "delete-confirm",
+				"when": "User triggered Delete action",
+				"renders": "Confirm modal with destructive primary."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click Activate action",
+				"effect": "POST `/wp/v2/plugins/{file}` `{ status: 'active' }` per item; invalidate `root/plugin`.",
+				"guards": [
+					"item.status === 'inactive'"
+				]
+			},
+			{
+				"trigger": "Click Deactivate action",
+				"effect": "POST `/wp/v2/plugins/{file}` `{ status: 'inactive' }`; invalidate.",
+				"guards": [
+					"item.status === 'active' || item.status === 'network-active'"
+				]
+			},
+			{
+				"trigger": "Click Visit plugin site",
+				"effect": "`window.open(item.pluginUri, '_blank')`.",
+				"guards": [
+					"!!item.pluginUri"
+				]
+			},
+			{
+				"trigger": "Click Delete action",
+				"effect": "Open confirm modal; on confirm `DELETE /wp/v2/plugins/{file}` per item; invalidate.",
+				"guards": [
+					"item.status === 'inactive'"
+				]
+			},
+			{
+				"trigger": "Change view (search / filter / sort / page)",
+				"effect": "Local `view` updates; client-side filter recomputes (single REST request returns the full list)."
+			}
+		],
+		"a11y": {
+			"focus-management": "DataViews owns focus inside the table + modal."
+		},
+		"constraints": [
+			{
+				"concern": "dataviews-import-path",
+				"note": "Import from `@wordpress/dataviews/wp`."
+			},
+			{
+				"concern": "client-side-filter",
+				"note": "REST returns the full installed-plugin list in one request (it's typically tens of records). Search + status filter run client-side via `Array.filter`; pagination is computed against the filtered length."
+			},
+			{
+				"concern": "api-fetch-not-coredata",
+				"note": "Status changes + delete go through `apiFetch` because `core-data`'s `saveEntityRecord` / `deleteEntityRecord` don't have a clean payload shape for the plugin endpoint's `{ status }` PATCH. After mutating, manually `invalidateResolution` on the entity records query."
+			},
+			{
+				"concern": "plugin-file-encoding",
+				"note": "Plugin identifiers carry slashes (`hello-dolly/hello.php`). `encodeURIComponent` the value before interpolating into the REST path."
+			},
+			{
+				"concern": "network-active",
+				"note": "Multisite shows `network-active` status. Deactivate action covers both `active` + `network-active` to keep the row menu functional in network admin."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/dataviews/wp#DataViews",
+				"purpose": "Table view with actions."
+			},
+			{
+				"import": "@wordpress/ui#Button, Notice, Stack, Text",
+				"purpose": "Modal layout + error banner + cells."
+			},
+			{
+				"import": "@wordpress/components#Button (as DestructiveButton)",
+				"purpose": "Destructive primary in delete-confirm modal."
+			},
+			{
+				"import": "@wordpress/icons#trash, external, check, closeSmall",
+				"purpose": "Action icons."
+			}
+		]
 	}
 }

--- a/src/apps/plugins/app.md
+++ b/src/apps/plugins/app.md
@@ -1,0 +1,38 @@
+# core:plugins
+
+Prose accompanying `app.json#documentation` for the plugin manager.
+
+## Overview
+
+PluginsApp lists every installed plugin and surfaces the activate / deactivate / delete actions with `activate_plugins` capability gating. Unlike most DataViews apps in the shell, the read is one-shot — there's no server-side pagination (REST returns the full list in a single request), so search + status filter run client-side against `data` in `useMemo`. This is fine because plugin counts are typically tens, not thousands.
+
+Mutations split between two layers:
+
+- **Reads** go through `core-data`'s `useEntityRecords('root', 'plugin')` so the entity layer caches the full list.
+- **Writes** go through `apiFetch` directly because the plugin endpoint accepts a `{ status }` PATCH shape that doesn't map cleanly to `saveEntityRecord`. After each mutation, `invalidateResolution('getEntityRecords', ['root', 'plugin', query])` is fired manually so the entity layer refetches.
+
+## Architecture
+
+The client-side filter compares against the search string in name + stripped description. `stripTags()` runs once at projection time. The status filter accepts both array (`isAny`) and scalar (`is`) operator shapes.
+
+Error handling is **terminal**: when a mutation fails, the app replaces the table with an error notice and stays there until the next action attempt clears it. This is more conservative than other DataViews apps in the shell (which surface dismissible banners) — plugin-state corruption is high-consequence enough that a noisy error feels right.
+
+Plugin paths (`hello-dolly/hello.php`) carry slashes; `encodeURIComponent` is mandatory before interpolating into the REST path.
+
+## Rebuild guide
+
+The architectural pattern worth preserving: **single-shot read + manual invalidation on write**. For a non-`core-data` rebuild:
+
+- Issue one `GET /wp/v2/plugins?context=edit` on mount; cache the response.
+- Run search + filter client-side against the cached list.
+- On activate/deactivate/delete, fire the REST call, then **refetch** (not patch the local cache — let the server be the source of truth).
+- During refetch, the table can either show the previous state (optimistic) or a spinner (pessimistic). Shell uses the latter via `isLoading`.
+
+A non-WPDS rebuild needs the standard DataViews equivalents plus an error banner primitive.
+
+## Known limitations
+
+- No install / upload flow — only manage what's installed. wp-admin's "Add new" + zip-upload paths aren't ported.
+- No update flow. WordPress shows an "Update available" indicator + bulk update; the app reads `version` but doesn't compare against the .org repository version.
+- Network-active deactivation falls through the multisite delegation chain; we don't verify the multisite path actually completes.
+- The activate path doesn't surface a fatal-error rollback. If activation triggers a PHP error, WordPress traps it and returns `update`/`network_active` state; we don't currently parse that response to show a contextual error.

--- a/src/apps/posts/app.json
+++ b/src/apps/posts/app.json
@@ -40,5 +40,154 @@
 		},
 		"multiInstance": true,
 		"icon": "post"
+	},
+	"documentation": {
+		"purpose": "DataViews table over any single post type. Defaults to 20 rows per page sorted by date descending, with title / status / author / date columns. Authors filter by status, search the title field, switch between table and grid layouts, paginate, and run per-row or bulk actions (edit, view in new tab, move to trash). Used in every bundled shell for the Posts and Pages screens, and rebindable to custom post types through the `postType` config key.",
+		"rebuilds": "posts",
+		"data": {
+			"reads": [
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Rows in the DataViews table.",
+					"fields": [
+						"id",
+						"title.raw",
+						"title.rendered",
+						"status",
+						"date",
+						"link",
+						"_embedded.author.0.name"
+					],
+					"query": {
+						"_embed": "author",
+						"per_page": "view.perPage",
+						"page": "view.page",
+						"order": "view.sort.direction",
+						"orderby": "view.sort.field",
+						"status": "config.status||any|filter.status",
+						"context": "edit",
+						"search": "view.search",
+						"author": "filter.author"
+					}
+				}
+			],
+			"writes": [
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"operation": "trash",
+					"purpose": "Move one or more selected posts to trash from the row action or bulk action.",
+					"invalidates": [
+						"postType/{config.postType}"
+					]
+				}
+			]
+		},
+		"url": {
+			"navigates": [
+				"#/posts/{id}/edit",
+				"#/pages/{id}/edit"
+			]
+		},
+		"states": [
+			{
+				"id": "loading",
+				"when": "isResolving && !records",
+				"renders": "DataViews built-in loading indicator over the previous rows (or an empty table on first paint)."
+			},
+			{
+				"id": "ready",
+				"when": "records !== null && records.length > 0",
+				"renders": "Rows in the active layout (table or grid). Pagination footer shows totalItems / totalPages."
+			},
+			{
+				"id": "empty",
+				"when": "records?.length === 0",
+				"renders": "DataViews built-in empty state for the current filter/search."
+			},
+			{
+				"id": "trash-confirm",
+				"when": "User clicked Trash row/bulk action",
+				"renders": "Modal asking to confirm the destructive action with Cancel + Move to Trash buttons."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click row title",
+				"effect": "Navigate to the editor route for the post type via `navigate(editHref(postType, item.id))`."
+			},
+			{
+				"trigger": "Edit row action",
+				"effect": "Same as clicking the title — navigate to editor."
+			},
+			{
+				"trigger": "View row action",
+				"effect": "Open `item.link` in a new tab.",
+				"guards": [
+					"item.status === 'publish'"
+				]
+			},
+			{
+				"trigger": "Trash row action (single)",
+				"effect": "Open the confirm modal; on confirm `deleteEntityRecord('postType', postType, item.id)` is dispatched without `force` so the record is trashed not deleted."
+			},
+			{
+				"trigger": "Trash bulk action",
+				"effect": "Open the confirm modal with a pluralized message; on confirm `Promise.all(items.map(deleteEntityRecord(...)))` is awaited."
+			},
+			{
+				"trigger": "Change DataViews view (search / filter / sort / layout / page / perPage)",
+				"effect": "Local `view` state updates; `queryArgs` recomputes via `useMemo` and `useEntityRecords` re-fetches."
+			}
+		],
+		"a11y": {
+			"focus-management": "DataViews owns focus inside the grid. After the trash modal closes, DataViews restores focus to the action trigger automatically via its `RenderModal` plumbing."
+		},
+		"constraints": [
+			{
+				"concern": "dataviews-import-path",
+				"note": "Import `DataViews` from `@wordpress/dataviews/wp` (the runtime-private export), never bare `@wordpress/dataviews`. The bare path risks minified React error #130 in plugin contexts."
+			},
+			{
+				"concern": "context-edit",
+				"note": "Pass `context: 'edit'` so `title.raw` is populated; without it the table renders decoded HTML and any future inline-edit flow silently breaks."
+			},
+			{
+				"concern": "trash-not-delete",
+				"note": "`deleteEntityRecord('postType', name, id)` without `force: true` trashes the record (standard wp-admin behavior). Passing `force: true` would permanently delete."
+			},
+			{
+				"concern": "destructive-button-fallback",
+				"note": "WPDS 0.12 has no `tone=\"critical\"`. The destructive Trash button uses legacy `Button as DestructiveButton` from `@wordpress/components` with `isDestructive`."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/dataviews/wp#DataViews",
+				"purpose": "Table + grid view with built-in filtering, sorting, pagination, selection, bulk actions, and per-row action modals."
+			},
+			{
+				"import": "@wordpress/ui#Button",
+				"purpose": "Title cell renderer + Cancel button in trash-confirm modal."
+			},
+			{
+				"import": "@wordpress/ui#Stack",
+				"purpose": "Layout primitives inside the trash-confirm modal."
+			},
+			{
+				"import": "@wordpress/ui#Text",
+				"purpose": "Status label + modal copy."
+			},
+			{
+				"import": "@wordpress/components#Button (as DestructiveButton)",
+				"purpose": "Destructive primary button in trash-confirm modal — WPDS 0.12 has no `tone=\"critical\"`."
+			},
+			{
+				"import": "@wordpress/icons#pencil, external, trash",
+				"purpose": "Row action icons."
+			}
+		]
 	}
 }

--- a/src/apps/posts/app.md
+++ b/src/apps/posts/app.md
@@ -1,0 +1,40 @@
+# core:posts
+
+Substantive prose accompanying `app.json#documentation`. Structured facts (REST sources, states, interactions, DS imports) live in the manifest; this document captures the *why* — composition decisions, trade-offs, and rebuild guidance.
+
+## Overview
+
+PostsApp is the canonical DataViews host in the shell. Every bundled shell that surfaces a post-type list (`wp-admin-default`, `developer-admin`, `content-author`, `v2-demo`) mounts an instance of `core:posts` and either leaves the default `postType: "post"` or overrides it (`pages`, `wp_block`). The component itself is intentionally thin: it pulls rows through `useEntityRecords`, declares the DataViews `fields` / `actions` / `view` shape, and lets the DataViews package own everything else — layout switching, pagination, sort, selection, action modals, the empty state.
+
+## Architecture
+
+Three pieces of state drive the app:
+
+1. **`view`** — a local `useState` mirroring the DataViews controlled shape. Holds search string, active filters, page, perPage, sort, fields, and layout. Owned by the app; DataViews calls `onChangeView(next)` whenever the user changes anything.
+2. **`queryArgs`** — derived from `view + config.status` via `useMemo`. Maps DataViews concepts (filter operators, sort direction) to REST query arguments. The `_embed=author` arg lets one round trip cover the author column without a second request per row.
+3. **`records / isResolving / totalItems / totalPages`** — pulled from `useEntityRecords('postType', config.postType, queryArgs)`. Reading `totalItems` + `totalPages` keeps DataViews' pagination footer accurate without a separate count call.
+
+`data` is a `useMemo` projection of `records` into the row shape DataViews wants (`{ id, title, status, date, author, link, rawRecord }`). The original record is kept on `rawRecord` so future row actions can read fields the projection doesn't surface.
+
+The trash-confirm modal is implemented via DataViews' `RenderModal` action shape — DataViews owns the focus trap, backdrop, and dismiss handling. Inside the modal the app uses WPDS `Stack` + `Text` for layout and copy, with the destructive primary button falling back to legacy `@wordpress/components` `Button as DestructiveButton` because WPDS 0.12 has no `tone="critical"`.
+
+## Rebuild guide
+
+A rebuild on a non-WPDS / non-DataViews stack needs to provide:
+
+- A **list/grid view component** with built-in filtering, sorting, pagination, selection, and per-row + bulk actions. DataViews is the heavy lift — for Material, MUI's `DataGrid` is the closest equivalent; for Tailwind/Vue, TanStack Table + your own action menu.
+- A **REST/core-data adapter** that returns `{ rows, total, isLoading }` for a query shape compatible with WordPress REST. The shell's `core-data` reads return `useEntityRecords`'s `{ records, isResolving, totalItems, totalPages }` shape — a Vue rebuild would expose the same triple from a Pinia store.
+- A **destructive-action confirm modal**. Re-use whatever modal primitive the host DS provides; the contract is: open on action invocation, render confirmation copy, await async confirm, close, then let the list refresh.
+- An **icon set** covering pencil/external/trash equivalents for row actions.
+
+Two patterns to preserve:
+
+- `context: 'edit'` is **required** on the read — without it `title.raw` is missing and the title cell renders decoded HTML. Any inline-edit feature added later would silently fail.
+- `deleteEntityRecord` without `force` **trashes**, matching wp-admin behavior. Don't switch to a hard delete without surfacing a separate "Delete permanently" action.
+
+## Known limitations
+
+- No inline edit (DataViews supports it; not wired up here).
+- Status filter is a single-select today. The `filterBy.operators: ['isAny']` declaration exists but the queryArgs mapper only handles the `isAny`/`is` operators against the `status` field.
+- Site-editor post types (`wp_template`, `wp_block`, `wp_navigation`) navigate through `editHref()` but `editHref()` only special-cases `page`. Their URL-encoded slug-shaped IDs would need a new edit pattern + decode step; deferred until those screens land.
+- The trash action is hard-coded. A future iteration may surface restore / delete-permanently as separate eligible actions once the post is in trash status.

--- a/src/apps/preview-pane/app.json
+++ b/src/apps/preview-pane/app.json
@@ -16,5 +16,47 @@
 		},
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Spec §6.4 + V2.M4: regions coordinate via URL state, not a shell-level selection bus. PreviewPaneApp reads the routes block + URL slot at `config.follow` (default `_self`), maps the matched route's `config` to a `core-data` entity (`post-type` + `post-id`), and renders the entity as JSON. Designed for shells whose `detail` region (or any routable region) holds an editor-style app and whose `preview` region wants to mirror what the editor is editing.",
+		"data": {
+			"reads": [
+				{
+					"source": "config.routes (kernel)",
+					"via": "core-data",
+					"purpose": "Routes block — used to match the URL slot value against route patterns."
+				},
+				{
+					"source": "postType/{post-type}/{post-id}",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Entity record matched by the route. Only resolves when the matched route's `config` has both `post-type` + numeric `post-id`."
+				}
+			]
+		},
+		"url": {
+			"reads-slots": [ "_self", "{config.follow}" ]
+		},
+		"states": [
+			{ "id": "empty", "when": "Slot value is empty or route didn't match", "renders": "`Select an item to preview.` placeholder." },
+			{ "id": "loading", "when": "Matched a post-shaped route but entity is resolving", "renders": "Centered Spinner." },
+			{ "id": "not-found", "when": "Entity fetch resolved without a record", "renders": "`Item not found.` placeholder." },
+			{ "id": "ready-entity", "when": "Entity resolved", "renders": "`<pre>` block of `JSON.stringify(record, null, 2)`." },
+			{ "id": "ready-fallback", "when": "Route matched but config isn't post-shaped", "renders": "`<pre>` block of `JSON.stringify({ app, config }, null, 2)` — debug-style fall-back for non-entity routes." }
+		],
+		"interactions": [
+			{ "trigger": "URL changes (primary path or `follow` slot)", "effect": "useRoute re-runs; matchRoute reevaluates; entity record refetches." }
+		],
+		"a11y": {
+			"focus-management": "Preview pane is read-only; focus stays in the primary region."
+		},
+		"constraints": [
+			{ "concern": "self-vs-named-slot", "note": "`follow: '_self'` reads `route.primary` (the primary hash path). Other values read `route.params[follow]` — useful for shells with a named `detail` region carrying its own route param." },
+			{ "concern": "post-shape-only-today", "note": "Only `post-type` + numeric `post-id` routes resolve as entities. Other shapes fall back to JSON-of-config — useful as a debug surface, but a future iteration should support more entity types (taxonomy terms, users, etc.)." },
+			{ "concern": "url-as-coordination-not-bus", "note": "Spec §6.4 explicitly chose URL state over a shell-level selection bus. PreviewPaneApp is the reference consumer." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/components#Spinner", "purpose": "Loading indicator." }
+		]
+	}
 }

--- a/src/apps/preview-pane/app.md
+++ b/src/apps/preview-pane/app.md
@@ -1,0 +1,48 @@
+# core:preview-pane
+
+Prose accompanying `app.json#documentation` for the route-following preview pane.
+
+## Overview
+
+PreviewPaneApp is the reference consumer of the **URL-as-coordination** pattern (spec §6.4 / V2.M4). Earlier v1 designs had a shell-level "selection bus" with explicit dispatch + subscribe channels — apps would `selectionBus.set('content', { type: 'post', id: 42 })` and other apps would subscribe. v2 removed it. Region-to-region coordination happens through URL state instead: the editor region writes `/posts/42/edit`; the preview region reads `_self` (or a named slot) and matches it against the routes block.
+
+The result is simpler and survives cross-cutting refresh / deep-link / browser-back semantics for free. The cost is "preview" use-cases need a route pattern that uniquely identifies the previewed entity. For the bundled shells, `post-type` + `post-id` route configs cover it.
+
+## Architecture
+
+`useRoute()` returns `{ primary, params }`. `useKernel()` exposes the routes block (passed via `<KernelProvider>`).
+
+Slot resolution:
+
+- `follow === '_self'` → read `route.primary`.
+- Otherwise → read `route.params[follow]`.
+
+`matchRoute(routesBlock, slotValue)` returns the matched route entry + extracted params. If the matched route's `config` has `post-type` + numeric `post-id`, fetch the entity via `useEntityRecord('postType', name, id)`.
+
+Render branches:
+
+- No match → "Select an item to preview." placeholder.
+- Match but non-post-shaped → JSON-of-config (debug fallback).
+- Post-shaped + resolving → Spinner.
+- Post-shaped + resolved + no record → "Item not found."
+- Post-shaped + resolved + record → JSON-of-record.
+
+The JSON-of-record render is intentionally crude: this app is a reference implementation. A real preview surface (block rendering, frontend iframe, prose-style metadata) is application-specific and belongs in a custom app.
+
+## Rebuild guide
+
+The pattern is the interesting bit, not the implementation:
+
+1. **Read the URL slot you're following.** `_self` for primary path; named slot for a sibling region's param.
+2. **Match the slot value against the route map.** Reuse the kernel's matchRoute or your host's router.
+3. **Map matched config to your data layer.** Post-shape today; extend to your entity types as needed.
+4. **Render a stable shape across loading / not-found / ready.** Avoid layout jumps as the route resolves.
+
+For a non-`core-data` rebuild, the data adapter changes; everything else stays.
+
+## Known limitations
+
+- **Post-shape only.** Other entities (taxonomy terms, users, comments) fall through to the debug-fallback render.
+- **Crude render.** JSON.stringify; not visually useful for end-users. Replace with whatever preview surface is appropriate per app — block render via `@wordpress/block-editor`, iframe preview of the frontend, etc.
+- **No edit-to-preview live sync.** When the editor saves, the entity refetches; while editing locally, the preview still shows the last-saved state (because it reads through core-data's record, not the editor's local edits).
+- **No multi-route preview composition.** Following a single slot only — can't show two simultaneous previews from different slots in one app.

--- a/src/apps/profile/app.json
+++ b/src/apps/profile/app.json
@@ -25,5 +25,123 @@
 		},
 		"multiInstance": false,
 		"icon": "people"
+	},
+	"documentation": {
+		"purpose": "Profile editor for the acting user (`window.wpAdminShell.userId`). Edits first/last/nickname, display name (chosen from a generated option set), email, website, and biographical info. Reads + writes go through `core-data` `useEntityRecord('root', 'user', userId)`; the save button is disabled until `hasEdits` and shows a loading state while `isSaving`. Success + error route through `@wordpress/notices` snackbar / banner.",
+		"rebuilds": "profile",
+		"data": {
+			"reads": [
+				{
+					"source": "root/user/{window.wpAdminShell.userId}",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Profile fields of the acting user.",
+					"fields": [
+						"id",
+						"username",
+						"first_name",
+						"last_name",
+						"nickname",
+						"name",
+						"email",
+						"url",
+						"description"
+					]
+				},
+				{
+					"source": "window.wpAdminShell.userId",
+					"via": "window-global",
+					"purpose": "Identify the acting user; absence shows a permission-denied message."
+				}
+			],
+			"writes": [
+				{
+					"source": "root/user",
+					"via": "core-data",
+					"operation": "update",
+					"purpose": "Save accumulated `edit()` calls via `save()` from useEntityRecord."
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "permission-denied",
+				"when": "!userId (no acting user in context)",
+				"renders": "Single-paragraph fallback message."
+			},
+			{
+				"id": "loading",
+				"when": "!record",
+				"renders": "Centered Spinner."
+			},
+			{
+				"id": "ready",
+				"when": "record !== null && !hasEdits",
+				"renders": "Form with the seven fields populated; Save button disabled."
+			},
+			{
+				"id": "with-edits",
+				"when": "hasEdits === true && !isSaving",
+				"renders": "Same form with Save enabled; dirty-state reported to kernel."
+			},
+			{
+				"id": "saving",
+				"when": "isSaving === true",
+				"renders": "Save button shows loading spinner + disabled state."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Type in any text field",
+				"effect": "`edit({ <field>: e.target.value })`; hasEdits becomes true."
+			},
+			{
+				"trigger": "Choose display name from select",
+				"effect": "`edit({ name: value })` with options generated from username / first / last / first+last / last+first / nickname / current name."
+			},
+			{
+				"trigger": "Click Save Changes",
+				"effect": "`await save()`; on success: success snackbar. On failure: error banner with `err.message`."
+			}
+		],
+		"a11y": {
+			"focus-management": "Form fields are in document order; native focus order is sufficient."
+		},
+		"constraints": [
+			{
+				"concern": "null-guard-record",
+				"note": "`useEntityRecord('root','user', userId)` returns `{ record: null }` while loading. Reading `record.first_name` without a guard crashes on first paint."
+			},
+			{
+				"concern": "displayname-options-generated",
+				"note": "Display name dropdown options are computed in render from the record's name fields. A field combination that produces only one option still renders the select; the user is forced to keep that option even if it's not what they want."
+			},
+			{
+				"concern": "dirty-state-reports",
+				"note": "Manifest declares `core:dirty-state: true`. The app does NOT call `useDirtyState` directly — it relies on `hasEdits` being read by a sibling NavigationGuard. (`block-navigation-on-dirty` is intentionally not set; profile edits are low-stakes.)"
+			},
+			{
+				"concern": "inputcontrol-event-shape",
+				"note": "WPDS `InputControl` onChange takes a DOM event (`e.target.value`), not the raw value. The same applies wherever WPDS form fields are used."
+			},
+			{
+				"concern": "textarea-fallback",
+				"note": "Uses legacy `TextareaControl` from `@wordpress/components` — WPDS 0.12 has no port."
+			},
+			{
+				"concern": "select-fallback",
+				"note": "Uses legacy `SelectControl` from `@wordpress/components` for the display name (WPDS 0.12 SelectControl has no `__nextHasNoMarginBottom` parity)."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Button, InputControl, Stack, Text",
+				"purpose": "Form layout + text + URL + email inputs + save button."
+			},
+			{
+				"import": "@wordpress/components#TextareaControl, SelectControl, Spinner",
+				"purpose": "Bio textarea + display-name select + loading spinner — WPDS 0.12 gaps."
+			}
+		]
 	}
 }

--- a/src/apps/profile/app.md
+++ b/src/apps/profile/app.md
@@ -1,0 +1,38 @@
+# core:profile
+
+Prose accompanying `app.json#documentation` for the profile editor.
+
+## Overview
+
+ProfileApp is the simplest write-path in the shell: a flat form over `useEntityRecord('root', 'user', userId)`. The acting user is read from `window.wpAdminShell.userId` (injected by PHP); without it the app renders a permission-denied fallback. The form populates from the entity record on first paint, accumulates edits via `edit({ <field>: value })`, and flushes via `save()` when the user clicks Save Changes.
+
+## Architecture
+
+The display name field is the only non-trivial bit. WordPress's user UI lets you pick `display_name` from a generated option set — username, first, last, first+last, last+first, nickname, current name — and this app reproduces that. The option list is built in render via a small `addOption` helper that dedupes empty + duplicate values.
+
+Save flow:
+
+1. `await save()` from `useEntityRecord`.
+2. On success: `createSuccessNotice('Profile updated.', { type: 'snackbar' })`.
+3. On error: `createErrorNotice(err.message, { isDismissible: true })`.
+
+Notice routing: success → snackbar (auto-dismiss), failure → dismissible banner (sticky until the user clears).
+
+## Rebuild guide
+
+The "form over an entity record" pattern is generic. For a non-`core-data` rebuild:
+
+- Treat the entity as a single state object with an `edited` overlay. Edits accumulate locally; only flush on save.
+- Track `hasEdits` derived from `JSON.stringify(edited) !== JSON.stringify(record)` if your store doesn't expose it.
+- Disable the save button while `!hasEdits || isSaving`. Show a loading state on the button while saving.
+- Route success + failure through the host's notice system.
+
+A non-WPDS rebuild needs text input + email input + URL input + select + textarea + button primitives. All standard.
+
+## Known limitations
+
+- **No password change.** WordPress wp-admin's profile page includes a password section; this app omits it. Password updates need the dedicated endpoint with the current-password confirm step.
+- **No application passwords / two-factor.** Out of scope.
+- **No avatar customization.** WordPress uses Gravatar; this app shows nothing about it.
+- **Admin-email change differs from wp-admin.** REST saves email directly; wp-admin uses a confirm-by-link flow. We don't surface this distinction beyond a description on the field.
+- **Profile is current-user-only.** No editing-another-user flow exists; that would need to live in `core:users` (with `edit_users` cap gating) and a different mount.

--- a/src/apps/settings-general/app.json
+++ b/src/apps/settings-general/app.json
@@ -13,5 +13,64 @@
 		"type": "object",
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Form over WordPress's `general-settings` REST surface (`options.php`'s native equivalent). Covers site identity (title, tagline, URL, home URL, admin email), membership (registration toggle, default role — site-only, hidden on multisite), language (with optgroups for installed + available locales), timezone (city + UTC groups, with current UTC / local time display), date format (preset radio + custom-format input), time format (same), and week-start day. Reads + writes through `core-data` `useEntityRecord('root','site')`. Composable host (`core:settings`) mounts this for the `general` panel; shells can also mount this directly for a minimal settings screen.",
+		"rebuilds": "settings-general",
+		"data": {
+			"reads": [
+				{
+					"source": "root/site",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Site-wide options.",
+					"fields": [ "title", "description", "url", "home", "email", "users_can_register", "default_role", "language", "timezone", "date_format", "time_format", "start_of_week" ]
+				},
+				{
+					"source": "window.wpAdminShell.settingsGeneral",
+					"via": "window-global",
+					"purpose": "PHP-injected options that don't live in `root/site` — pending admin-email change, presence of `WP_SITEURL` / `WP_HOME` constants, role list, language list with optgroups, timezone group list, weekday labels, date + time format preset arrays, multisite flag."
+				}
+			],
+			"writes": [
+				{
+					"source": "root/site",
+					"via": "core-data",
+					"operation": "update",
+					"purpose": "Save accumulated edits via `save()`."
+				}
+			]
+		},
+		"states": [
+			{ "id": "loading", "when": "!record || !data", "renders": "Centered Spinner." },
+			{ "id": "ready", "when": "record && data && !hasEdits", "renders": "Form with fields populated; Save disabled." },
+			{ "id": "with-edits", "when": "hasEdits && !isSaving", "renders": "Form with Save enabled." },
+			{ "id": "saving", "when": "isSaving", "renders": "Save button shows loading state." },
+			{ "id": "pending-email", "when": "data.pendingAdminEmail && data.pendingAdminEmail !== record.email", "renders": "Info notice showing the pending email-change target." }
+		],
+		"interactions": [
+			{ "trigger": "Type in title / tagline / URL / home / email", "effect": "`edit({ <field>: value })`." },
+			{ "trigger": "Toggle Anyone can register", "effect": "`edit({ users_can_register: bool })`.", "guards": [ "!isMultisite" ] },
+			{ "trigger": "Choose default role", "effect": "`edit({ default_role: value })`.", "guards": [ "!isMultisite" ] },
+			{ "trigger": "Choose language / timezone / week-start", "effect": "Edit the corresponding field." },
+			{ "trigger": "Choose Date Format / Time Format radio", "effect": "Selecting a preset edits the field directly; selecting `Custom` reveals the custom-format input below the radio set and seeds with previous custom value or a default (`Y-m-d` / `H:i`)." },
+			{ "trigger": "Edit custom date/time format", "effect": "Edit the field + stash in local state so re-selecting Custom doesn't blank the value." },
+			{ "trigger": "Click Save Changes", "effect": "`await save()`; on success: success snackbar. On failure: dismissible error banner with `err.message`." }
+		],
+		"a11y": {
+			"focus-management": "Native form focus order is sufficient."
+		},
+		"constraints": [
+			{ "concern": "null-guard-record", "note": "`useEntityRecord('root','site')` returns `{ record: null }` while loading. Guard before reading any field." },
+			{ "concern": "siteurl-home-readonly", "note": "When `WP_SITEURL` / `WP_HOME` PHP constants are defined, the corresponding REST endpoints reject changes. The inputs disable + show a description naming the constant." },
+			{ "concern": "site-only-fields", "note": "Membership + admin-email + URL fields hide on multisite (`data.isMultisite`). Network admin manages those." },
+			{ "concern": "selectcontrol-for-optgroups", "note": "Uses legacy `SelectControl` from `@wordpress/components` because WPDS 0.12's Select cannot render `<optgroup>`. Language + timezone selects both need optgroup support." },
+			{ "concern": "form-control-fallbacks", "note": "Uses legacy `CheckboxControl`, `RadioControl`, `__experimentalDivider` — all WPDS 0.12 gaps." },
+			{ "concern": "pending-email-distinction", "note": "REST saves admin email directly — wp-admin's confirm-by-link flow is bypassed. We surface the pending value as an info notice when WordPress has one queued from a prior wp-admin attempt." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/ui#Button, InputControl, Notice, Stack, Text", "purpose": "Form layout + text inputs + notice + save button." },
+			{ "import": "@wordpress/components#SelectControl, CheckboxControl, RadioControl, Spinner, __experimentalDivider", "purpose": "Optgroup-capable select + checkbox + radio + loading + section divider — WPDS 0.12 gaps." }
+		]
+	}
 }

--- a/src/apps/settings-general/app.md
+++ b/src/apps/settings-general/app.md
@@ -1,0 +1,43 @@
+# core:settings-general
+
+Prose accompanying `app.json#documentation` for the General Settings form.
+
+## Overview
+
+SettingsGeneralApp is the canonical WordPress `general-settings` screen ported to React + core-data. It's the most form-heavy app in the shell — fifteen-plus fields covering site identity, membership, language, timezone, date/time formatting, and week-start. It lands inside the composable `core:settings` host as the `general` panel; standalone registration is kept for shells that want a minimal "just general settings" experience.
+
+The interesting bits are the **date/time format pickers**: WordPress's wp-admin shows a list of preset radios + a "Custom" radio that reveals a free-text input. Reproducing this pattern requires careful state — the custom-input value must persist across radio toggles so re-selecting Custom doesn't blank the previous custom value.
+
+## Architecture
+
+Two data sources:
+
+1. **`useEntityRecord('root', 'site')`** — the writable site options. Save flows through `save()`.
+2. **`window.wpAdminShell.settingsGeneral`** — PHP-injected read-only metadata: role list, language optgroups, timezone groups, weekday labels, preset date/time format arrays, multisite flag, pending admin-email target, constant flags. This data is computed PHP-side because it requires reading `WP_LANG_DIR` (installed locales), the active translation set (available locales), timezone identifiers from PHP's `DateTimeZone::listIdentifiers()`, and `defined('WP_SITEURL') / WP_HOME` PHP constants. None of these are REST-exposed.
+
+Date/Time format logic:
+
+- Compute `dateFormatRadioValue` from `editedRecord.date_format`: either matches a preset value or is `__custom__`.
+- Render the radio set with preset options + a `__custom__` option labeled "Custom".
+- When radio changes to a preset, edit the field with the preset value.
+- When radio changes to `__custom__`, restore previous custom value from local `useState` (or fallback to `Y-m-d`) and surface the custom input.
+- When custom input changes, edit the field + stash in local state.
+
+The local `dateFormatCustom` / `timeFormatCustom` state survives radio toggles so the user can flip between Custom and a preset without losing their typed custom format.
+
+## Rebuild guide
+
+- **Form pattern** — same as `core:profile`: useEntityRecord + edit + save + notice on success/failure.
+- **PHP-injected metadata** — reproduce `settingsGeneral` shape via your host's config-injection mechanism. The role list, language optgroups, timezone groups, weekday labels, etc. are computed PHP-side because they aren't REST-exposed.
+- **Preset-or-custom pattern** — radio set with the last "Custom" option revealing an input field. Local state preserves custom values across radio toggles. A reusable component is worth extracting if your settings surface has more than two of these.
+- **Constant-aware fields** — when `WP_SITEURL` / `WP_HOME` are defined, REST rejects writes. Detect this server-side, inject the flag, disable the input + show a contextual description.
+
+A non-WPDS rebuild needs text inputs, email + URL types, select (with optgroup support — Material's `Select` works), checkbox, radio group, divider, notice banner, button. Pretty standard form-library territory.
+
+## Known limitations
+
+- **Admin-email change has no confirm-by-link flow.** REST saves directly. We surface the wp-admin pending email change as an info notice but can't initiate one.
+- **Privacy-policy page selector** is not in this panel — privacy lives in the iframed privacy panel.
+- **Time-format custom field accepts any PHP date format string** — no live preview of what the format produces against the current time.
+- **No "reset to default" affordance** for date/time formats.
+- **Constant-defined URL fields** show "Defined by WP_SITEURL constant" but don't show the value of the constant; user has to look at wp-config.php to see it.

--- a/src/apps/settings/app.json
+++ b/src/apps/settings/app.json
@@ -36,5 +36,73 @@
 		},
 		"multiInstance": false,
 		"icon": "settings"
+	},
+	"documentation": {
+		"purpose": "Composable host that mounts a vertical nav (left) + one selected settings panel (right). Bundles seven built-in panels reflecting WordPress's settings screens: general (native), writing (native, partial REST coverage), reading (native, partial), discussion (native, partial), permalinks (iframed — no REST), media (iframed — partial REST), privacy (iframed — no REST). Shells narrow the panel set via `config.panels[]`. Unknown sub-routes fall back to the first available panel rather than 404-ing.",
+		"rebuilds": "settings-general",
+		"data": {
+			"reads": [
+				{
+					"source": "Per-panel — see settings-general / settings-writing / settings-reading / settings-discussion individual app docs.",
+					"via": "core-data",
+					"purpose": "Each native panel mounts its own component and reads its own slice of `useEntityRecord('root','site')` or related entities."
+				}
+			]
+		},
+		"url": {
+			"reads-slots": [
+				"_self"
+			],
+			"navigates": []
+		},
+		"states": [
+			{
+				"id": "empty-allowlist",
+				"when": "config.panels filters out every built-in",
+				"renders": "Empty-state copy: `No settings panels are available.`"
+			},
+			{
+				"id": "ready",
+				"when": "activePanel !== null",
+				"renders": "Two-column layout: nav on left (Item per panel) + active panel (or IframeApp) on right."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click a panel in the nav",
+				"effect": "`setActive(panel.id)`; right column re-renders with the new panel's Component (or iframe)."
+			}
+		],
+		"a11y": {
+			"focus-management": "Item nav handles its own focus; clicking a nav item moves focus to the activated entry."
+		},
+		"constraints": [
+			{
+				"concern": "active-state-local",
+				"note": "Active panel id is in `useState`, NOT the URL. Refreshing the page lands on the first panel, not the previously-active one. A future iteration may move this to a URL slot for parity with NavigationApp's `?screen=` pattern."
+			},
+			{
+				"concern": "panel-allowlist-empty-fallback",
+				"note": "If `config.panels` allowlist filters out every built-in panel (empty array passes through), the empty-state UI surfaces. Authoring tools should warn if the resolved list is empty."
+			},
+			{
+				"concern": "permission-floor-manage-options",
+				"note": "Every built-in panel requires `manage_options`. The kernel's capability gate suppresses the whole app for users without it; per-panel cap gating is uniform today."
+			},
+			{
+				"concern": "iframe-fallback-for-no-rest",
+				"note": "Permalinks, Media, and Privacy panels delegate to `IframeApp` because their settings have no REST coverage. The iframe inherits chrome-stripping CSS but iframes are otherwise opaque to the host."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Stack",
+				"purpose": "Two-column layout."
+			},
+			{
+				"import": "@wordpress/components#__experimentalItemGroup, __experimentalItem",
+				"purpose": "Vertical nav — WPDS 0.12 has no ItemGroup port."
+			}
+		]
 	}
 }

--- a/src/apps/settings/app.md
+++ b/src/apps/settings/app.md
@@ -1,0 +1,42 @@
+# core:settings
+
+Prose accompanying `app.json#documentation` for the settings host.
+
+## Overview
+
+SettingsApp is a thin composer — it owns the vertical nav and panel-switching state, but every actual settings UI lives in a sibling component (`SettingsGeneralApp`, `SettingsWritingApp`, `SettingsReadingApp`, `SettingsDiscussionApp`) or in `IframeApp` for the three wp-admin screens without REST coverage. The decomposition matches WordPress's settings page list one-for-one.
+
+Native panels (general, writing, reading, discussion) are React components that hit core-data directly. Iframed panels (permalinks, media, privacy) wrap `wp-admin/options-{permalink,media,privacy}.php` with chrome stripped. The decision matrix is documented in `docs/admin-json-api-validation.md#core-settings` — when REST coverage exists for a setting, it's native; when it doesn't, the iframe pattern preserves the right user-visible outcome at the cost of some shell-chrome polish.
+
+## Architecture
+
+`BUILTIN_PANELS` is a module-level constant — id, label, Component or iframe URL, required capability. Shells narrow via `config.panels[]` allowlist; unknown ids in the allowlist are silently filtered out.
+
+State:
+
+- `activeId` (`useState`) — currently selected panel id. Initial value comes from URL segment (`segments[0]`) when present, falling back to `panels[0]?.id`.
+- `activePanel` — the matched object, with safety fallback to `panels[0]` for unknown ids.
+
+The right-column renderer:
+
+- `PanelComponent` defined → render `<PanelComponent app={app} config={...} />`.
+- `iframeUrl` defined → render `<IframeApp app={app} config={{ url }} />`.
+- Neither → `null` (unreachable in practice).
+
+The active state lives in `useState`, not the URL. This is a deliberate v1 compromise — refreshing the page lands on the first panel, not the one you were on. A future iteration should move this to a query slot (analogous to NavigationApp's `?screen=`).
+
+## Rebuild guide
+
+Two patterns worth preserving:
+
+- **Decompose by panel.** Each settings sub-screen has its own data + form contract. Keeping them as siblings (not as one giant 1000-line component with a `switch`) means panels can be added, removed, or replaced independently. A non-WPDS rebuild ports each panel separately.
+- **Iframe fallback for un-REST-able settings.** Permalinks, Media, and Privacy don't have clean REST surfaces; rather than reimplement them with custom endpoints, the iframe path preserves the right outcome with minimal effort. Mark these clearly in your panel registry so authors know which paths are "native" vs "iframed."
+
+A non-WPDS rebuild needs a Tab / SegmentedControl / vertical-nav primitive, and equivalents of `ItemGroup + Item` for the panel list.
+
+## Known limitations
+
+- **Active panel id not in URL.** Refreshing the page returns to the first panel.
+- **No plugin-panel registry.** The slot/fill extension was retired in V2.M4; plugins can ship their own apps but can't slot panels into `core:settings`. v2.x may reintroduce a registry once the surface stabilizes.
+- **Capability gating is uniform** — every built-in panel requires `manage_options`. Per-panel capability differentiation (e.g. a future site-health-related panel needing `view_site_health_checks`) isn't wired up.
+- **Empty-allowlist edge case** — if `config.panels = []` or filters out every built-in, the empty-state copy renders. Authoring tools should warn.

--- a/src/apps/simple-editor/app.json
+++ b/src/apps/simple-editor/app.json
@@ -33,5 +33,191 @@
 		},
 		"multiInstance": true,
 		"icon": "edit"
+	},
+	"documentation": {
+		"purpose": "Substack-style minimal block editor: a title input plus a constrained block tree (paragraph / heading / image / quote / list / list-item / code / separator / embed). Loads/saves through `core-data` `useEntityRecord('postType', postType, id)`. Auto-saves on a 2-second debounce after edits stop; Publish button flips between `Publish` and `Update` based on `record.status`. Composes Gutenberg's `BlockEditorProvider` + `BlockTools` + `WritingFlow` + `ObserveTyping` + `BlockList` directly so the editor renders inline (not iframed) and inherits the shell's DOM.",
+		"rebuilds": "editor-block",
+		"data": {
+			"reads": [
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Existing-post hydration via `useEntityRecord`.",
+					"fields": [
+						"id",
+						"title.raw",
+						"content.raw",
+						"status"
+					]
+				}
+			],
+			"writes": [
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"operation": "update",
+					"purpose": "Auto-save (`save()` from useEntityRecord) every 2s of inactivity while `hasEdits`; Publish/Update button flushes immediately."
+				},
+				{
+					"source": "/wp/v2/posts | /wp/v2/pages",
+					"via": "api-fetch",
+					"operation": "create",
+					"purpose": "Create a draft when the route lacks an `id`. Seeds an empty paragraph block in `content` for the same REST 400-on-empty reason as the iframe editor."
+				}
+			]
+		},
+		"url": {
+			"reads-slots": [
+				"_self"
+			],
+			"navigates": [
+				"#/posts",
+				"#/pages",
+				"#/{segment}/{id}/edit"
+			]
+		},
+		"states": [
+			{
+				"id": "creating-draft",
+				"when": "isNew && isCreating",
+				"renders": "Centered spinner during the POST."
+			},
+			{
+				"id": "loading-entity",
+				"when": "isResolving || !record || !hydrated",
+				"renders": "Centered spinner while core-data resolves the post + block-tree hydrates from `content.raw`."
+			},
+			{
+				"id": "ready",
+				"when": "record && hydrated && !hasEdits",
+				"renders": "Toolbar (Back + clean state) + title input + block editor body."
+			},
+			{
+				"id": "with-edits",
+				"when": "hasEdits && !isSaving",
+				"renders": "Toolbar shows `Unsaved changes` indicator; auto-save timer running."
+			},
+			{
+				"id": "saving",
+				"when": "isSaving || saveStatus === 'saving'",
+				"renders": "Toolbar shows `Saving…`; Publish button is `loading` + disabled."
+			},
+			{
+				"id": "saved",
+				"when": "saveStatus === 'saved'",
+				"renders": "Toolbar shows `Saved`; auto-fades to `idle` after 2s."
+			},
+			{
+				"id": "save-failed",
+				"when": "saveStatus === 'error'",
+				"renders": "Toolbar shows `Save failed` with `err.message`."
+			},
+			{
+				"id": "error",
+				"when": "error !== null",
+				"renders": "Toolbar + empty-state with the error message; no editor body."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Mount with `#/{segment}/new`",
+				"effect": "POST a draft with seeded empty paragraph; replace URL via `history.replaceState`; hydrate block tree."
+			},
+			{
+				"trigger": "Type in title input",
+				"effect": "`edit({ title })` on the entity; debounce triggers auto-save."
+			},
+			{
+				"trigger": "Enter / Tab from title",
+				"effect": "Focus moves to the first contenteditable in the body (the block list)."
+			},
+			{
+				"trigger": "Edit blocks",
+				"effect": "`onChange(newBlocks)` updates local block state + serializes back via `edit({ content: serialize(newBlocks) })`; debounce triggers auto-save."
+			},
+			{
+				"trigger": "Auto-save tick (2s after last edit)",
+				"effect": "`save()` runs; saveStatus transitions `saving → saved`; success fades after 2s. On failure: `saveStatus = 'error'` with `err.message`."
+			},
+			{
+				"trigger": "Click Publish/Update",
+				"effect": "Cancel any pending auto-save timer, `edit({ status: 'publish' })`, then `save()` synchronously."
+			},
+			{
+				"trigger": "Click Back to list",
+				"effect": "Navigate to `#/posts` or `#/pages` based on postType. Dirty-state guard fires if there are unsaved edits."
+			}
+		],
+		"a11y": {
+			"focus-management": "Title input gets autofocus via `core:autofocus-target` platform service. Enter/Tab on the title moves focus to the first contenteditable in the body.",
+			"keyboard": [
+				{
+					"keys": "Tab",
+					"action": "From title input: focus first block."
+				},
+				{
+					"keys": "Enter",
+					"action": "From title input: focus first block (overrides default newline)."
+				}
+			],
+			"screen-reader": "Save status announces transitions via the visible `Saving…` / `Saved` text; not aria-live (would announce too eagerly during typing)."
+		},
+		"constraints": [
+			{
+				"concern": "block-registration-idempotent",
+				"note": "`registerCoreBlocks()` is gated by a module-level flag + `getBlockTypes().length === 0` check. Calling twice would throw duplicate-registration errors."
+			},
+			{
+				"concern": "empty-post-seed",
+				"note": "Same `<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->` seed as EditorApp — REST rejects fully-empty posts."
+			},
+			{
+				"concern": "block-styles-enqueued-php-side",
+				"note": "PHP enqueues `wp-block-editor`, `wp-block-library`, `wp-format-library` styles on the shell page so block chrome and default block styles render. A reimplementation must arrange the equivalent style loading."
+			},
+			{
+				"concern": "hydrate-once",
+				"note": "Block tree is parsed from `record.content.raw` exactly once after first paint (`hydrated` flag). Subsequent records updates do NOT re-parse — that would clobber in-progress edits."
+			},
+			{
+				"concern": "dirty-state-wired",
+				"note": "`useDirtyState(regionId, hasEdits, { blocksNavigation: true })` reports unsaved state to the kernel; NavigationGuard shows beforeunload + intra-shell confirm dialogs."
+			},
+			{
+				"concern": "auto-save-cancelable",
+				"note": "Auto-save uses a single `setTimeout` ref. Publish clears the pending timer + saves immediately to avoid a double-save race."
+			},
+			{
+				"concern": "title-shape-fallback",
+				"note": "`editedRecord.title` may be a string (from inline edit) or an object (from REST). The titleValue reader handles both."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Button",
+				"purpose": "Toolbar Back + Publish buttons."
+			},
+			{
+				"import": "@wordpress/components#Spinner, Slot",
+				"purpose": "Loading indicator + plugin-extension slot — WPDS 0.12 has no Spinner or Slot port."
+			},
+			{
+				"import": "@wordpress/block-editor#BlockEditorProvider, BlockList, BlockTools, WritingFlow, ObserveTyping, BlockEditorKeyboardShortcuts",
+				"purpose": "The Gutenberg block-editor primitives. Inline-mounted (not iframed) so block styles inherit from the shell DOM."
+			},
+			{
+				"import": "@wordpress/block-library#registerCoreBlocks",
+				"purpose": "Register the ~30 core blocks at first mount (idempotent guard)."
+			},
+			{
+				"import": "@wordpress/blocks#parse, serialize, getBlockTypes",
+				"purpose": "Block tree (de)serialization between `record.content.raw` HTML and the React block array."
+			},
+			{
+				"import": "@wordpress/icons#arrowLeft",
+				"purpose": "Back button icon."
+			}
+		]
 	}
 }

--- a/src/apps/simple-editor/app.md
+++ b/src/apps/simple-editor/app.md
@@ -1,0 +1,42 @@
+# core:simple-editor
+
+Prose accompanying `app.json#documentation` for the inline minimal block editor.
+
+## Overview
+
+SimpleEditorApp is the Substack-style entry: title + a constrained block tree + auto-save. It exists to prove the kernel can host a block editor inline (not iframed), and to be the reference implementation for shells that want a writer-focused editor without the full `@wordpress/edit-post` surface (post settings, plugins panel, distraction-free mode, etc.). Composes Gutenberg's primitives directly: `BlockEditorProvider` + `BlockTools` + `WritingFlow` + `ObserveTyping` + `BlockList`. The block list renders in the shell's DOM tree so block styles inherit from the engine's ThemeProvider — no iframe boundary.
+
+## Architecture
+
+**Routing.** Same shape as EditorApp — `#/{segment}/{postId}/edit` mounts directly; `#/{segment}/new` creates a draft, captures the id, `history.replaceState`s to the existing-post URL. The `segment` is `posts` for `postType=post`, `pages` for `postType=page`.
+
+**Entity data.** `useEntityRecord('postType', postType, postId)` returns `{ record, editedRecord, edit, save, hasEdits, isSaving, isResolving }`. `edit({ title, content, status })` is the local-edit accumulator; `save()` flushes the accumulated edits to REST.
+
+**Block-tree hydration.** A one-shot — parse `record.content.raw` after the first record arrives, set the `hydrated` flag, never re-parse. Re-parsing on subsequent records updates would clobber in-progress edits. Block state lives in local `useState` so the BlockEditorProvider has a stable identity; `onChange` syncs serialized HTML back to the entity edit via `edit({ content })`.
+
+**Auto-save.** A single `setTimeout` ref scheduled on every change while `hasEdits`. Two-second debounce; if another edit lands first, the existing timer is cleared. Publish/Update flushes the pending timer + calls `save()` synchronously so there's no double-save race.
+
+**Status indicator.** The `saveStatus` state machine (`idle | saving | saved | error`) drives the toolbar status text. `saved` auto-fades back to `idle` after 2s via a second `setTimeout`.
+
+**Dirty-state.** `useDirtyState(regionId, hasEdits, { blocksNavigation: true })` reports unsaved-state to the kernel. The NavigationGuard component (shell-level) shows the standard "unsaved changes" confirmation on `beforeunload`, Navigation API, and intra-shell route changes.
+
+**Title input.** Native `<input type="text">` outside the block tree — not a "title block". Tab/Enter from the title focuses the first contenteditable in the body. The shell mounts the editor with `core:autofocus-target` pointing at this input so a fresh editor lands cursor-in-title.
+
+## Rebuild guide
+
+The Gutenberg primitives are tightly coupled — `BlockEditorProvider` expects a specific settings shape, block types must be registered against the global block-type registry, etc. A non-Gutenberg rebuild needs to replace the block tree wholesale (TipTap, Lexical, ProseMirror, Slate) and adopt the surrounding shell patterns:
+
+1. **Toolbar with back, status, save** — Stack of three controls. Back navigates to the list; status reflects save state; save is the primary action with `loading` indicator + label that flips between Publish/Update.
+2. **Title + body layout** — Native input for the title, rich-text editor below it. Tab/Enter from title focuses first body element.
+3. **Entity-record save semantics** — Local accumulator of edits + `save()` flush. Don't write to the server on every keystroke; batch via the auto-save timer.
+4. **Auto-save debounce** — Single timer ref, cancellable on flush. 2s feels about right; tighter risks spam, looser feels stale.
+5. **Dirty-state contract** — Report unsaved state to whatever NavigationGuard your host shell ships; block navigation when dirty.
+6. **Draft seed for new posts** — REST rejects empty-everything posts; seed a placeholder block (any non-empty content) so the auto-draft saves before the user types.
+
+## Known limitations
+
+- **Featured image, taxonomy, excerpt, scheduling** — out of scope for MVP. Future "post settings panel" adds them.
+- **Slot is exposed but no plugin contributes today.** `core:editor.sidebar` slot accepts `{ postId, postType, status }` fillProps; extensions would use this hook to add side panels without forking the app.
+- **Hydration is one-shot.** Reloading the record from elsewhere in the app (e.g. an external panel mutating status) would not re-parse the block tree. Edge case but worth flagging.
+- **Block library registers all ~30 core blocks** even though `allowedBlockTypes` restricts the slash menu to nine. A future iteration may switch to per-block lazy registration via `registerCoreBlock` to avoid loading unused blocks.
+- **`editedRecord.title` shape inconsistency** — sometimes a string (from a previous local edit), sometimes an object (from REST). The titleValue reader handles both; `core-data` should arguably normalize this.

--- a/src/apps/site-editor/app.json
+++ b/src/apps/site-editor/app.json
@@ -31,5 +31,59 @@
 		},
 		"multiInstance": false,
 		"icon": "layout"
+	},
+	"documentation": {
+		"purpose": "Stable identifier for the WordPress Site Editor screen, currently fronted by an iframe pointing at `site-editor.php`. Behind the namespace, the implementation is a one-line delegation to `IframeApp` so authors can target `core:site-editor` in admin.json today and inherit the native `@wordpress/edit-site` mount when it lands in a v2.x release — without touching their config.",
+		"rebuilds": "site-editor",
+		"data": {
+			"reads": [
+				{
+					"source": "window.wpAdminShell.adminUrl",
+					"via": "window-global",
+					"purpose": "Base URL passed to IframeApp."
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "loading",
+				"when": "iframe load event pending",
+				"renders": "Centered `Spinner` overlaid on the iframe."
+			},
+			{
+				"id": "ready",
+				"when": "iframe loaded",
+				"renders": "Full-bleed iframe with wp-admin chrome (admin menu, admin bar, footer) hidden by the injected CSS."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Mount",
+				"effect": "IframeApp renders `<iframe src=\"site-editor.php\">` and injects chrome-hiding CSS on load."
+			}
+		],
+		"a11y": {
+			"focus-management": "Iframe owns its own focus tree."
+		},
+		"constraints": [
+			{
+				"concern": "iframe-css-fragile",
+				"note": "Hides `edit-site-layout__sidebar*` + `edit-site-site-hub` + `edit-site-layout__header-container`; rev with each WordPress release. Verify Style Book canvas layout after upgrades."
+			},
+			{
+				"concern": "native-mount-blockers",
+				"note": "Top-of-file comment in `SiteEditorApp.js` lists five blockers: preferences-store collision (with `core:appearance`), command-palette double-registration (edit-site ships its own commands), full-screen-mode CSS, hash-router collision, and missing `@wordpress/edit-site` from BUNDLED_PACKAGES. All five must be resolved before native mount can land."
+			},
+			{
+				"concern": "stable-id-policy",
+				"note": "Authors target `core:site-editor` (not `core:iframe-fallback` with a hand-rolled URL) so the native-mount path can land in a v2.x release without admin.json migrations."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "../iframe-fallback#IframeApp",
+				"purpose": "Delegated rendering. Inherits IframeApp's DS dependencies (Spinner from @wordpress/components)."
+			}
+		]
 	}
 }

--- a/src/apps/site-editor/app.md
+++ b/src/apps/site-editor/app.md
@@ -1,0 +1,29 @@
+# core:site-editor
+
+Prose accompanying `app.json#documentation` for the Site Editor adapter.
+
+## Overview
+
+SiteEditorApp is a one-line delegation to `IframeApp` pointing at `site-editor.php` — but it ships under its own namespaced id because the **id is the contract**. Shells write `core:site-editor` in admin.json today; when the native `@wordpress/edit-site` mount lands in a v2.x release, the implementation changes behind the same id and no admin.json migrates.
+
+The native mount is blocked on five known issues (top-of-file comment in `SiteEditorApp.js`). Two of them — preferences-store collision with `core:appearance` and command-palette double-registration — are shell-architecture concerns. Two — full-screen CSS and hash-router collision — are edit-site internals fighting the shell's chrome and routing. One — `@wordpress/edit-site` not being in the dep-extraction `BUNDLED_PACKAGES` list — is a webpack config concern. All five must be resolved before the native mount can land safely.
+
+Until then, the iframe is the path. Users get the WordPress Site Editor with admin chrome stripped via injected CSS; the experience is "site editor inside a different shell" rather than "site editor inside wp-admin."
+
+## Rebuild guide
+
+If you're rebuilding this for a different framework: don't. The Site Editor is a substantial Gutenberg surface area; reimplementing it from scratch would be a project of its own, not a port of this 35-line file. The right move is one of:
+
+- Iframe the legacy `site-editor.php` (this app's pattern).
+- Embed `@wordpress/edit-site` directly once the five blockers are resolved.
+- Use a separate template/style editor that your design system natively supports (Tailwind config UI, Material theme builder, etc.).
+
+The stable-id pattern is worth preserving: ship the id, defer the implementation. Authors don't have to migrate when you ship the native mount later.
+
+## Known limitations
+
+All limitations are IframeApp's, plus:
+
+- **No Site Editor settings round-trip.** Templates, template parts, global styles changes happen entirely inside the iframe; the shell can't observe them.
+- **Save state is invisible.** The shell shows no "unsaved changes" indicator; that lives inside the iframed UI.
+- **Permalinks may navigate the iframe out from under us.** Site editor has its own routing; clicking a link inside the iframe doesn't update the shell URL.

--- a/src/apps/site-health/app.json
+++ b/src/apps/site-health/app.json
@@ -25,5 +25,91 @@
 		},
 		"multiInstance": false,
 		"icon": "wordpress"
+	},
+	"documentation": {
+		"purpose": "Runs WordPress's async site-health checks (`/wp-site-health/v1/tests/{id}`) in parallel on mount and on user re-run. Surfaces a per-test card with status (Good / Recommended / Critical) and a HTML description; the toolbar summarizes counts per category and offers a re-run button. Five tests today: WordPress.org communication, background updates, loopback requests, HTTPS status, authorization header.",
+		"rebuilds": "site-health",
+		"data": {
+			"reads": [
+				{
+					"source": "/wp-site-health/v1/tests/{id}",
+					"via": "api-fetch",
+					"purpose": "One request per test id; runs `Promise.all` over all five. Each returns `{ status, label, description }`."
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "running",
+				"when": "isRunning === true",
+				"renders": "Toolbar Re-run button shows loading; cards without results show Spinner."
+			},
+			{
+				"id": "partial",
+				"when": "isRunning && results has some entries",
+				"renders": "Cards already-completed show their status pill; remaining cards show Spinner."
+			},
+			{
+				"id": "complete",
+				"when": "!isRunning && results has all entries",
+				"renders": "All cards show status + description; toolbar shows category counts."
+			},
+			{
+				"id": "error",
+				"when": "error !== null",
+				"renders": "Error text below the toolbar (plus per-test error captured in results)."
+			},
+			{
+				"id": "per-test-error",
+				"when": "A test request rejected",
+				"renders": "That test's card shows status=critical with `err.message` as description."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Mount",
+				"effect": "`runTests()` fires automatically."
+			},
+			{
+				"trigger": "Click Re-run tests",
+				"effect": "Reset results + run all tests in parallel."
+			}
+		],
+		"a11y": {
+			"focus-management": "Native focus order — toolbar button + card content.",
+			"screen-reader": "Per-test status surfaces as a Badge with intent (`success` / `warning` / `error` / `neutral`). The badge text is the live status; no aria-live region announces completion."
+		},
+		"constraints": [
+			{
+				"concern": "trusted-html-description",
+				"note": "Test descriptions arrive as HTML from `/wp-site-health/v1/tests/{id}`. WordPress core authors these strings; we render via `dangerouslySetInnerHTML`. ESLint disable comment in source notes the trust boundary."
+			},
+			{
+				"concern": "promise-all-with-per-error-catch",
+				"note": "Each test's request is wrapped in try/catch so one failing test doesn't reject the `Promise.all`. Failed tests show as critical with the error message — preserves partial results."
+			},
+			{
+				"concern": "spinner-fallback",
+				"note": "Uses legacy `Spinner` from `@wordpress/components`."
+			},
+			{
+				"concern": "static-test-list",
+				"note": "Tests are hard-coded module-scope. WordPress site-health is plugin-extensible (`site_status_tests` filter); the shell doesn't yet honor this."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Badge, Button, Card, Stack, Text",
+				"purpose": "Status pills + cards + heading + re-run button."
+			},
+			{
+				"import": "@wordpress/components#Spinner",
+				"purpose": "Per-test loading indicator."
+			},
+			{
+				"import": "@wordpress/icons#update",
+				"purpose": "Re-run button icon."
+			}
+		]
 	}
 }

--- a/src/apps/site-health/app.md
+++ b/src/apps/site-health/app.md
@@ -1,0 +1,40 @@
+# core:site-health
+
+Prose accompanying `app.json#documentation` for the site-health runner.
+
+## Overview
+
+SiteHealthApp runs WordPress's async site-health checks and reports results in a card list. Each card shows the test label + status pill (Good / Recommended / Critical) + a description sourced from the REST response (which is HTML, written by WordPress core, and trusted accordingly). The toolbar summarizes results into three category counts; clicking Re-run resets results and fires the checks again in parallel.
+
+The interesting pattern is the **per-test error fallback**: each test's `apiFetch` is wrapped in its own try/catch inside the `Promise.all`. A failing test doesn't reject the whole batch — it just renders as critical with `err.message` as the description. This is the right call because site-health is a diagnostic surface; users want partial results when some checks fail.
+
+## Architecture
+
+Tests live in a module-scope `ASYNC_TESTS` array — five entries today (dotorg-communication, background-updates, loopback, https, auth-header). Each entry has an id + a translated label.
+
+`runTests`:
+
+1. Set `isRunning=true`, clear results, clear error.
+2. `Promise.all(ASYNC_TESTS.map(async t => { try { const res = await apiFetch(...); setResults(prev => ({ ...prev, [t.id]: res })) } catch (err) { setResults(prev => ({ ...prev, [t.id]: { status: 'critical', label: t.label, description: err.message } })) } }))`.
+3. Set `isRunning=false`.
+
+The per-test `setResults` calls are intentional — results stream in as each request completes rather than waiting for all five.
+
+Category counts: `Object.values(results).reduce((acc, r) => { if (r?.status && acc[r.status] !== undefined) acc[r.status] += 1; return acc; }, { good: 0, recommended: 0, critical: 0 })`. Bucket pattern with init values; trivial.
+
+## Rebuild guide
+
+Two patterns worth preserving:
+
+- **Partial-result reporting.** Most async-batch UIs reject the whole batch when one request fails. Site-health is the rare case where partial results are useful — wrap each request in try/catch and treat errors as data, not exceptions.
+- **Stream results as they arrive.** `setResults(prev => ({ ...prev, [id]: res }))` mounted per request beats `await Promise.all().then(setResults)` — the user sees progress.
+
+A non-WPDS rebuild needs Card, Badge (status pill with intent), Button, Spinner, and dangerously-set-HTML (or equivalent) for trusted descriptions.
+
+## Known limitations
+
+- **Static test list.** WordPress site-health has plugin-extensible tests via `site_status_tests` filter. The shell ignores plugin-contributed tests; a future iteration could enumerate them via a `/wp-site-health/v1/tests` index endpoint.
+- **No "Run all checks" / "Run only failing" granularity.** Always all-or-nothing.
+- **No direct-test runner.** WordPress has direct tests (synchronous PHP checks) shown alongside async tests; the shell only runs async tests.
+- **No history.** Re-running a test discards the previous result; no diff or trend over time.
+- **`view_site_health_checks` cap floor.** Subscribers can't see the screen. This matches wp-admin's behavior.

--- a/src/apps/site-hub/app.json
+++ b/src/apps/site-hub/app.json
@@ -13,5 +13,64 @@
 		"type": "object",
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Branded header at the top of the navigation sidebar. Renders site icon (linked to the dashboard URL) + site title (linked to the home URL, opens in new tab) + a command-palette toggle. Site icon respects `styles.branding.*` cascade values; site title comes from `useEntityRecord('root', 'site').record.title` with HTML-entity decoding and a window-global fallback.",
+		"data": {
+			"reads": [
+				{
+					"source": "root/site",
+					"via": "core-data",
+					"purpose": "Site title (decoded via `decodeEntities` from `@wordpress/html-entities`) + URL fallback for site-without-title case.",
+					"fields": [ "title", "url" ]
+				},
+				{
+					"source": "config.styles.branding",
+					"via": "core-data",
+					"purpose": "Branded site icon — branding object passed to SiteIcon helper."
+				},
+				{
+					"source": "window.wpAdminShell.siteName",
+					"via": "window-global",
+					"purpose": "Fallback for site title before core-data hydrates."
+				},
+				{
+					"source": "window.wpAdminShell.homeUrl | siteUrl | dashboardUrl",
+					"via": "window-global",
+					"purpose": "Anchor hrefs for the site-icon button (dashboard) and the site-title button (home, new tab)."
+				}
+			]
+		},
+		"states": [
+			{ "id": "ready", "when": "Always (renders with whatever data is available; falls back gracefully)", "renders": "Site icon + title + command-palette icon button. Title falls back to filterURLForDisplay(site.url) when title is empty but URL is set." },
+			{ "id": "transparent-icon", "when": "appConfig.isTransparent === true", "renders": "Site-icon container drops its background — useful when the engine's chrome already provides the surface." }
+		],
+		"interactions": [
+			{ "trigger": "Click site icon", "effect": "Navigate to `window.wpAdminShell.dashboardUrl` via native `<a href>`." },
+			{ "trigger": "Click site title", "effect": "Open `window.wpAdminShell.homeUrl` in a new tab via native `<a href target=\"_blank\" rel=\"noopener noreferrer\">`." },
+			{ "trigger": "Click command-palette icon", "effect": "`dispatch('core/commands').open()` — opens the global command palette." }
+		],
+		"a11y": {
+			"focus-management": "All three controls (icon, title, palette toggle) are native focusable elements.",
+			"keyboard": [
+				{ "keys": "Mod+K", "action": "Surfaced as the keyboard shortcut hint on the palette button (`displayShortcut.primary('k')`). The actual binding is shell-level — declared in admin.json's `bindings` block + wired through `useCommandLoader`." }
+			],
+			"screen-reader": "Site icon button has `aria-label=\"Go to the Dashboard\"`. Title button includes a visually-hidden `(opens in a new tab)` hint inside the link. Palette button has `aria-label=\"Open command palette\"` + `ariaKeyShortcut=\"Meta+K\"`."
+		},
+		"constraints": [
+			{ "concern": "site-title-source-of-truth", "note": "Read title via `useEntityRecord('root','site').record.title` (with `decodeEntities`). Falls back to `window.wpAdminShell?.siteName` only as last resort. Fixes a prior bug where the toolbar showed a stale title on first paint." },
+			{ "concern": "memoized-forwardref", "note": "Wrapped in `memo + forwardRef` because engines may attach refs (e.g. for measure-on-mount layout)." },
+			{ "concern": "ellipsis-in-flex", "note": "Title button uses the `display: flex; min-width: 0;` wrapper pattern + button-level `flex-grow: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap` so long site titles truncate cleanly in a constrained sidebar." },
+			{ "concern": "anchor-rendered-buttons", "note": "Site-icon button + site-title button + palette button all use `render={<a href={...}/>}` so native HTML link behavior works (middle-click new tab, etc.)." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/ui#Button, IconButton, Stack", "purpose": "Three controls + layout primitives." },
+			{ "import": "@wordpress/components#VisuallyHidden", "purpose": "Visually-hidden `(opens in a new tab)` hint." },
+			{ "import": "@wordpress/icons#search", "purpose": "Command-palette icon." },
+			{ "import": "@wordpress/commands#store", "purpose": "Open the global palette via `dispatch('core/commands').open()`." },
+			{ "import": "@wordpress/keycodes#displayShortcut", "purpose": "Format the `Mod+K` shortcut hint for the palette button." },
+			{ "import": "@wordpress/html-entities#decodeEntities", "purpose": "Decode site title HTML entities." },
+			{ "import": "@wordpress/url#filterURLForDisplay", "purpose": "Compact-URL fallback when site title is empty." }
+		]
+	}
 }

--- a/src/apps/site-hub/app.md
+++ b/src/apps/site-hub/app.md
@@ -1,0 +1,35 @@
+# core:site-hub
+
+Prose accompanying `app.json#documentation` for the site-hub header.
+
+## Overview
+
+SiteHubApp pins to the top of the navigation sidebar in the default engine. Three controls: site icon (→ dashboard), site title (→ home URL, new tab), command-palette toggle. The role is `banner` (ARIA landmark for the site identity surface).
+
+The title-source-of-truth distinction matters: `useEntityRecord('root','site').record.title` is the canonical source; `window.wpAdminShell.siteName` is a fallback for the brief window before core-data hydrates. A prior bug had the site-hub render the window-global value indefinitely, missing user-edits from the settings page until refresh.
+
+## Architecture
+
+`memo + forwardRef` wrapping is deliberate. Engines may attach refs to measure the hub's rendered size for layout calculations; the forwardRef keeps that contract usable. `memo` is a defensive optimization — the hub re-renders on every kernel state change otherwise.
+
+`SiteIcon` (sibling helper) renders the branded icon — reads `styles.branding.*` from the cascade and resolves to whatever asset path is set, or falls back to a default WordPress mark.
+
+The ellipsis-in-flex pattern for the title is the one CLAUDE.md calls out: `display: flex; min-width: 0;` on the wrapper + `flex-grow: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap` on the Button. Both halves are required — WPDS Button is `inline-flex` by default; the wrapper's `min-width: 0` overrides the default `min-width: auto`; the wrapper's `display: flex` makes the Button's `flex-grow` actually stretch.
+
+All three controls use `render={<a href={...}/>}` so they're real anchors. WPDS Button + IconButton drop `href` silently otherwise.
+
+## Rebuild guide
+
+A non-WPDS rebuild needs:
+
+- An anchor-rendering button primitive (or just `<a>` styled to look like a button).
+- A clipboard / command-palette integration. The shell uses `@wordpress/commands` for the open() dispatch; rebuilds must wire to whatever palette they ship.
+- HTML-entity decoding for the site title. WordPress stores entities (`&amp;`) and serves them rendered; raw display would show the entities.
+- Ellipsis-in-flex CSS for the title. Without it, long titles overflow the sidebar width.
+
+## Known limitations
+
+- **Site icon doesn't honor `site_icon` REST field.** It uses the engine's branding cascade. A future iteration could fall back to the REST `site_icon` URL when no engine branding is configured.
+- **No notification badge.** wp-admin shows update counts as a badge on the admin bar; the shell omits this here.
+- **Command palette shortcut is shell-level.** The `Mod+K` binding is declared in admin.json's `bindings` block, not by this app. The hub only renders the shortcut hint.
+- **`isTransparent` prop is engine-specific.** Single-pane engine uses it; default engine doesn't. Documented as a per-engine convention rather than a stable contract.

--- a/src/apps/taxonomy/app.json
+++ b/src/apps/taxonomy/app.json
@@ -31,5 +31,167 @@
 		},
 		"multiInstance": true,
 		"icon": "tag"
+	},
+	"documentation": {
+		"purpose": "DataViews-driven manager for any WordPress taxonomy. Defaults to `category`; rebind via the `taxonomy` config key for `post_tag` or any custom taxonomy. Authors can list (with search, sort, pagination), create, edit (in a modal with name / slug / description fields), and bulk delete terms. Replaces wp-admin's `edit-tags.php` for the configured taxonomy.",
+		"rebuilds": "taxonomies",
+		"data": {
+			"reads": [
+				{
+					"source": "taxonomy/{config.taxonomy}",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Term rows in the DataViews table.",
+					"fields": [
+						"id",
+						"name",
+						"slug",
+						"count",
+						"description",
+						"parent"
+					],
+					"query": {
+						"per_page": "view.perPage",
+						"page": "view.page",
+						"order": "view.sort.direction",
+						"orderby": "view.sort.field",
+						"context": "edit",
+						"hide_empty": false,
+						"search": "view.search"
+					}
+				}
+			],
+			"writes": [
+				{
+					"source": "taxonomy/{config.taxonomy}",
+					"via": "core-data",
+					"operation": "create",
+					"purpose": "Add a new term via the Add new modal.",
+					"invalidates": [
+						"taxonomy/{config.taxonomy}"
+					]
+				},
+				{
+					"source": "taxonomy/{config.taxonomy}",
+					"via": "core-data",
+					"operation": "update",
+					"purpose": "Edit an existing term (name / slug / description).",
+					"invalidates": [
+						"taxonomy/{config.taxonomy}"
+					]
+				},
+				{
+					"source": "taxonomy/{config.taxonomy}",
+					"via": "core-data",
+					"operation": "delete",
+					"purpose": "Bulk-delete terms permanently (`force: true` — taxonomies have no trash).",
+					"invalidates": [
+						"taxonomy/{config.taxonomy}"
+					]
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "loading",
+				"when": "isResolving && !records",
+				"renders": "DataViews loading indicator."
+			},
+			{
+				"id": "ready",
+				"when": "records !== null && records.length > 0",
+				"renders": "Table of terms with row + bulk actions."
+			},
+			{
+				"id": "empty",
+				"when": "records?.length === 0",
+				"renders": "DataViews empty state."
+			},
+			{
+				"id": "editing",
+				"when": "editTerm !== null",
+				"renders": "Modal with name / slug / description fields populated from the term."
+			},
+			{
+				"id": "creating",
+				"when": "isCreating === true",
+				"renders": "Same modal with empty fields and Add term button."
+			},
+			{
+				"id": "saving",
+				"when": "isSaving === true (inside modal)",
+				"renders": "Save button shows loading spinner; inputs stay editable."
+			},
+			{
+				"id": "delete-confirm",
+				"when": "User triggered Delete action",
+				"renders": "Confirm modal with destructive primary button."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click Add new",
+				"effect": "Open the term modal in create mode."
+			},
+			{
+				"trigger": "Click row name or Edit action",
+				"effect": "Open the term modal in edit mode pre-filled from `item.rawRecord`."
+			},
+			{
+				"trigger": "Submit term modal",
+				"effect": "`saveEntityRecord('taxonomy', taxonomy, payload)`; on success: success snackbar + invalidate `getEntityRecords` + close modal. On failure: error notice (dismissible)."
+			},
+			{
+				"trigger": "Click Delete action (single or bulk)",
+				"effect": "Open confirm modal; on confirm `deleteEntityRecord(..., { force: true })` for each item + invalidate + success snackbar."
+			},
+			{
+				"trigger": "Change view (search / sort / page / perPage)",
+				"effect": "Local `view` updates; queryArgs recomputes; records refetch."
+			}
+		],
+		"a11y": {
+			"focus-management": "DataViews owns focus inside the table. The legacy `Modal` traps focus; on close, DataViews restores focus to the trigger."
+		},
+		"constraints": [
+			{
+				"concern": "dataviews-import-path",
+				"note": "Import from `@wordpress/dataviews/wp`."
+			},
+			{
+				"concern": "force-delete",
+				"note": "Taxonomies have no trash. `deleteEntityRecord` must pass `{ force: true }` or the request 400s."
+			},
+			{
+				"concern": "modal-fallback",
+				"note": "Uses legacy `Modal` from `@wordpress/components` because WPDS 0.12's Dialog is not a clean port for complex form modals."
+			},
+			{
+				"concern": "textarea-fallback",
+				"note": "Uses legacy `TextareaControl` — WPDS 0.12 has no TextareaControl port."
+			},
+			{
+				"concern": "invalidate-after-mutate",
+				"note": "Both create + update + delete must call `invalidateResolution('getEntityRecords', ['taxonomy', taxonomy])` — `saveEntityRecord` does not bust the parent query."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/dataviews/wp#DataViews",
+				"purpose": "Table view with sort/pagination/actions."
+			},
+			{
+				"import": "@wordpress/ui#Button, Stack, Text, InputControl",
+				"purpose": "Header, modal layout, name + slug inputs."
+			},
+			{
+				"import": "@wordpress/components#Button (as DestructiveButton), Modal, TextareaControl",
+				"purpose": "Destructive confirm action, modal container, multiline description input — WPDS 0.12 gaps."
+			},
+			{
+				"import": "@wordpress/icons#plus, pencil, trash",
+				"purpose": "Add / row / delete action icons."
+			}
+		]
 	}
 }

--- a/src/apps/taxonomy/app.md
+++ b/src/apps/taxonomy/app.md
@@ -1,0 +1,37 @@
+# core:taxonomy
+
+Prose accompanying `app.json#documentation` for the taxonomy term manager.
+
+## Overview
+
+TaxonomyApp manages categories, tags, and any custom taxonomy through a single DataViews table + modal pair. The default mount targets `category`; shells that want to surface multiple taxonomies mount the app once per taxonomy with different `config.taxonomy` values (and optionally a `config.title` override for the page heading). The default `DEFAULT_TAXONOMY_LABEL` map handles `category` / `post_tag` naming; custom taxonomies fall back to the raw slug unless `config.title` is provided.
+
+## Architecture
+
+Three state slots:
+
+1. **`view`** — DataViews controlled state (same shape as PostsApp).
+2. **`editTerm`** — the term currently being edited, or `null` when not editing. Set from the table by clicking a row name or the Edit action.
+3. **`isCreating`** — boolean flag for the create variant of the same modal.
+
+The modal (`TermEditModal`) is rendered conditionally when `editTerm || isCreating`. It uses a single component for both create + edit because the field set is identical — only the `id` payload field and the submit button label differ. Form state lives inside the modal via `useState`, which is the right call here: the parent doesn't need to observe in-progress edits, and the modal unmounts on close so state cleanup is free.
+
+Notice routing: success messages go through `@wordpress/notices` as snackbars (auto-dismiss), failures as dismissible banners. The `notices-snackbar` + `notices-banner` apps render them in their respective regions.
+
+## Rebuild guide
+
+Reuses the same primitives as PostsApp (DataViews + destructive modal). The unique addition is the **form modal pattern**:
+
+- Modal wraps a column of inputs (name, slug, description).
+- Save button is `loading` while the request is in flight, `disabled` until name is non-empty.
+- On success, parent invalidates the parent query *and* fires a snackbar notice via `@wordpress/notices`.
+- On error, parent fires a dismissible banner notice — error message comes from `err.message` with a fallback.
+
+A non-WPDS rebuild needs: a Modal/Dialog component (focus trap + Esc close + backdrop), text + textarea inputs, a save button with a loading state, and a notice bus equivalent.
+
+## Known limitations
+
+- Hierarchical taxonomies (categories) ignore `parent`. Term creation always lands at the root; editing surfaces no parent picker. A future iteration would add a tree-picker for hierarchical taxonomies.
+- No bulk update — only bulk delete.
+- The slug field is editable on edit but the REST endpoint may renormalize it server-side. We don't reflect the normalized value back into the form after save.
+- Term content count (`count`) is read-only; clicking it does not filter posts by the term.

--- a/src/apps/themes/app.json
+++ b/src/apps/themes/app.json
@@ -25,5 +25,121 @@
 		},
 		"multiInstance": false,
 		"icon": "layout"
+	},
+	"documentation": {
+		"purpose": "Grid view of installed themes with screenshot + activate / details actions. The active theme floats to the front; the remainder sorts alphabetically. Activation uses a custom `/wp-admin-shell/v1/activate-theme` endpoint with a graceful fall-back to wp-admin's `themes.php?action=activate` link if the endpoint is missing. Details modal surfaces description + version + author + theme-site link.",
+		"rebuilds": "themes",
+		"data": {
+			"reads": [
+				{
+					"source": "root/theme",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Installed themes (active + inactive).",
+					"fields": [
+						"stylesheet",
+						"name.rendered",
+						"description.rendered",
+						"version",
+						"author.rendered",
+						"screenshot",
+						"status",
+						"theme_uri"
+					],
+					"query": {
+						"context": "edit",
+						"status": "active,inactive"
+					}
+				},
+				{
+					"source": "window.wpAdminShell.activeTheme",
+					"via": "window-global",
+					"purpose": "Fallback for active stylesheet lookup before core-data hydrates."
+				}
+			],
+			"writes": [
+				{
+					"source": "/wp-admin-shell/v1/activate-theme",
+					"via": "api-fetch",
+					"operation": "custom",
+					"purpose": "Switch the active theme via the shell's custom endpoint.",
+					"invalidates": [
+						"root/theme"
+					]
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "loading",
+				"when": "isLoading || !themes",
+				"renders": "Centered `Spinner` covering the panel."
+			},
+			{
+				"id": "ready",
+				"when": "themes !== null",
+				"renders": "Header (count) + 3-column grid of theme cards. Active card has an Active badge; non-active cards show Activate button."
+			},
+			{
+				"id": "details-open",
+				"when": "details !== null",
+				"renders": "Modal with large screenshot + description + version / author + Theme site / Activate buttons."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click Details on a theme card",
+				"effect": "Open the details modal with that theme."
+			},
+			{
+				"trigger": "Click Activate on a theme card",
+				"effect": "POST `/wp-admin-shell/v1/activate-theme` with `{ stylesheet }`; on success invalidate `root/theme` + close any open modal. On failure: `window.location.href` to `themes.php?action=activate&stylesheet=...` so the user falls back to wp-admin.",
+				"guards": [
+					"theme.stylesheet !== activeStylesheet"
+				]
+			},
+			{
+				"trigger": "Click Theme site in details",
+				"effect": "`window.open(theme.theme_uri, '_blank')`.",
+				"guards": [
+					"!!theme.theme_uri"
+				]
+			}
+		],
+		"a11y": {
+			"focus-management": "Legacy `Modal` traps focus while open. After close (via Esc or backdrop click) focus returns to the trigger button."
+		},
+		"constraints": [
+			{
+				"concern": "no-core-rest-theme-switch",
+				"note": "WordPress core REST does not expose a theme-switch operation. The shell ships a custom `/wp-admin-shell/v1/activate-theme` endpoint; rebuilds must provide the equivalent or implement the wp-admin link fall-back."
+			},
+			{
+				"concern": "graceful-fallback",
+				"note": "If the custom endpoint 404s (older shell version or stripped feature), the app navigates to wp-admin's `themes.php` flow so the user can complete the action — preserves the right outcome even without the optimized path."
+			},
+			{
+				"concern": "modal-fallback",
+				"note": "Uses legacy `Modal` from `@wordpress/components`; WPDS Dialog 0.12 lacks size variants."
+			},
+			{
+				"concern": "grid-fallback",
+				"note": "Uses `__experimentalGrid` — no WPDS 0.12 port."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Button, Card, Stack, Text",
+				"purpose": "Theme card layout, header, action buttons."
+			},
+			{
+				"import": "@wordpress/components#__experimentalGrid, CardMedia, Spinner, Modal",
+				"purpose": "Grid layout, screenshot media slot, loading spinner, details modal — all WPDS 0.12 gaps."
+			},
+			{
+				"import": "@wordpress/icons#check, external",
+				"purpose": "Action icons."
+			}
+		]
 	}
 }

--- a/src/apps/themes/app.md
+++ b/src/apps/themes/app.md
@@ -1,0 +1,40 @@
+# core:themes
+
+Prose accompanying `app.json#documentation` for the themes browser.
+
+## Overview
+
+ThemesApp surfaces every installed theme as a 3-column card grid with screenshot + name + truncated description, and a per-card actions row (Details, Activate when non-active). The active theme floats to the front of the grid; the remainder sorts alphabetically by name. Activation uses an out-of-band custom endpoint because WordPress core REST does not expose a theme-switch operation natively — and falls back to wp-admin's classic activate link when the endpoint is missing.
+
+This **graceful-fallback** pattern is the most interesting thing here: when an optimized native path can't be guaranteed (custom endpoint missing, plugin gated, etc.), the right answer is often "navigate the user back into wp-admin to complete the action" rather than failing loudly. The user gets the correct outcome with one extra page load — preferable to a broken Activate button.
+
+## Architecture
+
+`sorted` is a derived `useMemo` over `themes` that puts the active theme first and sorts the rest by name. `activeStylesheet` is read from the records first, then falls back to `window.wpAdminShell.activeTheme` for the brief window before core-data hydrates.
+
+`details` holds `{ theme, isActive }` — a small object so the modal can render Activate buttons that aren't disabled when the user lands directly via details for the current active theme.
+
+The activate handler:
+
+1. Tries POST `/wp-admin-shell/v1/activate-theme` `{ stylesheet }`.
+2. On success: `invalidateResolution` on the theme query + close any open details modal.
+3. On failure: `window.location.href = adminUrl + 'themes.php?action=activate&stylesheet=...'` — the user lands in wp-admin's flow.
+
+The custom endpoint is implemented on the PHP side (out of scope of this doc); rebuilds in other frameworks need their own.
+
+## Rebuild guide
+
+For a non-WPDS rebuild:
+
+- Cards: any 3-column grid + media + content layout. Tailwind `grid-cols-3 gap-4` works directly.
+- Details modal: a sizable modal with a media slot. Don't load the screenshot at full resolution unless the modal is open.
+- Activation: either implement a server-side switch endpoint or fall back to wp-admin's `themes.php?action=activate&stylesheet=...` link with `_wpnonce` (note: nonce flow needs care; the shell's endpoint avoids this by relying on REST capability checks).
+- Sort: active first, then alphabetical.
+
+## Known limitations
+
+- No install / upload flow. Adding themes happens in wp-admin.
+- No theme preview (live preview via Customizer or block-theme preview).
+- The screenshot URL is loaded directly from the theme record; large screenshots are not lazy-loaded.
+- Description truncation is hard 140 chars. No "read more" affordance — long descriptions live in the details modal.
+- The fallback URL flow loses the user's place in the shell; we don't restore it on return.

--- a/src/apps/toolbar-actions/app.json
+++ b/src/apps/toolbar-actions/app.json
@@ -21,5 +21,37 @@
 		},
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Toolbar layout: two horizontal IconButton clusters separated by a `flex: 1` spacer. Renders nothing if both `left` + `right` arrays are empty. Each action is either `{ href, icon, label, external? }` (link) or `{ command, icon, label }` (built-in command resolved via `COMMAND_HREFS` map). IconButton uses `render={<a href>}` so middle-click + right-click → Copy link work natively.",
+		"data": {
+			"reads": [
+				{
+					"source": "config.left + config.right",
+					"via": "core-data",
+					"purpose": "Action descriptors — declared inline in admin.json."
+				}
+			]
+		},
+		"states": [
+			{ "id": "empty", "when": "Both arrays empty", "renders": "Nothing (return null)." },
+			{ "id": "ready", "when": "At least one action", "renders": "Row layout — left cluster + spacer + right cluster." }
+		],
+		"interactions": [
+			{ "trigger": "Click an action", "effect": "Native anchor navigation. External actions open in new tab." },
+			{ "trigger": "Middle-click / Cmd-click", "effect": "Native browser behavior — opens in new tab. Works because IconButton renders as `<a>`." }
+		],
+		"a11y": {
+			"focus-management": "Native anchor focus order.",
+			"screen-reader": "IconButton's `label` prop doubles as the assistive-tech label and the tooltip."
+		},
+		"constraints": [
+			{ "concern": "command-href-map", "note": "`COMMAND_HREFS` translates legacy `command` ids (`core/new-post`, `core/new-page`) to hash URLs. Adding more requires updating the table." },
+			{ "concern": "iconbutton-anchor-render", "note": "Render-prop swap is required: `<IconButton render={<a href target rel/>}/>`. The plain `href` prop is dropped by Base UI Button." },
+			{ "concern": "no-onclick-actions", "note": "All actions resolve to URLs. There's no `onClick`-only callback action — keep dispatching to `core:command-palette` or a separate app for command-style invocations." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/ui#IconButton, Stack", "purpose": "Toolbar buttons + layout primitives." }
+		]
+	}
 }

--- a/src/apps/toolbar-actions/app.md
+++ b/src/apps/toolbar-actions/app.md
@@ -1,0 +1,26 @@
+# core:toolbar-actions
+
+Prose accompanying `app.json#documentation` for the toolbar action clusters.
+
+## Overview
+
+ToolbarActionsApp is a thin renderer over `config.left[]` + `config.right[]`. Each entry is either a plain link descriptor or a built-in command id translated through a `COMMAND_HREFS` map. The app contributes nothing dynamic — no data fetching, no state — but is bundled separately so shells can mount it once or many times depending on their toolbar layout needs.
+
+The `command` shape exists for back-compat with admin.json v1 — early shells declared `{ command: 'core/new-post' }` and the kernel resolved it. v2 prefers `{ href: '#/posts/new' }` directly; the `command` shape stays as a translation layer.
+
+## Architecture
+
+`renderAction` resolves `href = action.href || COMMAND_HREFS[action.command]`. Missing both → render null (the action silently disappears). External actions add `target="_blank"` + `rel="noopener noreferrer"` to the rendered anchor.
+
+The spacer between left + right is `<div style={{flex: 1}}/>`. Could be a CSS-only solution via `justify-content: space-between` on the outer Stack, but the explicit spacer makes the two-cluster layout intent obvious.
+
+## Rebuild guide
+
+Trivial port. Two arrays of action descriptors, render each as an anchor-styled button. The only subtle bit is the **anchor-render pattern** — buttons that need real anchor semantics (middle-click new-tab) must render as `<a>`, not as `<button>` with an onClick + `window.location.href`. Reuse the host framework's link primitive (React Router `Link`, Next `Link`) when the navigation is internal.
+
+## Known limitations
+
+- **No onClick actions.** Everything resolves to a URL. Apps that need to dispatch commands (open a modal, trigger a save) must do so through `core:command-palette` or their own app.
+- **`COMMAND_HREFS` is hard-coded.** Two entries today; adding a new command alias means editing this file.
+- **No grouping within a cluster.** The left + right clusters are flat. A future iteration could add `{ group: 'New', items: [...] }` shapes mirroring NavigationApp's pattern.
+- **No active state.** Toolbar actions don't get `aria-current` — they're outbound links, not nav items.

--- a/src/apps/tools/app.json
+++ b/src/apps/tools/app.json
@@ -22,5 +22,67 @@
 		},
 		"multiInstance": false,
 		"icon": "tool"
+	},
+	"documentation": {
+		"purpose": "Landing screen for the Tools navigation entry. Renders a 2-column grid of cards, one per available tool. Each card opens either a sibling shell app (Site Health → `#/site-health`) or a wp-admin page (Import, Export, Export Personal Data, Erase Personal Data — all four still link out to `import.php`, `export.php`, etc. because the wp-admin equivalents have no REST surface and no v2 native equivalent yet).",
+		"rebuilds": "tools",
+		"data": {
+			"reads": [
+				{
+					"source": "window.wpAdminShell.adminUrl",
+					"via": "window-global",
+					"purpose": "Base URL for legacy wp-admin links."
+				}
+			]
+		},
+		"url": {
+			"navigates": [
+				"#/site-health"
+			]
+		},
+		"states": [
+			{
+				"id": "ready",
+				"when": "Always (no data dependencies)",
+				"renders": "Header + 2-column card grid with five tool cards."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click Open on a tool card with `appId`",
+				"effect": "`navigate('site-health')` (or whichever tool's app id)."
+			},
+			{
+				"trigger": "Click Open on a tool card with `legacy`",
+				"effect": "`window.location.href = adminUrl + tool.legacy` — leaves the shell into wp-admin."
+			}
+		],
+		"a11y": {
+			"focus-management": "Native button focus order."
+		},
+		"constraints": [
+			{
+				"concern": "legacy-link-fallback",
+				"note": "Import / Export / Personal Data Export / Personal Data Erase have no REST coverage and no native v2 app yet. Their cards navigate out to wp-admin and lose the user's place in the shell."
+			},
+			{
+				"concern": "static-tool-list",
+				"note": "Tools list is hard-coded — plugins cannot inject tool cards. A future iteration may add a filter / registry once the surface stabilizes."
+			},
+			{
+				"concern": "grid-fallback",
+				"note": "Uses `__experimentalGrid` — no WPDS 0.12 port."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/ui#Button, Card, Stack, Text",
+				"purpose": "Card layout + open buttons."
+			},
+			{
+				"import": "@wordpress/components#__experimentalGrid",
+				"purpose": "2-column responsive grid — WPDS 0.12 gap."
+			}
+		]
 	}
 }

--- a/src/apps/tools/app.md
+++ b/src/apps/tools/app.md
@@ -1,0 +1,24 @@
+# core:tools
+
+Prose accompanying `app.json#documentation` for the tools landing.
+
+## Overview
+
+ToolsApp is a card grid of links. Five tools today: Site Health (native v2 app), Import, Export, Export Personal Data, Erase Personal Data (four legacy wp-admin links). Each card has a title, a sentence-long description, and an Open button that either navigates to a sibling shell app or hard-navigates to wp-admin's classic page.
+
+This is the simplest fully-static app in the shell — no data fetching, no state machine, no async. It exists to give the Tools navigation entry a landing screen instead of a 404.
+
+## Architecture
+
+The `TOOLS` array is module-scope. Each entry has `{ id, title, description, appId | legacy }`. The card click handler branches: `appId` → `navigate(tool.appId)`, `legacy` → `window.location.href = adminUrl(tool.legacy)`.
+
+## Rebuild guide
+
+Trivial port. Card + grid + button primitives are universal; the only project-specific bit is the URL resolution helper for legacy links. Reuse your host's link primitive (React Router `Link`, Next `Link`) instead of `window.location.href` where the navigation is internal — `legacy` links cross out of the shell so plain `<a>` or `window.location.href` is correct.
+
+## Known limitations
+
+- **Plugins can't inject tools.** WordPress core has hooks like `update_management_pages` for plugins to add tool entries; the shell doesn't honor any.
+- **Legacy links lose place.** Clicking Import / Export navigates fully out of the shell. The user has to find their way back via browser back or the toolbar.
+- **No description-action distinction.** Cards have title + description + Open button; no row-action menu or secondary action.
+- **Hard-coded tool list.** Adding a new tool requires editing this file. A `wp_admin_shell_register_tool` filter would be the natural extension.

--- a/src/apps/user-menu/app.json
+++ b/src/apps/user-menu/app.json
@@ -13,5 +13,46 @@
 		"type": "object",
 		"additionalProperties": false
 	},
-	"script": "wp-admin-shell"
+	"script": "wp-admin-shell",
+	"documentation": {
+		"purpose": "Acting-user affordance: avatar trigger that opens a DropdownMenu with three controls (Profile, optional Switch shell submenu, Log out). All data sourced from `window.wpAdminShell.user` (displayName, avatarUrl, profileUrl, logoutUrl) + `window.wpAdminShell.shells` (for the switcher submenu). Shell switcher only renders when more than one `userSwitchable` shell is available; calls `window.wpAdminShell.switchShell(slug)` which posts the new active shell + reloads.",
+		"data": {
+			"reads": [
+				{
+					"source": "window.wpAdminShell.user",
+					"via": "window-global",
+					"purpose": "Display name, avatar URL, profile URL, logout URL."
+				},
+				{
+					"source": "window.wpAdminShell.shells",
+					"via": "window-global",
+					"purpose": "Available shells (with `userSwitchable` flag) for the switcher submenu."
+				}
+			]
+		},
+		"states": [
+			{ "id": "ready-no-switcher", "when": "shells.length <= 1 || no userSwitchable", "renders": "Avatar trigger + dropdown with Profile + Log out." },
+			{ "id": "ready-with-switcher", "when": "More than one userSwitchable shell", "renders": "Same dropdown plus `Switch to {title}` entries between Profile and Log out." }
+		],
+		"interactions": [
+			{ "trigger": "Click avatar", "effect": "Open dropdown." },
+			{ "trigger": "Click Profile", "effect": "`window.location.hash = profileUrl` (or `#/profile`)." },
+			{ "trigger": "Click Switch to {title}", "effect": "Call `window.wpAdminShell.switchShell(slug)` — PHP saves new active shell + page reloads." },
+			{ "trigger": "Click Log out", "effect": "`window.location.href = logoutUrl`." }
+		],
+		"a11y": {
+			"focus-management": "DropdownMenu handles focus trap when open. Avatar has `aria-label={displayName}`.",
+			"screen-reader": "Avatar `<img>` carries empty `alt=\"\"` (decorative — the `aria-label` on the toggle is the accessible name)."
+		},
+		"constraints": [
+			{ "concern": "window-global-only", "note": "Doesn't fetch user data via core-data — `wpAdminShell.user` is injected PHP-side at every page load. Cheaper than a REST round trip; safe because user identity is fixed for the session." },
+			{ "concern": "shell-switch-reloads", "note": "Switching shells does a full page reload (PHP-side option write + reload). No SPA-style live switch; the alternative would require unmounting + remounting the entire shell, which has tricky edge cases (modal state, in-flight saves)." },
+			{ "concern": "dropdown-fallback", "note": "Uses legacy `DropdownMenu` from `@wordpress/components`. WPDS 0.12 has no direct port; `Tabs.*` + `Popover.*` could compose one but `DropdownMenu` is more semantic." },
+			{ "concern": "default-profile-hash", "note": "`profileUrl` defaults to `#/profile` if missing. Shells that omit a `#/profile` route from their map will render the link, but clicking it 404s." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/components#DropdownMenu", "purpose": "Avatar trigger + items + submenu — no WPDS 0.12 port." },
+			{ "import": "@wordpress/icons#moreVertical", "purpose": "Fallback trigger icon when no avatar URL." }
+		]
+	}
 }

--- a/src/apps/user-menu/app.md
+++ b/src/apps/user-menu/app.md
@@ -1,0 +1,33 @@
+# core:user-menu
+
+Prose accompanying `app.json#documentation` for the user menu.
+
+## Overview
+
+UserMenuApp is the avatar dropdown that lives in the toolbar or topbar. Three controls: Profile, optional shell switcher, Log out. All data sourced from `window.wpAdminShell.user` + `window.wpAdminShell.shells` — both injected PHP-side at page load. No REST round trip; user identity is fixed for the session.
+
+The shell switcher is conditional: it surfaces only when more than one `userSwitchable` shell is available. Switching shells posts the new active shell to PHP and reloads the page. Full-reload was chosen over SPA-style live switch because the alternative requires unmounting + remounting the entire kernel (preserving in-flight saves, modal state, etc.) and the trade-off didn't pay back.
+
+## Architecture
+
+Trivial — read user, derive `controls` array, hand to `DropdownMenu`. Each control is `{ title, onClick }`. The shell switcher loops over `userSwitchable` shells and adds one entry per shell. `controls` is memoized but the dependency list (`profileUrl, logoutUrl, showShellSwitcher, switchableShells`) doesn't change often in practice.
+
+`DropdownMenu` is legacy (`@wordpress/components`) — WPDS 0.12 has no direct port. The Tabs + Popover primitives could compose one, but `DropdownMenu` is more semantic.
+
+## Rebuild guide
+
+A non-WPDS rebuild needs a dropdown menu primitive that:
+
+- Trigger renders user-provided content (avatar `<img>` or fallback icon).
+- Items support click handlers (no sub-menu navigation needed for this app).
+- Focus trap when open; Esc + outside-click dismiss.
+
+Beyond that, the data wiring is plain JS — read from a config global, derive the items array, render.
+
+## Known limitations
+
+- **No notification surface.** WordPress wp-admin's user dropdown is a single "Howdy, Name" link; the shell version is richer but doesn't carry update-counts or messages.
+- **Avatar `<img>` is plain.** No fallback letter on broken URLs, no Gravatar size optimization, no dark-mode-aware default.
+- **`profileUrl` default is naive.** Falls back to `#/profile` regardless of whether the shell actually mounts a profile app at that route.
+- **Shell switch reloads.** No optimistic UI; the user sees the full-page transition.
+- **No "Account settings" or "API tokens".** Single Profile entry covers everything user-related — fine for now, may need expanding when more user-scoped surfaces land.

--- a/src/apps/users/app.json
+++ b/src/apps/users/app.json
@@ -25,5 +25,140 @@
 		},
 		"multiInstance": false,
 		"icon": "people"
+	},
+	"documentation": {
+		"purpose": "DataViews table of WordPress users with permanent bulk delete (content reassigned to the acting user). Lists name + username, email, roles, and registered date. Search hits name + email. Filter by role. The DataViews `RenderModal` for the destructive action ships a self-delete guard that strips the acting user from the target set before issuing the REST call.",
+		"rebuilds": "users",
+		"data": {
+			"reads": [
+				{
+					"source": "root/user",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "User rows in the DataViews table. `context: 'edit'` is required for email + roles to be present.",
+					"fields": [
+						"id",
+						"name",
+						"username",
+						"email",
+						"roles",
+						"registered_date"
+					],
+					"query": {
+						"per_page": "view.perPage",
+						"page": "view.page",
+						"order": "view.sort.direction",
+						"orderby": "view.sort.field|registered_date",
+						"context": "edit",
+						"search": "view.search",
+						"roles": "filter.roles"
+					}
+				},
+				{
+					"source": "window.wpAdminShell.userId",
+					"via": "window-global",
+					"purpose": "Identify the acting user so self-delete is blocked + content reassignment target is set."
+				}
+			],
+			"writes": [
+				{
+					"source": "root/user",
+					"via": "core-data",
+					"operation": "delete",
+					"purpose": "Bulk-delete users permanently with content reassigned to the acting user (`force: true, reassign: currentUserId`).",
+					"invalidates": [
+						"root/user"
+					]
+				}
+			]
+		},
+		"states": [
+			{
+				"id": "loading",
+				"when": "isResolving && !records",
+				"renders": "DataViews loading indicator."
+			},
+			{
+				"id": "ready",
+				"when": "records !== null && records.length > 0",
+				"renders": "Table of users with Delete bulk action."
+			},
+			{
+				"id": "empty",
+				"when": "records?.length === 0",
+				"renders": "DataViews empty state."
+			},
+			{
+				"id": "delete-confirm",
+				"when": "User triggered Delete action",
+				"renders": "Confirm modal. Copy varies by target count and whether the acting user is in the selection."
+			},
+			{
+				"id": "delete-self-only",
+				"when": "Modal opened but `targets` is empty after self-filter",
+				"renders": "Cannot-delete-yourself message; destructive button is disabled."
+			}
+		],
+		"interactions": [
+			{
+				"trigger": "Click Delete action (single or bulk)",
+				"effect": "Open confirm modal with copy adjusted for target count + self-skipped marker."
+			},
+			{
+				"trigger": "Confirm delete",
+				"effect": "Filter out the acting user, dispatch `deleteEntityRecord` per target with `{ force: true, reassign: currentUserId }`, `invalidateResolution` on the user query, success snackbar.",
+				"guards": [
+					"targets.length > 0",
+					"currentUserId !== item.id"
+				]
+			},
+			{
+				"trigger": "Change view (search / filter / sort / page)",
+				"effect": "Local `view` updates; queryArgs recomputes; records refetch."
+			}
+		],
+		"a11y": {
+			"focus-management": "DataViews owns focus inside the table + modal."
+		},
+		"constraints": [
+			{
+				"concern": "dataviews-import-path",
+				"note": "Import from `@wordpress/dataviews/wp`."
+			},
+			{
+				"concern": "context-edit",
+				"note": "Without `context: 'edit'` the response omits email + roles."
+			},
+			{
+				"concern": "self-delete-guard",
+				"note": "Filter out `window.wpAdminShell.userId` before sending REST. Reassign-to-self fails server-side and the bulk request errors silently mid-flight."
+			},
+			{
+				"concern": "no-trash-for-users",
+				"note": "WordPress has no user trash. Delete is permanent; the `reassign` parameter is mandatory or content with `post_author = id` is orphaned."
+			},
+			{
+				"concern": "invalidate-after-delete",
+				"note": "Call `invalidateResolution('getEntityRecords', ['root', 'user', queryArgs])` — the per-row `deleteEntityRecord` does not bust the parent query."
+			}
+		],
+		"design-system-leakage": [
+			{
+				"import": "@wordpress/dataviews/wp#DataViews",
+				"purpose": "Table view with selection + bulk action."
+			},
+			{
+				"import": "@wordpress/ui#Button, Stack, Text",
+				"purpose": "Modal layout + cancel button."
+			},
+			{
+				"import": "@wordpress/components#Button (as DestructiveButton)",
+				"purpose": "Destructive primary action — WPDS 0.12 has no `tone=\"critical\"`."
+			},
+			{
+				"import": "@wordpress/icons#trash",
+				"purpose": "Delete row action icon."
+			}
+		]
 	}
 }

--- a/src/apps/users/app.md
+++ b/src/apps/users/app.md
@@ -1,0 +1,39 @@
+# core:users
+
+Prose accompanying `app.json#documentation` for the user list.
+
+## Overview
+
+UsersApp is a DataViews list of WordPress users with a single, carefully-guarded bulk action: permanent delete with content reassignment. WordPress has no user trash, so deletion is irreversible — the app's responsibility is to make the consequences clear (modal copy varies by selection size + self-skip) and to ensure the request succeeds atomically (filter the acting user out before issuing the REST calls).
+
+Read shape follows PostsApp: `useEntityRecords('root', 'user', queryArgs)` with `context: 'edit'`. Without `edit` context the response omits email + roles — those columns would render empty and any future role-edit feature would silently fail. Filter by role is wired up but only the `is` operator is honored (single-role filter); multi-role filtering would need REST-side `roles__in` support.
+
+## Architecture
+
+Sortby field aliasing: DataViews sends `view.sort.field` matching the column id; the queryArgs mapper passes it through with a special case for `registered_date` (column id matches REST orderby alias). For a custom column whose REST orderby alias differs, expand this map.
+
+The destructive modal is rendered via DataViews' `RenderModal` shape so DataViews owns the focus trap + backdrop + dismiss. Inside the modal:
+
+1. `currentUserId` is read from `window.wpAdminShell.userId` (injected by PHP).
+2. `targets = items.filter((i) => i.id !== currentUserId)` — the acting user is stripped from the target set.
+3. `skipped = items.length - targets.length` — used to surface the "(Your own account will be skipped.)" addendum.
+4. If `targets.length === 0`, the modal renders the cannot-delete-yourself copy and disables the destructive button.
+
+On confirm: `Promise.all(targets.map(deleteEntityRecord(..., { force: true, reassign: currentUserId })))`, then `invalidateResolution('getEntityRecords', ['root', 'user', queryArgs])`, then a success snackbar. On error, a dismissible error notice with `err.message`.
+
+## Rebuild guide
+
+The data shape is straightforward; the architectural pattern worth preserving is the **self-action guard**:
+
+- Identify the acting user via a host-injected global, store config, or a `whoami` REST call before the action fires.
+- Strip the acting user out of bulk target sets for any operation that can't legally include them (delete, demote, role-change-to-lower).
+- Surface the skip in the confirmation UI rather than silently filtering — users notice when their selection count shrinks.
+
+A non-WPDS rebuild needs the same primitives as PostsApp (table + destructive modal + invalidation) plus access to the acting user's id.
+
+## Known limitations
+
+- No add-user flow. Adding a user requires a `POST /wp/v2/users` flow with role + email + password fields; that lands as a separate iteration alongside an invite-style UX.
+- No edit-user flow. Click-row-name navigates nowhere; profile lives in `core:profile` for the acting user only.
+- Role filter is single-select; the underlying REST endpoint accepts comma-separated roles in `?roles=`, but the queryArgs mapper only handles the `is` operator.
+- The plugin-contributed row-actions slot (`core:users.row-actions` per M4.5) is documented but not yet wired up.

--- a/tests/schema/fixtures/v2/app/negative/06-documentation-extra-prop.json
+++ b/tests/schema/fixtures/v2/app/negative/06-documentation-extra-prop.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "../../../../../../docs/schemas/admin-app-v2.json",
+	"id": "core:posts",
+	"version": 1,
+	"title": "Posts",
+	"role": "main",
+	"script": "core-posts",
+	"documentation": {
+		"purpose": "DataViews over a post type.",
+		"shouldNotBeHere": "extra property — additionalProperties: false rejects this"
+	}
+}

--- a/tests/schema/fixtures/v2/app/negative/07-documentation-bad-via.json
+++ b/tests/schema/fixtures/v2/app/negative/07-documentation-bad-via.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "../../../../../../docs/schemas/admin-app-v2.json",
+	"id": "core:posts",
+	"version": 1,
+	"title": "Posts",
+	"role": "main",
+	"script": "core-posts",
+	"documentation": {
+		"data": {
+			"reads": [
+				{ "source": "postType/post", "via": "fetch" }
+			]
+		}
+	}
+}

--- a/tests/schema/fixtures/v2/app/positive/04-documentation.json
+++ b/tests/schema/fixtures/v2/app/positive/04-documentation.json
@@ -1,0 +1,59 @@
+{
+	"$schema": "../../../../../../docs/schemas/admin-app-v2.json",
+	"id": "core:posts",
+	"version": 1,
+	"title": "Posts",
+	"role": "main",
+	"script": "core-posts",
+	"documentation": {
+		"purpose": "DataViews table over a single post type. The default view lists 20 rows, ordered by date descending, with title / status / author / date columns. The author can filter by status, search the title field, switch to a grid layout, paginate, and perform per-row or bulk row actions (edit, view, trash).",
+		"rebuilds": "posts",
+		"data": {
+			"reads": [
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Rows in the DataViews table.",
+					"fields": [ "id", "title.raw", "status", "date", "link", "_embedded.author.0.name" ],
+					"query": { "_embed": "author", "per_page": 20, "context": "edit" }
+				}
+			],
+			"writes": [
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"operation": "trash",
+					"purpose": "Move selected posts to trash from the row action or bulk action.",
+					"invalidates": [ "postType/{config.postType}" ]
+				}
+			]
+		},
+		"url": {
+			"navigates": [ "#/posts/{id}/edit", "#/pages/{id}/edit" ]
+		},
+		"states": [
+			{ "id": "loading", "when": "isResolving && !records", "renders": "DataViews built-in loading indicator." },
+			{ "id": "ready", "when": "records !== null", "renders": "Rows rendered in the active layout (table or grid)." },
+			{ "id": "empty", "when": "records?.length === 0", "renders": "DataViews built-in empty state." }
+		],
+		"interactions": [
+			{ "trigger": "Click row title", "effect": "Navigate to editor route for the post type." },
+			{ "trigger": "Click row View action", "effect": "Open the post's permalink in a new tab.", "guards": [ "item.status === 'publish'" ] },
+			{ "trigger": "Click Trash action (single or bulk)", "effect": "Confirm in a modal, then trash via deleteEntityRecord and DataViews refreshes the list." }
+		],
+		"a11y": {
+			"focus-management": "DataViews handles focus inside the grid; after trash modal closes focus returns to the action trigger."
+		},
+		"constraints": [
+			{ "concern": "dataviews-import-path", "note": "Import from `@wordpress/dataviews/wp`, not the bare package path — bare risks React error #130." },
+			{ "concern": "context-edit", "note": "Pass `context: 'edit'` so title.raw is populated; without it titles render as decoded HTML and edit flows silently break." }
+		],
+		"design-system-leakage": [
+			{ "import": "@wordpress/dataviews/wp#DataViews", "purpose": "Table / grid view with built-in filtering, sorting, pagination, selection, and bulk actions." },
+			{ "import": "@wordpress/ui#Button", "purpose": "Title cell renderer + modal action buttons." },
+			{ "import": "@wordpress/components#Button (as DestructiveButton)", "purpose": "Destructive primary action in the trash-confirm modal — WPDS 0.12 has no `tone=\"critical\"`." },
+			{ "import": "@wordpress/icons#pencil, trash, external", "purpose": "Row action icons." }
+		]
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds a comprehensive `documentation` field to the admin-app-v2 schema and populates it across all 28 bundled shell apps. The documentation contract provides machine-readable descriptions of app behavior, data dependencies, URL participation, and runtime states — intended for reviewers, ecosystem tooling, and authors rebuilding apps on different design systems or frameworks.

## Key Changes

- **Schema extension** (`docs/schemas/admin-app-v2.json`):
  - Added `appDocumentation` definition with seven top-level fields: `purpose`, `rebuilds`, `data`, `url`, `states`, `interactions`, and `keyboard`
  - `data` object declares `reads[]` and `writes[]` with structured operation metadata (source, via, context, fields, query args, cache invalidation)
  - `url` object documents URL slot participation (`reads-slots`, `writes-slots`, `navigates`)
  - `states[]` array lists discriminated runtime states with `id`, `when` condition, and `renders` description
  - `interactions[]` and `keyboard[]` arrays document user-facing affordances and keyboard shortcuts
  - All fields marked `additionalProperties: false` for strict validation

- **App documentation population** (all 28 bundled apps):
  - **Data-heavy apps** (posts, media, comments, users, plugins, taxonomy, dashboard): detailed REST sources, query parameters, cache invalidation responsibilities
  - **Editor apps** (simple-editor, editor, site-editor): block editor composition, auto-save behavior, iframe delegation patterns
  - **Settings apps** (settings, settings-general): form field coverage, REST surface mapping, iframed fallback panels
  - **Utility apps** (navigation, command-palette, preview-pane, user-menu, toolbar-actions, notices-*): window-global dependencies, notice bus integration, URL coordination patterns
  - **Shell-only apps** (site-hub, appearance, tools, iframe-fallback): no `rebuilds` field (no wp-admin screen equivalent)

- **Prose documentation** (26 new `.md` files):
  - One markdown file per app under `src/apps/{app}/app.md`
  - Captures narrative explanation, composition decisions, trade-offs, and rebuild guidance
  - Complements structured facts in `app.json#documentation`
  - Examples: DataViews pagination patterns, multipart upload via raw apiFetch, graceful fallback to wp-admin, per-test error handling in site-health

- **Test fixtures**:
  - Added positive fixture `tests/schema/fixtures/v2/app/positive/04-documentation.json` demonstrating valid documentation structure
  - Added negative fixtures for schema validation: `06-documentation-extra-prop.json`, `07-documentation-bad-via.json`

## Notable Implementation Details

- **Data operation metadata**: Each read/write declares `source` (entity path or REST endpoint), `via` (core-data, api-fetch, or window-global), `context` (REST context like 'edit'), and optional `fields` array + `query` object for pagination/filtering
- **Cache invalidation**: Write operations list `invalidates[]` to document which reads must be refreshed after mutation
- **URL coordination**: Apps document which URL slots they read (`_self` for primary hash path, named slots for cross-region state), which they write, and which route patterns they navigate to
- **State machine**: Apps list discriminated states (loading, empty, error, ready, saving, saved, with-edits, permission-denied) with conditions and render descriptions
- **Keyboard shortcuts**: Documented via `{ keys: "Cmd+K", action: "..." }` entries for accessibility and discoverability
- **No load-bearing contract**: Runtime does not read or enforce documentation fields — purely informational for tooling and human reviewers

The documentation pairs with the sibling `app.md` prose document: structured facts live in the manifest, narrative explanation lives in markdown.

https://claude.ai/code/session_01KyTZodm19kK5sGRuHK4wEg