### PR TITLE
feat(F.1): migrate TaxonomyApp to useViewConfig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,11 +296,11 @@ wp-admin-shell/
 
 | Source | Component | Native? | Cap floor | Notes |
 |---|---|---|---|---|
-| `core:posts` | PostsApp | ✅ | — | DataViews table; `config.postType`; consumes view-config `(postType, {postType}[, variant])` |
+| `core:posts` | PostsApp | ✅ | — | DataViews table; `config.postType`. C2 view-config consumer (`useViewConfig('postType', config.postType, variant?)`). |
 | `core:simple-editor` | SimpleEditorApp | ✅ | — | Substack-style; title + 9 blocks + auto-save |
 | `core:editor` | EditorApp | iframe | — | `post.php?post={id}&action=edit`. Native `@wordpress/edit-post` mount deferred to v2.x — see `SiteEditorApp.js` for blockers. |
 | `core:media` | MediaApp | ✅ | — | Grid, upload, detail modal |
-| `core:taxonomy` | TaxonomyApp | ✅ | — | DataViews + create/edit/delete terms |
+| `core:taxonomy` | TaxonomyApp | ✅ | — | DataViews + create/edit/delete terms. C2 view-config consumer (`useViewConfig('taxonomy', config.taxonomy, variant?)`); manifest baseline binds `(taxonomy, category)`, other taxonomies consume cascade-only entries (`developer-admin.json` ships `(taxonomy, post_tag)`). |
 | `core:profile` | ProfileApp | ✅ | — | `useEntityRecord('root','user',userId)` |
 | `core:users` | UsersApp | ✅ | `list_users` | DataViews + bulk delete with reassign + self-delete guard; consumes view-config `(root, user)` |
 | `core:comments` | CommentsApp | ✅ | `moderate_comments` | DataViews + approve/spam/trash via partial saveEntityRecord. Reads spec via `useViewConfig('root','comment')` (C2). |

--- a/shells/developer-admin.json
+++ b/shells/developer-admin.json
@@ -418,6 +418,31 @@
 					]
 				}
 			}
+		},
+		"taxonomy": {
+			"post_tag": {
+				"_default": {
+					"fields": [
+						{ "id": "name",        "type": "text",    "label": "Tag", "enableGlobalSearch": true, "enableHiding": false },
+						{ "id": "slug",        "type": "text",    "label": "Slug" },
+						{ "id": "count",       "type": "integer", "label": "Posts" },
+						{ "id": "description", "type": "text",    "label": "Description" }
+					],
+					"defaultView": {
+						"type": "table",
+						"page": 1,
+						"perPage": 20,
+						"fields": [ "slug", "count" ],
+						"titleField": "name",
+						"sort": { "field": "name", "direction": "asc" }
+					},
+					"defaultLayouts": { "table": {} },
+					"actions": [
+						{ "id": "edit",   "label": "Edit",   "isPrimary": true, "icon": "pencil" },
+						{ "id": "delete", "label": "Delete", "isDestructive": true, "supportsBulk": true, "icon": "trash" }
+					]
+				}
+			}
 		}
 	},
 

--- a/src/apps/taxonomy/app.json
+++ b/src/apps/taxonomy/app.json
@@ -15,11 +15,41 @@
 			},
 			"title": {
 				"type": "string"
+			},
+			"variant": {
+				"type": "string",
+				"description": "Optional view-config variant id to consume. When set, useViewConfig reads `viewConfigs.taxonomy.<taxonomy>.<variant>` instead of the `_default` triple."
 			}
 		},
 		"additionalProperties": false
 	},
 	"script": "wp-admin-shell",
+	"viewConfig": {
+		"kind": "taxonomy",
+		"name": "category",
+		"defaultView": {
+			"type": "table",
+			"search": "",
+			"filters": [],
+			"page": 1,
+			"perPage": 20,
+			"sort": { "field": "name", "direction": "asc" },
+			"fields": [ "slug", "count", "description" ],
+			"titleField": "name",
+			"layout": {}
+		},
+		"defaultLayouts": { "table": {} },
+		"fields": [
+			{ "id": "name", "type": "text", "label": "Name", "enableGlobalSearch": true, "enableHiding": false },
+			{ "id": "slug", "type": "text", "label": "Slug" },
+			{ "id": "count", "type": "integer", "label": "Count" },
+			{ "id": "description", "type": "text", "label": "Description" }
+		],
+		"actions": [
+			{ "id": "edit", "label": "Edit", "isPrimary": true, "icon": "pencil" },
+			{ "id": "delete", "label": "Delete", "isDestructive": true, "supportsBulk": true, "icon": "trash" }
+		]
+	},
 	"window": {
 		"defaultSize": {
 			"w": 960,
@@ -37,6 +67,18 @@
 		"rebuilds": "taxonomies",
 		"data": {
 			"reads": [
+				{
+					"source": "viewConfigs.taxonomy.{config.taxonomy}._default",
+					"via": "kernel-config",
+					"purpose": "Resolved view-config triple — fields, default view, default layouts, actions. Read via `useViewConfig(kind, name)`; baseline ships in `app.json#viewConfig` for `(taxonomy, category)` and is injected post-merge by `inject_app_baselines`. Other taxonomies (`post_tag`, custom) consume cascade-only entries or filter overrides.",
+					"fields": [
+						"fields",
+						"defaultView",
+						"defaultLayouts",
+						"actions",
+						"fieldsRef"
+					]
+				},
 				{
 					"source": "taxonomy/{config.taxonomy}",
 					"via": "core-data",
@@ -173,6 +215,10 @@
 			{
 				"concern": "invalidate-after-mutate",
 				"note": "Both create + update + delete must call `invalidateResolution('getEntityRecords', ['taxonomy', taxonomy])` — `saveEntityRecord` does not bust the parent query."
+			},
+			{
+				"concern": "decode-name-entities",
+				"note": "Term `name` may contain HTML entities (`&amp;`, `&#039;`). Pass through `decodeEntities` before rendering so the table mirrors wp-admin's `wp_specialchars_decode` display."
 			}
 		],
 		"design-system-leakage": [
@@ -181,8 +227,8 @@
 				"purpose": "Table view with sort/pagination/actions."
 			},
 			{
-				"import": "@wordpress/ui#Button, Stack, Text, InputControl",
-				"purpose": "Header, modal layout, name + slug inputs."
+				"import": "@wordpress/ui#Button, Stack, Text, InputControl, Icon",
+				"purpose": "Header, modal layout, name + slug inputs, Add-new icon."
 			},
 			{
 				"import": "@wordpress/components#Button (as DestructiveButton), Modal, TextareaControl",
@@ -193,8 +239,8 @@
 				"purpose": "Success / error notices for create / update / delete flows. The canonical shell notices contract — a non-WPDS rebuild must mirror it."
 			},
 			{
-				"import": "@wordpress/icons#plus, pencil, trash",
-				"purpose": "Add / row / delete action icons."
+				"import": "@wordpress/icons#plus",
+				"purpose": "Add-new toolbar icon. Row + delete icons resolve through the kernel icon registry (`pencil`, `trash`)."
 			}
 		]
 	}

--- a/src/apps/taxonomy/app.md
+++ b/src/apps/taxonomy/app.md
@@ -4,19 +4,60 @@ Prose accompanying `app.json#documentation` for the taxonomy term manager.
 
 ## Overview
 
-TaxonomyApp manages categories, tags, and any custom taxonomy through a single DataViews table + modal pair. The default mount targets `category`; shells that want to surface multiple taxonomies mount the app once per taxonomy with different `config.taxonomy` values (and optionally a `config.title` override for the page heading). The default `DEFAULT_TAXONOMY_LABEL` map handles `category` / `post_tag` naming; custom taxonomies fall back to the raw slug unless `config.title` is provided.
+TaxonomyApp manages categories, tags, and any custom taxonomy through a single DataViews table + modal pair. The default mount targets `category`; shells that want to surface multiple taxonomies mount the app once per taxonomy with different `config.taxonomy` values (and optionally a `config.title` override for the page heading). The `DEFAULT_TAXONOMY_LABEL` map handles `category` / `post_tag` naming; custom taxonomies fall back to the raw slug unless `config.title` is provided.
 
 ## Architecture
 
-Three state slots:
+Four pieces of state drive the app:
 
-1. **`view`** — DataViews controlled state (same shape as PostsApp).
-2. **`editTerm`** — the term currently being edited, or `null` when not editing. Set from the table by clicking a row name or the Edit action.
-3. **`isCreating`** — boolean flag for the create variant of the same modal.
+1. **`viewConfig`** — pulled via `useViewConfig('taxonomy', config.taxonomy, config.variant)`. Holds the JSON spec for fields, default view, default layouts, and actions. The baseline ships in `app.json#viewConfig` bound to `(taxonomy, category)` and reaches the resolved cascade via `inject_app_baselines`. Site authors and plugin code override via admin.json `viewConfigs[taxonomy][category]._default` or the `wp_admin_shell_view_config_taxonomy_category` filter. For `post_tag` and custom taxonomies the manifest baseline does not apply — those triples consume cascade-only entries or filter overrides (bundled `developer-admin.json` ships a baseline for `post_tag`). **Field renderers and action callbacks live in the React layer** — the spec carries data; `buildFieldRenderers()` and `buildActions()` in `index.js` map ids to behavior.
+2. **`view`** — a local `useState` mirroring the DataViews controlled shape, seeded from `viewConfig.defaultView`. Holds search string, active filters, page, perPage, sort, fields, and layout. Owned by the app; DataViews calls `onChangeView(next)` whenever the user changes anything. A `useEffect` keyed on `[taxonomy, variant]` resyncs the view when the triple flips on the same hook instance so a `category` → `post_tag` rebind doesn't inherit the previous triple's filters/sort.
+3. **`editTerm` / `isCreating`** — modal toggles for the term editor. The same `TermEditModal` covers create and edit; only the payload `id` field and submit button label differ. Form state lives inside the modal via `useState` so the parent doesn't observe in-progress edits and state cleans up on unmount.
+4. **`records / isResolving / totalItems / totalPages`** — pulled from `useEntityRecords('taxonomy', config.taxonomy, queryArgs)`. `context: 'edit'` keeps `description` populated.
 
-The modal (`TermEditModal`) is rendered conditionally when `editTerm || isCreating`. It uses a single component for both create + edit because the field set is identical — only the `id` payload field and the submit button label differ. Form state lives inside the modal via `useState`, which is the right call here: the parent doesn't need to observe in-progress edits, and the modal unmounts on close so state cleanup is free.
+`data` is a `useMemo` projection of `records` into the row shape DataViews wants (`{ id, name, slug, count, description, parent, rawRecord }`). Term `name` may contain HTML entities — `decodeEntities` mirrors wp-admin's `wp_specialchars_decode` display. The original record is kept on `rawRecord` so the row-name renderer and edit action can pass it to the modal without re-fetching.
+
+The delete-confirm modal is implemented via DataViews' `RenderModal` action shape — DataViews owns the focus trap, backdrop, and dismiss handling. Inside the modal the app uses WPDS `Stack` + `Text` for layout and copy, with the destructive primary button falling back to legacy `@wordpress/components` `Button as DestructiveButton` because WPDS 0.12 has no `tone="critical"`. The action's `id` (`delete`) is what `buildActions()` keys off; plugins overriding the view-config can keep / rename / drop the action via their filter, and the React layer simply skips ids it has no callback for.
 
 Notice routing: success messages go through `@wordpress/notices` as snackbars (auto-dismiss), failures as dismissible banners. The `notices-snackbar` + `notices-banner` apps render them in their respective regions.
+
+## View-config integration (C2)
+
+TaxonomyApp consumes the C2 view-config primitive (spec §13 #7). The cascade flow mirrors PostsApp:
+
+1. **Baseline** lives in `app.json#viewConfig` bound to `(taxonomy, category)` (machine-readable; same shape Ajv validates). `inject_app_baselines` injects it into the post-merge resolved tree only when nothing in the cascade declared the same triple.
+2. **Admin.json overrides** under `viewConfigs.taxonomy.<name>._default` cascade through the 6 origins (core / engine / plugin / site / role / user). Declared triples are authoritative — they win outright over the manifest baseline. Sites and plugins swap columns, change default page size, hide the delete action, etc., without forking the app. The bundled `developer-admin.json` ships a baseline for `(taxonomy, post_tag)` so the Tags mount renders parity columns; sites that surface other taxonomies (custom taxonomies, `nav_menu`) add their own entries the same way.
+3. **Filter overrides** run last via `wp_admin_shell_view_config_taxonomy_<name>`. Useful for dynamic mutations (per-request, per-user) that JSON can't express.
+4. **TaxonomyApp consumes** via `useViewConfig('taxonomy', taxonomy, variant?)` → `{ config, isLoading }`. The hook reads from `window.wpAdminShell.config.viewConfigs` synchronously when present; otherwise falls through to `/wp-admin-shell/v1/view-config` REST.
+
+The renderer tables (`buildFieldRenderers`, `buildActions`, action callbacks keyed by `spec.id`) stay app-side. Any view-config override that uses an unfamiliar field id falls through to DataViews' default renderer for the declared `type`; unfamiliar action ids surface with no callback (action declared but inert) until the app side adds a mapping.
+
+### Translation recipe
+
+View-configs ship as locale-agnostic JSON primitives — `app.json#viewConfig` and admin.json `viewConfigs` overrides reach DataViews with raw strings in whatever locale the spec was authored in. TaxonomyApp recovers translation by keeping two id→`__()` tables in `index.js`:
+
+```js
+const FIELD_LABELS = {
+    name:        __( 'Name',        'wp-admin-shell' ),
+    slug:        __( 'Slug',        'wp-admin-shell' ),
+    count:       __( 'Count',       'wp-admin-shell' ),
+    description: __( 'Description', 'wp-admin-shell' ),
+};
+
+const ACTION_LABELS = {
+    edit:   __( 'Edit',   'wp-admin-shell' ),
+    delete: __( 'Delete', 'wp-admin-shell' ),
+};
+```
+
+`buildFields` and `buildActions` consult the table first:
+
+```js
+compiled.label = FIELD_LABELS[ spec.id ] ?? spec.label;   // fields
+compiled.label = ACTION_LABELS[ spec.id ] ?? spec.label;  // actions
+```
+
+**Precedence — LABELS wins for ids the app knows; spec wins for ids it doesn't.** `??` ensures plugin extension columns and actions (ids the app didn't author) keep whatever string the cascade supplied. Modal copy, the Add-new button label, and the destructive-confirm copy are plain JSX `__()` literals and translate normally — only the spec-supplied DataViews `label` field needs the recipe.
 
 ## Rebuild guide
 
@@ -27,7 +68,18 @@ Reuses the same primitives as PostsApp (DataViews + destructive modal). The uniq
 - On success, parent invalidates the parent query *and* fires a snackbar notice via `@wordpress/notices`.
 - On error, parent fires a dismissible banner notice — error message comes from `err.message` with a fallback.
 
-A non-WPDS rebuild needs: a Modal/Dialog component (focus trap + Esc close + backdrop), text + textarea inputs, a save button with a loading state, and a notice bus equivalent.
+A non-WPDS rebuild needs:
+
+- A **list/grid view component** with built-in filtering, sorting, pagination, selection, and per-row + bulk actions (DataViews equivalent).
+- A **REST/core-data adapter** that returns `{ rows, total, isLoading }` for the `taxonomy/<name>` entity at `context: 'edit'`.
+- A **Modal/Dialog component** with focus trap + Esc close + backdrop.
+- Text + textarea inputs, a save button with a loading state, and a notice bus equivalent.
+- A **destructive-action confirm modal** keyed on the `delete` action id.
+
+Two patterns to preserve:
+
+- `context: 'edit'` is required so `description` is populated for the column renderer.
+- `deleteEntityRecord` must pass `{ force: true }` — taxonomies have no trash. Without `force` the REST endpoint 400s.
 
 ## Known limitations
 
@@ -37,3 +89,20 @@ A non-WPDS rebuild needs: a Modal/Dialog component (focus trap + Esc close + bac
 - Term content count (`count`) is read-only; clicking it does not filter posts by the term.
 - No default-category protection. wp-admin disables Delete on the site's default category (option `default_category`); the v2 app surfaces a Delete action that the REST endpoint will reject server-side without a clear UX cue.
 - No term-reassignment on delete. wp-admin's term delete offers "Reassign to another term" before deleting; the v2 app deletes outright and posts get reparented to the default term by core's fallback.
+
+Parity gaps versus `docs/screens/taxonomy.md` not surfaced in the v2 app:
+
+- No split-pane Add form. wp-admin renders Add new in a left pane next to the list; the v2 app uses a modal toggled by an Add-new button in the toolbar.
+- No Quick Edit (inline name + slug edit on row toggle).
+- No hierarchical tree display for categories. wp-admin recurses into a parent-indented tree; the v2 app renders flat sorted rows. Switching sort on a hierarchical taxonomy already collapses the wp-admin tree, so the flat view matches the sorted state but loses the default tree view.
+- No parent picker on Add / Edit (cycle-prevention `exclude_tree` not surfaced).
+- No `wp_dropdown_categories`-style indented option labels.
+- No default-category badge / delete protection.
+- No "View" archive link per row for public taxonomies.
+- No term-archive count link that drills into the `posts` app filtered by term.
+- No `meta` field rendering from `register_term_meta`.
+- No hide-empty toggle.
+- No Categories-only below-list hint area ("Deleting a category does not delete posts…").
+- No slug-collision feedback after save (when server appends `-2` etc.).
+- No keyboard shortcuts (`/` to focus search, `n` to focus Add form).
+- ARIA polish: no `aria-level` / `aria-setsize` for hierarchical rows, no per-row Default-category announcement.

--- a/src/apps/taxonomy/index.js
+++ b/src/apps/taxonomy/index.js
@@ -1,4 +1,4 @@
-import { useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -10,131 +10,156 @@ import {
 	TextareaControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { plus, trash, pencil } from '@wordpress/icons';
+import { decodeEntities } from '@wordpress/html-entities';
+import { plus } from '@wordpress/icons';
+import { resolveIcon } from '../../runtime/config/iconMap';
+import { useViewConfig } from '../../runtime/viewConfig/useViewConfig';
 
 const DEFAULT_TAXONOMY_LABEL = {
 	category: __( 'Categories', 'wp-admin-shell' ),
 	post_tag: __( 'Tags', 'wp-admin-shell' ),
 };
 
-export default function TaxonomyApp( { config = {} } ) {
-	const taxonomy = config.taxonomy || 'category';
-	const heading =
-		config.title || DEFAULT_TAXONOMY_LABEL[ taxonomy ] || taxonomy;
+// View-config primitives ship as locale-agnostic JSON (spec §13 #7). Recover
+// translation for the ids the app authors by mapping known field/action ids
+// to `__()`-wrapped strings at module load. Unknown ids (plugin extension
+// columns / actions) fall through to `spec.label`.
+const FIELD_LABELS = {
+	name: __( 'Name', 'wp-admin-shell' ),
+	slug: __( 'Slug', 'wp-admin-shell' ),
+	count: __( 'Count', 'wp-admin-shell' ),
+	description: __( 'Description', 'wp-admin-shell' ),
+};
 
-	const [ view, setView ] = useState( {
-		type: 'table',
-		search: '',
-		filters: [],
-		page: 1,
-		perPage: 20,
-		sort: { field: 'name', direction: 'asc' },
-		fields: [ 'name', 'slug', 'count', 'description' ],
-		titleField: 'name',
-		layout: {},
-	} );
+const ACTION_LABELS = {
+	edit: __( 'Edit', 'wp-admin-shell' ),
+	delete: __( 'Delete', 'wp-admin-shell' ),
+};
 
-	const queryArgs = useMemo( () => {
-		const args = {
-			per_page: view.perPage,
-			page: view.page,
-			order: view.sort?.direction || 'asc',
-			orderby: view.sort?.field || 'name',
-			context: 'edit',
-			hide_empty: false,
-		};
-		if ( view.search ) {
-			args.search = view.search;
-		}
-		return args;
-	}, [ view ] );
+const VIEW_DEFAULTS = {
+	type: 'table',
+	search: '',
+	filters: [],
+	page: 1,
+	perPage: 20,
+	sort: { field: 'name', direction: 'asc' },
+	fields: [],
+	layout: {},
+};
 
-	const { records, isResolving, totalItems, totalPages } = useEntityRecords(
-		'taxonomy',
+function stripTags( html ) {
+	return ( html || '' ).replace( /<[^>]*>/g, '' ).trim();
+}
+
+/**
+ * Field id → render callback. View-config declares the shape; the React
+ * layer owns the row renderer. Unknown ids fall through to DataViews'
+ * default renderer for the declared field type.
+ *
+ * @param {Object}   deps
+ * @param {Function} deps.onEditTerm Open the edit modal for a raw term record.
+ */
+function buildFieldRenderers( { onEditTerm } ) {
+	return {
+		name: ( { item } ) => (
+			<Button
+				variant="minimal"
+				onClick={ () => onEditTerm( item.rawRecord ) }
+			>
+				{ item.name }
+			</Button>
+		),
+		slug: ( { item } ) => <Text>{ item.slug }</Text>,
+		count: ( { item } ) => <Text>{ item.count }</Text>,
+		description: ( { item } ) => (
+			<Text>{ stripTags( item.description ) }</Text>
+		),
+	};
+}
+
+function compileEligibility( eligibleWhen ) {
+	if ( ! eligibleWhen || typeof eligibleWhen !== 'object' ) {
+		return undefined;
+	}
+	const entries = Object.entries( eligibleWhen );
+	if ( entries.length === 0 ) {
+		return undefined;
+	}
+	return ( item ) =>
+		entries.every( ( [ field, expected ] ) => {
+			const actual = item?.[ field ];
+			if ( Array.isArray( expected ) ) {
+				return expected.includes( actual );
+			}
+			return actual === expected;
+		} );
+}
+
+function buildFields( fieldSpecs, fieldRenderers ) {
+	return fieldSpecs
+		.filter( ( spec ) => spec && typeof spec === 'object' && spec.id )
+		.map( ( spec ) => {
+			const compiled = {
+				id: spec.id,
+				type: spec.type,
+				label: FIELD_LABELS[ spec.id ] ?? spec.label,
+			};
+			if ( spec.enableGlobalSearch !== undefined ) {
+				compiled.enableGlobalSearch = !! spec.enableGlobalSearch;
+			}
+			if ( spec.enableHiding !== undefined ) {
+				compiled.enableHiding = !! spec.enableHiding;
+			}
+			if ( spec.enableSorting !== undefined ) {
+				compiled.enableSorting = !! spec.enableSorting;
+			}
+			if ( Array.isArray( spec.elements ) ) {
+				compiled.elements = spec.elements;
+			}
+			if ( spec.filterBy ) {
+				compiled.filterBy = spec.filterBy;
+			}
+			if ( fieldRenderers[ spec.id ] ) {
+				compiled.render = fieldRenderers[ spec.id ];
+			}
+			return compiled;
+		} );
+}
+
+function buildActions(
+	actions,
+	{
 		taxonomy,
-		queryArgs
-	);
+		onEditTerm,
+		deleteEntityRecord,
+		invalidateResolution,
+		createSuccessNotice,
+		createErrorNotice,
+	}
+) {
+	const callbacks = {
+		edit: ( items ) => onEditTerm( items[ 0 ].rawRecord ),
+	};
 
-	const { saveEntityRecord, deleteEntityRecord, invalidateResolution } =
-		useDispatch( coreStore );
-	const { createSuccessNotice, createErrorNotice } =
-		useDispatch( noticesStore );
+	return actions
+		.filter( ( spec ) => spec && typeof spec === 'object' && spec.id )
+		.map( ( spec ) => {
+			const compiled = {
+				id: spec.id,
+				label: ACTION_LABELS[ spec.id ] ?? spec.label,
+				isPrimary: !! spec.isPrimary,
+				isDestructive: !! spec.isDestructive,
+				supportsBulk: !! spec.supportsBulk,
+				icon: spec.icon ? resolveIcon( spec.icon ) : undefined,
+				isEligible: compileEligibility( spec.eligibleWhen ),
+			};
 
-	const [ editTerm, setEditTerm ] = useState( null );
-	const [ isCreating, setIsCreating ] = useState( false );
-
-	const data = useMemo( () => {
-		if ( ! records ) {
-			return [];
-		}
-		return records.map( ( t ) => ( {
-			id: t.id,
-			name: t.name,
-			slug: t.slug,
-			count: t.count,
-			description: t.description || '',
-			parent: t.parent || 0,
-			rawRecord: t,
-		} ) );
-	}, [ records ] );
-
-	const fields = useMemo(
-		() => [
-			{
-				id: 'name',
-				type: 'text',
-				label: __( 'Name', 'wp-admin-shell' ),
-				enableGlobalSearch: true,
-				enableHiding: false,
-				render: ( { item } ) => (
-					<Button
-						variant="minimal"
-						onClick={ () => setEditTerm( item.rawRecord ) }
-					>
-						{ item.name }
-					</Button>
-				),
-			},
-			{
-				id: 'slug',
-				type: 'text',
-				label: __( 'Slug', 'wp-admin-shell' ),
-				render: ( { item } ) => <Text>{ item.slug }</Text>,
-			},
-			{
-				id: 'count',
-				type: 'integer',
-				label: __( 'Count', 'wp-admin-shell' ),
-				render: ( { item } ) => <Text>{ item.count }</Text>,
-			},
-			{
-				id: 'description',
-				type: 'text',
-				label: __( 'Description', 'wp-admin-shell' ),
-				render: ( { item } ) => (
-					<Text>{ stripTags( item.description ) }</Text>
-				),
-			},
-		],
-		[]
-	);
-
-	const actions = useMemo(
-		() => [
-			{
-				id: 'edit',
-				label: __( 'Edit', 'wp-admin-shell' ),
-				icon: pencil,
-				isPrimary: true,
-				callback: ( items ) => setEditTerm( items[ 0 ].rawRecord ),
-			},
-			{
-				id: 'delete',
-				label: __( 'Delete', 'wp-admin-shell' ),
-				icon: trash,
-				isDestructive: true,
-				supportsBulk: true,
-				RenderModal: ( { items, closeModal, onActionPerformed } ) => (
+			if ( spec.id === 'delete' ) {
+				compiled.RenderModal = ( {
+					items,
+					closeModal,
+					onActionPerformed,
+				} ) => (
 					<Stack
 						direction="column"
 						gap="md"
@@ -159,6 +184,8 @@ export default function TaxonomyApp( { config = {} } ) {
 								isDestructive
 								onClick={ async () => {
 									try {
+										// Terms have no trash — `force: true`
+										// is required or the request 400s.
 										await Promise.all(
 											items.map( ( item ) =>
 												deleteEntityRecord(
@@ -198,15 +225,116 @@ export default function TaxonomyApp( { config = {} } ) {
 							</DestructiveButton>
 						</Stack>
 					</Stack>
-				),
-			},
-		],
+				);
+			} else if ( callbacks[ spec.id ] ) {
+				compiled.callback = callbacks[ spec.id ];
+			}
+
+			return compiled;
+		} );
+}
+
+export default function TaxonomyApp( { config = {} } ) {
+	const taxonomy = config.taxonomy || 'category';
+	const variant = config.variant || null;
+	const heading =
+		config.title || DEFAULT_TAXONOMY_LABEL[ taxonomy ] || taxonomy;
+
+	const { config: viewConfig } = useViewConfig(
+		'taxonomy',
+		taxonomy,
+		variant
+	);
+
+	const [ view, setView ] = useState( () => ( {
+		...VIEW_DEFAULTS,
+		...viewConfig.defaultView,
+	} ) );
+
+	// Resync `view` when the underlying triple flips on the same hook
+	// instance (e.g. config.taxonomy `category` → `post_tag`). The useState
+	// initializer runs once, so without this effect the second triple
+	// inherits the first triple's perPage / sort / filters. Keyed only on
+	// the triple — not viewConfig — to avoid clobbering in-session view
+	// edits whenever the cascade re-resolves the doc shape.
+	useEffect( () => {
+		setView( {
+			...VIEW_DEFAULTS,
+			...( viewConfig.defaultView || {} ),
+		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ taxonomy, variant ] );
+
+	const queryArgs = useMemo( () => {
+		const args = {
+			per_page: view.perPage,
+			page: view.page,
+			order: view.sort?.direction || 'asc',
+			orderby: view.sort?.field || 'name',
+			context: 'edit',
+			hide_empty: false,
+		};
+		if ( view.search ) {
+			args.search = view.search;
+		}
+		return args;
+	}, [ view ] );
+
+	const { records, isResolving, totalItems, totalPages } = useEntityRecords(
+		'taxonomy',
+		taxonomy,
+		queryArgs
+	);
+
+	const { saveEntityRecord, deleteEntityRecord, invalidateResolution } =
+		useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const [ editTerm, setEditTerm ] = useState( null );
+	const [ isCreating, setIsCreating ] = useState( false );
+
+	const data = useMemo( () => {
+		if ( ! records ) {
+			return [];
+		}
+		return records.map( ( t ) => ( {
+			id: t.id,
+			name: decodeEntities( t.name || '' ),
+			slug: t.slug,
+			count: t.count,
+			description: t.description || '',
+			parent: t.parent || 0,
+			rawRecord: t,
+		} ) );
+	}, [ records ] );
+
+	const fields = useMemo(
+		() =>
+			buildFields(
+				viewConfig.fields ?? [],
+				buildFieldRenderers( { onEditTerm: setEditTerm } )
+			),
+		[ viewConfig ]
+	);
+
+	const actions = useMemo(
+		() =>
+			buildActions( viewConfig.actions ?? [], {
+				taxonomy,
+				onEditTerm: setEditTerm,
+				deleteEntityRecord,
+				invalidateResolution,
+				createSuccessNotice,
+				createErrorNotice,
+			} ),
 		[
+			viewConfig,
+			taxonomy,
 			deleteEntityRecord,
 			invalidateResolution,
 			createSuccessNotice,
 			createErrorNotice,
-			taxonomy,
 		]
 	);
 
@@ -250,7 +378,7 @@ export default function TaxonomyApp( { config = {} } ) {
 				actions={ actions }
 				paginationInfo={ paginationInfo }
 				isLoading={ isResolving }
-				defaultLayouts={ { table: {} } }
+				defaultLayouts={ viewConfig.defaultLayouts ?? { table: {} } }
 				selection={ selection }
 				onChangeSelection={ setSelection }
 				getItemId={ ( item ) => item.id.toString() }
@@ -286,10 +414,6 @@ export default function TaxonomyApp( { config = {} } ) {
 			) }
 		</div>
 	);
-}
-
-function stripTags( html ) {
-	return ( html || '' ).replace( /<[^>]*>/g, '' ).trim();
 }
 
 function TermEditModal( {


### PR DESCRIPTION
## Summary

Track **F.1** — second entity-CRUD app to consume the C2 view-config primitive after PostsApp (Track E baseline).

- Move TaxonomyApp's structural DataViews config (fields / actions / defaultView / defaultLayouts) into `app.json#viewConfig` bound to `(taxonomy, category)`.
- Rewrite `src/apps/taxonomy/index.js` in the post-E shape — `useViewConfig` + LABELS-table translation recipe + view-state resync `useEffect` keyed on `[taxonomy, variant]` + `decodeEntities` on term `name`. Modal flow + destructive-confirm + Add-new toolbar stay in JSX.
- Declare `viewConfigs.taxonomy.post_tag._default` in `shells/developer-admin.json` so the bundled Tags mount renders parity columns (manifest baseline binds only `category`) — doubles as the cascade smoke from the F sub-track checklist.
- Refresh `app.md`: Architecture, View-config integration, Translation recipe, parity-gap notes vs `docs/screens/taxonomy.md`.
- Update `CLAUDE.md` app table: PostsApp + TaxonomyApp rows note C2 consumption + the `(kind, name)` baseline binding.

Parity-preserving — only visible change is that admin.json can now override the spec.

## Test plan

- [x] `npm run build` clean (size warnings only)
- [x] `npm run lint:js -- src/apps/taxonomy/` clean
- [x] `npm run test:schema` 90 pass (covers new `viewConfig` block + dev-admin `taxonomy` entries)
- [x] `npm run test:runtime` 354 pass
- [x] `npm run test:parity` 4 pass
- [x] `npm run test:engines` 7 pass
- [ ] PHP suites — not executed against this worktree (port 8888 held by sibling main checkout); CI will run them. View-config resolver, manifest registry, cascade logic all untouched; only JSON + JS app code changed.
- [ ] Browser smoke: `core:taxonomy` mounts in `developer-admin` at `/categories` + `/tags`; columns render; Add new + Edit + Delete (single + bulk) work; locale switch translates LABELS.
- [ ] Cascade override smoke: confirm `developer-admin.json` `viewConfigs.taxonomy.post_tag` overrides the manifest baseline (rename column header to "Tag" / "Posts" — visible only in Tags mount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)