### PR TITLE
F.5 — migrate core:themes to useViewConfig + DataViews

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ wp-admin-shell/
 | `core:settings-general` | SettingsGeneralApp | ✅ | — | Standalone version of the General panel (legacy entry; kept registered) |
 | `core:dashboard` | DashboardApp | ✅ | — | Site overview cards; recent posts/drafts/comments |
 | `core:plugins` | PluginsApp | ✅ | `activate_plugins` | DataViews on `'root','plugin'` entity; activate/deactivate via REST. Consumes view-config `(root, plugin)` via `useViewConfig` (C2 / Track F.4). |
-| `core:themes` | ThemesApp | ✅ | `switch_themes` | DataViews on `'root','theme'` entity |
+| `core:themes` | ThemesApp | ✅ | `switch_themes` | DataViews on `'root','theme'` entity. Consumes view-config `(root, theme)` via `useViewConfig`; grid layout default with screenshot tiles + Activate / Details actions. |
 | `core:tools` | ToolsApp | ✅ | — | Linker cards to import/export/site-health |
 | `core:site-health` | SiteHealthApp | ✅ | `view_site_health_checks` | `/wp-site-health/v1/tests/{id}` runner |
 | `core:site-editor` | SiteEditorApp | iframe | `edit_theme_options` | `site-editor.php` adapter. Native `@wordpress/edit-site` mount deferred to v2.x; five blockers (preferences-store / commands / full-screen CSS / hash-router collisions, edit-site not in BUNDLED_PACKAGES) documented in `SiteEditorApp.js`. |

--- a/src/apps/themes/app.json
+++ b/src/apps/themes/app.json
@@ -3,7 +3,7 @@
 	"id": "core:themes",
 	"version": 1,
 	"title": "Themes",
-	"description": "Theme grid with activate / preview / details. Reads via `core-data` `'root','theme'` entity.",
+	"description": "DataViews grid + table view of installed themes. Reads via `core-data` `'root','theme'` entity.",
 	"designSystem": "@wordpress/ui",
 	"role": "main",
 	"capabilities": [
@@ -11,9 +11,44 @@
 	],
 	"config-schema": {
 		"type": "object",
+		"properties": {
+			"variant": {
+				"type": "string",
+				"description": "Optional view-config variant id to consume. When set, useViewConfig reads `viewConfigs.root.theme.<variant>` instead of the `_default` triple."
+			}
+		},
 		"additionalProperties": false
 	},
 	"script": "wp-admin-shell",
+	"viewConfig": {
+		"kind": "root",
+		"name": "theme",
+		"defaultView": {
+			"type": "grid",
+			"search": "",
+			"filters": [],
+			"page": 1,
+			"perPage": 50,
+			"sort": { "field": "status", "direction": "asc" },
+			"fields": [ "status", "description", "version", "author" ],
+			"titleField": "name",
+			"mediaField": "screenshot",
+			"layout": {}
+		},
+		"defaultLayouts": { "grid": {}, "table": {} },
+		"fields": [
+			{ "id": "name", "type": "text", "label": "Name", "enableGlobalSearch": true, "enableHiding": false },
+			{ "id": "screenshot", "type": "media", "label": "Screenshot", "enableSorting": false, "enableHiding": false },
+			{ "id": "status", "type": "text", "label": "Status", "elements": [ { "value": "active", "label": "Active" }, { "value": "inactive", "label": "Inactive" } ], "filterBy": { "operators": [ "isAny" ] } },
+			{ "id": "description", "type": "text", "label": "Description", "enableSorting": false },
+			{ "id": "version", "type": "text", "label": "Version" },
+			{ "id": "author", "type": "text", "label": "Author" }
+		],
+		"actions": [
+			{ "id": "activate", "label": "Activate", "isPrimary": true, "icon": "check", "eligibleWhen": { "status": "inactive" } },
+			{ "id": "details", "label": "Details", "isPrimary": true }
+		]
+	},
 	"window": {
 		"defaultSize": {
 			"w": 1024,
@@ -27,10 +62,22 @@
 		"icon": "layout"
 	},
 	"documentation": {
-		"purpose": "Grid view of installed themes with screenshot + activate / details actions. The active theme floats to the front; the remainder sorts alphabetically. Activation uses a custom `/wp-admin-shell/v1/activate-theme` endpoint with a graceful fall-back to wp-admin's `themes.php?action=activate` link if the endpoint is missing. Details modal surfaces description + version + author + theme-site link.",
+		"purpose": "DataViews host over the `root/theme` entity. Default grid layout shows screenshot + name + status + truncated description; table layout offers sortable columns for power users. The Activate action (eligible only when status=inactive) calls the shell's custom `/wp-admin-shell/v1/activate-theme` endpoint with a wp-admin fallback. The Details action opens a modal with full description + version + author + theme-site link.",
 		"rebuilds": "themes",
 		"data": {
 			"reads": [
+				{
+					"source": "viewConfigs.root.theme._default",
+					"via": "kernel-config",
+					"purpose": "Resolved view-config triple — fields, default view, default layouts, actions. Read via `useViewConfig(kind, name, variant?)`; baseline ships in `app.json#viewConfig` and is injected post-merge by `inject_app_baselines`.",
+					"fields": [
+						"fields",
+						"defaultView",
+						"defaultLayouts",
+						"actions",
+						"fieldsRef"
+					]
+				},
 				{
 					"source": "root/theme",
 					"via": "core-data",
@@ -72,31 +119,31 @@
 		"states": [
 			{
 				"id": "loading",
-				"when": "isLoading || !themes",
-				"renders": "Centered `Spinner` covering the panel."
+				"when": "isResolving && !records",
+				"renders": "DataViews built-in loading indicator over an empty grid."
 			},
 			{
 				"id": "ready",
-				"when": "themes !== null",
-				"renders": "Header (count) + 3-column grid of theme cards. Active card has an Active badge; non-active cards show Activate button."
+				"when": "records !== null && records.length > 0",
+				"renders": "Grid layout with screenshot tiles; status='active' floats first via the default sort by status asc. Activate action surfaces as an icon button on non-active rows; Details opens a modal."
 			},
 			{
 				"id": "details-open",
-				"when": "details !== null",
-				"renders": "Modal with large screenshot + description + version / author + Theme site / Activate buttons."
+				"when": "User clicked Details on a row",
+				"renders": "DataViews RenderModal with large screenshot + full description + version / author + Theme site / Activate buttons."
 			}
 		],
 		"interactions": [
 			{
-				"trigger": "Click Details on a theme card",
-				"effect": "Open the details modal with that theme."
+				"trigger": "Activate row action",
+				"effect": "POST `/wp-admin-shell/v1/activate-theme` with `{ stylesheet }`; on success invalidate `root/theme`. On failure: `window.location.href` to `themes.php?action=activate&stylesheet=...` so the user falls back to wp-admin.",
+				"guards": [
+					"item.status === 'inactive'"
+				]
 			},
 			{
-				"trigger": "Click Activate on a theme card",
-				"effect": "POST `/wp-admin-shell/v1/activate-theme` with `{ stylesheet }`; on success invalidate `root/theme` + close any open modal. On failure: `window.location.href` to `themes.php?action=activate&stylesheet=...` so the user falls back to wp-admin.",
-				"guards": [
-					"theme.stylesheet !== activeStylesheet"
-				]
+				"trigger": "Details row action",
+				"effect": "Open the details modal with that theme's metadata + inline Activate button + Theme site link."
 			},
 			{
 				"trigger": "Click Theme site in details",
@@ -107,9 +154,13 @@
 			}
 		],
 		"a11y": {
-			"focus-management": "Legacy `Modal` traps focus while open. After close (via Esc or backdrop click) focus returns to the trigger button."
+			"focus-management": "DataViews owns focus inside the grid + modal. The RenderModal contract restores focus to the action trigger on close."
 		},
 		"constraints": [
+			{
+				"concern": "dataviews-import-path",
+				"note": "Import `DataViews` from `@wordpress/dataviews/wp` — never bare `@wordpress/dataviews`."
+			},
 			{
 				"concern": "no-core-rest-theme-switch",
 				"note": "WordPress core REST does not expose a theme-switch operation. The shell ships a custom `/wp-admin-shell/v1/activate-theme` endpoint; rebuilds must provide the equivalent or implement the wp-admin link fall-back."
@@ -117,28 +168,20 @@
 			{
 				"concern": "graceful-fallback",
 				"note": "If the custom endpoint 404s (older shell version or stripped feature), the app navigates to wp-admin's `themes.php` flow so the user can complete the action — preserves the right outcome even without the optimized path."
-			},
-			{
-				"concern": "modal-fallback",
-				"note": "Uses legacy `Modal` from `@wordpress/components`; WPDS Dialog 0.12 lacks size variants."
-			},
-			{
-				"concern": "grid-fallback",
-				"note": "Uses `__experimentalGrid` — no WPDS 0.12 port."
 			}
 		],
 		"design-system-leakage": [
 			{
-				"import": "@wordpress/ui#Button, Card, Stack, Text",
-				"purpose": "Theme card layout, header, action buttons."
+				"import": "@wordpress/dataviews/wp#DataViews",
+				"purpose": "Grid + table view with filtering, sorting, pagination, selection, per-row + bulk actions, action modals."
 			},
 			{
-				"import": "@wordpress/components#__experimentalGrid, CardMedia, Spinner, Modal",
-				"purpose": "Grid layout, screenshot media slot, loading spinner, details modal — all WPDS 0.12 gaps."
+				"import": "@wordpress/ui#Button, Stack, Text",
+				"purpose": "Details modal layout and action buttons."
 			},
 			{
-				"import": "@wordpress/icons#check, external",
-				"purpose": "Action icons."
+				"import": "@wordpress/icons#check",
+				"purpose": "Activate action icon (registered in the core-default engine icon table)."
 			}
 		]
 	}

--- a/src/apps/themes/app.md
+++ b/src/apps/themes/app.md
@@ -4,38 +4,97 @@ Prose accompanying `app.json#documentation` for the themes browser.
 
 ## Overview
 
-ThemesApp surfaces every installed theme as a 3-column card grid with screenshot + name + truncated description, and a per-card actions row (Details, Activate when non-active). The active theme floats to the front of the grid; the remainder sorts alphabetically by name. Activation uses an out-of-band custom endpoint because WordPress core REST does not expose a theme-switch operation natively — and falls back to wp-admin's classic activate link when the endpoint is missing.
+ThemesApp surfaces every installed theme through a DataViews host bound to the `root/theme` entity. The default layout is **grid** (screenshot tiles with name + status + truncated description); the secondary **table** layout offers sortable columns for power users. Status sorts ascending by default so the lone `active` theme floats above the `inactive` block — DataViews' built-in pagination, filtering, and selection take it from there.
 
-This **graceful-fallback** pattern is the most interesting thing here: when an optimized native path can't be guaranteed (custom endpoint missing, plugin gated, etc.), the right answer is often "navigate the user back into wp-admin to complete the action" rather than failing loudly. The user gets the correct outcome with one extra page load — preferable to a broken Activate button.
+Activation runs through an out-of-band custom endpoint because WordPress core REST does not expose a theme-switch operation natively — and falls back to wp-admin's classic activate link when the endpoint is missing. This **graceful-fallback** pattern is the most interesting thing here: when an optimized native path can't be guaranteed (custom endpoint missing, plugin gated, etc.), the right answer is often "navigate the user back into wp-admin to complete the action" rather than failing loudly. The user gets the correct outcome with one extra page load — preferable to a broken Activate button.
 
 ## Architecture
 
-`sorted` is a derived `useMemo` over `themes` that puts the active theme first and sorts the rest by name. `activeStylesheet` is read from the records first, then falls back to `window.wpAdminShell.activeTheme` for the brief window before core-data hydrates.
+Four pieces of state drive the app:
 
-`details` holds `{ theme, isActive }` — a small object so the modal can render Activate buttons that aren't disabled when the user lands directly via details for the current active theme.
+1. **`viewConfig`** — pulled via `useViewConfig('root', 'theme', config.variant)`. Carries the JSON spec for fields, default view, default layouts, and actions. The baseline ships in `app.json#viewConfig` and reaches the resolved cascade via `inject_app_baselines`. Sites and plugins override via admin.json `viewConfigs.root.theme._default` (or a named variant) or the `wp_admin_shell_view_config_root_theme` filter. **Field renderers and action callbacks live in the React layer** — the spec carries data only; `buildFieldRenderers()` and `buildActions()` in `index.js` map ids to behavior.
+2. **`view`** — a local `useState` mirroring the DataViews controlled shape, seeded from `viewConfig.defaultView`. Owned by the app; DataViews calls `onChangeView(next)` on every user-driven change.
+3. **`themes`** — the raw entity records from `useEntityRecords('root', 'theme', { context: 'edit', status: 'active,inactive' })`.
+4. **`data`** — a `useMemo` projection of `themes` into the flat row shape DataViews wants (`{ id, name, screenshot, status, description, version, author, theme_uri, rawRecord }`). `id` is the stylesheet (themes are keyed by slug, not numeric id).
 
-The activate handler:
+The Activate action calls a `useCallback` `activate(theme)` that:
 
-1. Tries POST `/wp-admin-shell/v1/activate-theme` `{ stylesheet }`.
-2. On success: `invalidateResolution` on the theme query + close any open details modal.
-3. On failure: `window.location.href = adminUrl + 'themes.php?action=activate&stylesheet=...'` — the user lands in wp-admin's flow.
+1. POSTs `/wp-admin-shell/v1/activate-theme` with `{ stylesheet }`.
+2. On success: `invalidateResolution` on the theme query + emits a success snackbar.
+3. On failure: `window.location.href = adminUrl + 'themes.php?action=activate&stylesheet=...'` so the user lands in wp-admin's flow.
 
-The custom endpoint is implemented on the PHP side (out of scope of this doc); rebuilds in other frameworks need their own.
+The Details action uses DataViews' `RenderModal` shape — DataViews owns the focus trap, backdrop, and dismiss handling. Inside the modal the app renders the full description + version + author + Theme site link + an inline Activate button (visible only when `status !== 'active'`).
+
+## View-config integration (C2)
+
+ThemesApp consumes the C2 view-config primitive (spec §13 #7). The cascade flow mirrors PostsApp's:
+
+1. **Baseline** lives in `app.json#viewConfig`. `inject_app_baselines` injects it into the post-merge resolved tree only when nothing in the cascade declared the same triple.
+2. **Admin.json overrides** under `viewConfigs.root.theme.<variant|_default>` cascade through the 6 origins (core / engine / plugin / site / role / user). Declared triples are authoritative — they win outright over the manifest baseline.
+3. **Filter overrides** run last via `wp_admin_shell_view_config_root_theme` (`..._{$variant}` when present). Useful for dynamic mutations that JSON can't express.
+4. **ThemesApp consumes** via `useViewConfig('root', 'theme', config.variant)` → `{ config, isLoading }`. The hook reads from `window.wpAdminShell.config.viewConfigs` synchronously when present; otherwise falls through to `/wp-admin-shell/v1/view-config`.
+
+The renderer tables (`buildFieldRenderers`, `buildActions`, action callbacks keyed by `spec.id`) stay app-side — they're the React half of the contract. View-config overrides that introduce an unfamiliar field id fall through to DataViews' default renderer for the declared `type`; unfamiliar action ids surface with no callback (declared but inert).
+
+### Translation recipe
+
+View-configs ship as locale-agnostic JSON primitives (spec §13 #7) — `app.json#viewConfig` and admin.json overrides reach DataViews with raw strings in whatever locale the spec was authored in. ThemesApp recovers translation by keeping two id→`__()` tables in `index.js`:
+
+```js
+const FIELD_LABELS = {
+    name:        __( 'Name',        'wp-admin-shell' ),
+    screenshot:  __( 'Screenshot',  'wp-admin-shell' ),
+    status:      __( 'Status',      'wp-admin-shell' ),
+    description: __( 'Description', 'wp-admin-shell' ),
+    version:     __( 'Version',     'wp-admin-shell' ),
+    author:      __( 'Author',      'wp-admin-shell' ),
+};
+
+const ACTION_LABELS = {
+    activate: __( 'Activate', 'wp-admin-shell' ),
+    details:  __( 'Details',  'wp-admin-shell' ),
+};
+```
+
+`buildFields` and `buildActions` consult the table first:
+
+```js
+compiled.label = FIELD_LABELS[ spec.id ] ?? spec.label;   // fields
+compiled.label = ACTION_LABELS[ spec.id ] ?? spec.label;  // actions
+```
+
+**Precedence — LABELS wins for ids the app knows; spec wins for ids it doesn't.** `??` ensures plugin extension columns and actions keep whatever string the cascade supplied. STATUS_LABELS plays the same role for the `active`/`inactive` enumeration — the `status` renderer maps record values to translated strings; the table also seeds the field's `elements` array when the spec doesn't declare one.
+
+Modal copy (Theme site / Close / Activate / Version / Author labels) lives as inline JSX `__()` literals and translates normally — only spec-supplied DataViews label fields needed the recipe.
 
 ## Rebuild guide
 
-For a non-WPDS rebuild:
+For a non-WPDS / non-DataViews rebuild:
 
-- Cards: any 3-column grid + media + content layout. Tailwind `grid-cols-3 gap-4` works directly.
-- Details modal: a sizable modal with a media slot. Don't load the screenshot at full resolution unless the modal is open.
-- Activation: either implement a server-side switch endpoint or fall back to wp-admin's `themes.php?action=activate&stylesheet=...` link with `_wpnonce` (note: nonce flow needs care; the shell's endpoint avoids this by relying on REST capability checks).
-- Sort: active first, then alphabetical.
+- **List/grid component** with media-aware grid cards + sortable table fallback. MUI's `DataGrid` works for the table half; the grid half is a flex/grid layout + media field renderer.
+- **REST/core-data adapter** that exposes `root/theme` records with `{ context: 'edit', status: 'active,inactive' }`.
+- **Custom theme-switch endpoint** (or fall back to wp-admin's `themes.php?action=activate&stylesheet=...&_wpnonce=…` link). Rebuilds need their own server-side hook.
+- **Action modal** that DataViews-style accepts `{ items, closeModal, onActionPerformed }`. Any modal primitive works; the contract is open-on-invoke, await close.
+
+Two patterns to preserve:
+
+- `context: 'edit'` is **required** for the read — without it the description and author render as decoded HTML.
+- Stylesheet (slug) is the row identity, not a numeric id. Set `getItemId={ ( item ) => item.id }` where `id = stylesheet`.
 
 ## Known limitations
 
 - No install / upload flow. Adding themes happens in wp-admin.
 - No theme preview (live preview via Customizer or block-theme preview).
-- The screenshot URL is loaded directly from the theme record; large screenshots are not lazy-loaded.
-- Description truncation is hard 140 chars. No "read more" affordance — long descriptions live in the details modal.
+- Screenshots are loaded directly from the theme record; no resizing or `srcset`.
+- Description truncation is hard 140 chars in the grid card. Full description lives in the details modal.
 - The fallback URL flow loses the user's place in the shell; we don't restore it on return.
 - **The classic-activate fallback link is missing `_wpnonce`.** `themes.php?action=activate&stylesheet=…` requires a fresh nonce or it silently bounces back to the themes list without activating. Per `docs/research/app-validation-2026-05-04.md`, this fallback path should either (a) call `wp_create_nonce('switch-theme_'.stylesheet)` from PHP and inject the resulting `&_wpnonce=…` into the link, or (b) route through a small PHP shim that performs the activation server-side. Until then, the fallback is best-effort only.
+- DataViews' built-in client-side pagination is used (the full theme list returns in one request); the `paginationInfo` is hard-coded to `totalPages: 1` because themes-per-install rarely exceeds the page size.
+
+Parity gaps versus `docs/screens/themes.md` not surfaced in the v2 app:
+
+- No "Add New Theme" upload affordance.
+- No live-preview / customizer launch.
+- No multisite "Network Activate" action variant.
+- No theme-update notice integration.
+- No theme delete action — wp-admin's row Delete + capability gate are not wired up here.

--- a/src/apps/themes/index.css
+++ b/src/apps/themes/index.css
@@ -1,0 +1,16 @@
+.wp-admin-shell-app-themes {
+	height: 100%;
+}
+
+.wp-admin-shell-app-themes .dataviews-wrapper {
+	height: 100%;
+}
+
+.wp-admin-shell-app-themes__details-modal {
+	padding: var( --wpds-dimension-padding-lg, 16px );
+}
+
+.wp-admin-shell-app-themes__details-modal img {
+	max-width: 100%;
+	height: auto;
+}

--- a/src/apps/themes/index.js
+++ b/src/apps/themes/index.js
@@ -68,27 +68,28 @@ function compileEligibility( eligibleWhen ) {
 		} );
 }
 
-function buildFieldRenderers() {
-	return {
-		name: ( { item } ) => <Text>{ item.name }</Text>,
-		screenshot: ( { item } ) =>
-			item.screenshot ? (
-				<img
-					src={ item.screenshot }
-					alt={ item.name || '' }
-					loading="lazy"
-				/>
-			) : null,
-		status: ( { item } ) => (
-			<Text>{ STATUS_LABELS[ item.status ] || item.status }</Text>
-		),
-		description: ( { item } ) => (
-			<Text>{ ( item.description || '' ).slice( 0, 140 ) }</Text>
-		),
-		version: ( { item } ) => <Text>{ item.version || '' }</Text>,
-		author: ( { item } ) => <Text>{ item.author || '' }</Text>,
-	};
-}
+// Module-scoped — renderers are stateless and capture no props, so we avoid
+// rebuilding the object on every render. A future refactor that introduces
+// props-capturing renderers should re-introduce a per-instance builder.
+const FIELD_RENDERERS = {
+	name: ( { item } ) => <Text>{ item.name }</Text>,
+	screenshot: ( { item } ) =>
+		item.screenshot ? (
+			<img
+				src={ item.screenshot }
+				alt={ item.name || '' }
+				loading="lazy"
+			/>
+		) : null,
+	status: ( { item } ) => (
+		<Text>{ STATUS_LABELS[ item.status ] || item.status }</Text>
+	),
+	description: ( { item } ) => (
+		<Text>{ ( item.description || '' ).slice( 0, 140 ) }</Text>
+	),
+	version: ( { item } ) => <Text>{ item.version || '' }</Text>,
+	author: ( { item } ) => <Text>{ item.author || '' }</Text>,
+};
 
 function buildFields( fieldSpecs, fieldRenderers ) {
 	return fieldSpecs
@@ -311,7 +312,7 @@ export default function ThemesApp( { config = {} } ) {
 	}, [ themes ] );
 
 	const fields = useMemo(
-		() => buildFields( viewConfig.fields ?? [], buildFieldRenderers() ),
+		() => buildFields( viewConfig.fields ?? [], FIELD_RENDERERS ),
 		[ viewConfig ]
 	);
 

--- a/src/apps/themes/index.js
+++ b/src/apps/themes/index.js
@@ -1,23 +1,165 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis -- __experimentalGrid has no @wordpress/ui 0.12 port. */
-import { useMemo, useState, useCallback } from '@wordpress/element';
+import './index.css';
+import { useEffect, useMemo, useState, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { Button, Card, Icon, Stack, Text } from '@wordpress/ui';
-import {
-	__experimentalGrid as Grid,
-	CardMedia,
-	Spinner,
-	Modal,
-} from '@wordpress/components';
+import { store as noticesStore } from '@wordpress/notices';
+import { DataViews } from '@wordpress/dataviews/wp';
+import { Button, Stack, Text } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
-import { check, external } from '@wordpress/icons';
+import { decodeEntities } from '@wordpress/html-entities';
+import { resolveIcon } from '../../runtime/config/iconMap';
+import { useViewConfig } from '../../runtime/viewConfig/useViewConfig';
 
 function stripTags( html ) {
 	return ( html || '' ).replace( /<[^>]*>/g, '' ).trim();
 }
 
-export default function ThemesApp() {
+const STATUS_LABELS = {
+	active: __( 'Active', 'wp-admin-shell' ),
+	inactive: __( 'Inactive', 'wp-admin-shell' ),
+};
+
+// View-configs ship as locale-agnostic JSON primitives (spec §13 #7) — labels
+// reach DataViews with raw English strings regardless of the user's locale.
+// Recover translation by mapping known field/action ids to `__()`-wrapped
+// strings at module load. Unknown ids fall through to `spec.label` so
+// plugin-extension columns / actions keep their cascade-supplied strings.
+const FIELD_LABELS = {
+	name: __( 'Name', 'wp-admin-shell' ),
+	screenshot: __( 'Screenshot', 'wp-admin-shell' ),
+	status: __( 'Status', 'wp-admin-shell' ),
+	description: __( 'Description', 'wp-admin-shell' ),
+	version: __( 'Version', 'wp-admin-shell' ),
+	author: __( 'Author', 'wp-admin-shell' ),
+};
+
+const ACTION_LABELS = {
+	activate: __( 'Activate', 'wp-admin-shell' ),
+	details: __( 'Details', 'wp-admin-shell' ),
+};
+
+const VIEW_DEFAULTS = {
+	type: 'grid',
+	search: '',
+	filters: [],
+	page: 1,
+	perPage: 50,
+	sort: { field: 'status', direction: 'asc' },
+	fields: [],
+	layout: {},
+};
+
+function compileEligibility( eligibleWhen ) {
+	if ( ! eligibleWhen || typeof eligibleWhen !== 'object' ) {
+		return undefined;
+	}
+	const entries = Object.entries( eligibleWhen );
+	if ( entries.length === 0 ) {
+		return undefined;
+	}
+	return ( item ) =>
+		entries.every( ( [ field, expected ] ) => {
+			const actual = item?.[ field ];
+			if ( Array.isArray( expected ) ) {
+				return expected.includes( actual );
+			}
+			return actual === expected;
+		} );
+}
+
+function buildFieldRenderers() {
+	return {
+		name: ( { item } ) => <Text>{ item.name }</Text>,
+		screenshot: ( { item } ) =>
+			item.screenshot ? (
+				<img
+					src={ item.screenshot }
+					alt={ item.name || '' }
+					loading="lazy"
+				/>
+			) : null,
+		status: ( { item } ) => (
+			<Text>{ STATUS_LABELS[ item.status ] || item.status }</Text>
+		),
+		description: ( { item } ) => (
+			<Text>{ ( item.description || '' ).slice( 0, 140 ) }</Text>
+		),
+		version: ( { item } ) => <Text>{ item.version || '' }</Text>,
+		author: ( { item } ) => <Text>{ item.author || '' }</Text>,
+	};
+}
+
+function buildFields( fieldSpecs, fieldRenderers ) {
+	return fieldSpecs
+		.filter( ( spec ) => spec && typeof spec === 'object' && spec.id )
+		.map( ( spec ) => {
+			const compiled = {
+				id: spec.id,
+				type: spec.type,
+				label: FIELD_LABELS[ spec.id ] ?? spec.label,
+			};
+			if ( spec.enableGlobalSearch !== undefined ) {
+				compiled.enableGlobalSearch = !! spec.enableGlobalSearch;
+			}
+			if ( spec.enableHiding !== undefined ) {
+				compiled.enableHiding = !! spec.enableHiding;
+			}
+			if ( spec.enableSorting !== undefined ) {
+				compiled.enableSorting = !! spec.enableSorting;
+			}
+			if ( Array.isArray( spec.elements ) ) {
+				compiled.elements = spec.elements;
+			} else if ( spec.id === 'status' && ! spec.elements ) {
+				compiled.elements = Object.entries( STATUS_LABELS ).map(
+					( [ value, label ] ) => ( { value, label } )
+				);
+			}
+			if ( spec.filterBy ) {
+				compiled.filterBy = spec.filterBy;
+			}
+			if ( fieldRenderers[ spec.id ] ) {
+				compiled.render = fieldRenderers[ spec.id ];
+			}
+			return compiled;
+		} );
+}
+
+function buildActions( actions, { activate, renderDetailsModal } ) {
+	const callbacks = {
+		activate: ( items ) => activate( items[ 0 ] ),
+	};
+
+	const renderers = {
+		details: renderDetailsModal,
+	};
+
+	return actions
+		.filter( ( spec ) => spec && typeof spec === 'object' && spec.id )
+		.map( ( spec ) => {
+			const compiled = {
+				id: spec.id,
+				label: ACTION_LABELS[ spec.id ] ?? spec.label,
+				isPrimary: !! spec.isPrimary,
+				isDestructive: !! spec.isDestructive,
+				supportsBulk: !! spec.supportsBulk,
+				icon: spec.icon ? resolveIcon( spec.icon ) : undefined,
+				isEligible: compileEligibility( spec.eligibleWhen ),
+			};
+			if ( renderers[ spec.id ] ) {
+				compiled.RenderModal = renderers[ spec.id ];
+			} else if ( callbacks[ spec.id ] ) {
+				compiled.callback = callbacks[ spec.id ];
+			}
+			return compiled;
+		} );
+}
+
+export default function ThemesApp( { config = {} } ) {
+	const variant = config.variant || null;
+
+	const { config: viewConfig } = useViewConfig( 'root', 'theme', variant );
+
 	const themesQuery = useMemo(
 		() => ( { context: 'edit', status: 'active,inactive' } ),
 		[]
@@ -28,19 +170,28 @@ export default function ThemesApp() {
 		themesQuery
 	);
 	const { invalidateResolution } = useDispatch( coreStore );
+	const { createNotice } = useDispatch( noticesStore );
 
-	const isLoading = isResolving;
-	const [ details, setDetails ] = useState( null );
+	const [ view, setView ] = useState( () => ( {
+		...VIEW_DEFAULTS,
+		...( viewConfig.defaultView || {} ),
+	} ) );
 
-	const activeStylesheet =
-		themes?.find( ( t ) => t.status === 'active' )?.stylesheet ||
-		window.wpAdminShell?.activeTheme ||
-		null;
+	// Resync `view` when the variant flips on the same hook instance —
+	// useState initializer runs once, so without this effect a variant switch
+	// inherits the prior triple's perPage / sort / filters. Keyed only on the
+	// variant axis (this app's variable input) so cascade re-resolves don't
+	// clobber in-session view edits.
+	useEffect( () => {
+		setView( {
+			...VIEW_DEFAULTS,
+			...( viewConfig.defaultView || {} ),
+		} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ variant ] );
 
 	const activate = useCallback(
 		async ( theme ) => {
-			// REST does not expose theme switching directly. Fall back to a
-			// custom endpoint when available, otherwise navigate to wp-admin.
 			try {
 				await apiFetch( {
 					path: '/wp-admin-shell/v1/activate-theme',
@@ -52,7 +203,11 @@ export default function ThemesApp() {
 					'theme',
 					themesQuery,
 				] );
-				setDetails( null );
+				createNotice(
+					'success',
+					__( 'Theme activated.', 'wp-admin-shell' ),
+					{ type: 'snackbar' }
+				);
 			} catch ( err ) {
 				const target =
 					( window.wpAdminShell?.adminUrl || '/wp-admin/' ) +
@@ -62,188 +217,138 @@ export default function ThemesApp() {
 				window.location.href = target;
 			}
 		},
-		[ invalidateResolution, themesQuery ]
+		[ invalidateResolution, themesQuery, createNotice ]
 	);
 
-	const sorted = useMemo( () => {
+	const renderDetailsModal = useCallback(
+		( { items, closeModal } ) => {
+			const item = items[ 0 ];
+			if ( ! item ) {
+				return null;
+			}
+			const isActive = item.status === 'active';
+			return (
+				<Stack
+					direction="column"
+					gap="md"
+					className="wp-admin-shell-app-themes__details-modal"
+				>
+					{ item.screenshot && (
+						<img src={ item.screenshot } alt="" />
+					) }
+					<Text variant="heading-md" render={ <h2 /> }>
+						{ item.name }
+					</Text>
+					<Text>{ item.description }</Text>
+					<Text variant="body-sm">
+						{ __( 'Version', 'wp-admin-shell' ) }: { item.version }
+						{ item.author
+							? ' · ' +
+							  __( 'Author', 'wp-admin-shell' ) +
+							  ': ' +
+							  item.author
+							: '' }
+					</Text>
+					<Stack direction="row" justify="flex-end" gap="sm">
+						{ item.theme_uri && (
+							<Button
+								tone="neutral"
+								variant="outline"
+								render={
+									<a
+										href={ item.theme_uri }
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								}
+							>
+								{ __( 'Theme site', 'wp-admin-shell' ) }
+							</Button>
+						) }
+						<Button variant="minimal" onClick={ closeModal }>
+							{ __( 'Close', 'wp-admin-shell' ) }
+						</Button>
+						{ ! isActive && (
+							<Button
+								tone="brand"
+								variant="solid"
+								onClick={ async () => {
+									await activate( item );
+									closeModal();
+								} }
+							>
+								{ __( 'Activate', 'wp-admin-shell' ) }
+							</Button>
+						) }
+					</Stack>
+				</Stack>
+			);
+		},
+		[ activate ]
+	);
+
+	const data = useMemo( () => {
 		if ( ! themes ) {
 			return [];
 		}
-		return [ ...themes ].sort( ( a, b ) => {
-			if ( a.stylesheet === activeStylesheet ) {
-				return -1;
-			}
-			if ( b.stylesheet === activeStylesheet ) {
-				return 1;
-			}
-			return ( a.name?.rendered || '' ).localeCompare(
-				b.name?.rendered || ''
-			);
-		} );
-	}, [ themes, activeStylesheet ] );
+		return themes.map( ( record ) => ( {
+			id: record.stylesheet,
+			stylesheet: record.stylesheet,
+			name: decodeEntities(
+				record.name?.rendered ||
+					record.name?.raw ||
+					record.stylesheet ||
+					''
+			),
+			screenshot: record.screenshot || '',
+			status: record.status,
+			description: stripTags( record.description?.rendered || '' ),
+			version: record.version || '',
+			author: stripTags( record.author?.rendered || '' ),
+			theme_uri: record.theme_uri || '',
+			rawRecord: record,
+		} ) );
+	}, [ themes ] );
 
-	if ( isLoading || ! themes ) {
-		return (
-			<div className="wp-admin-shell-app-themes__loading">
-				<Spinner />
-			</div>
-		);
-	}
+	const fields = useMemo(
+		() => buildFields( viewConfig.fields ?? [], buildFieldRenderers() ),
+		[ viewConfig ]
+	);
+
+	const actions = useMemo(
+		() =>
+			buildActions( viewConfig.actions ?? [], {
+				activate,
+				renderDetailsModal,
+			} ),
+		[ viewConfig, activate, renderDetailsModal ]
+	);
+
+	const paginationInfo = useMemo(
+		() => ( {
+			totalItems: data.length,
+			totalPages: 1,
+		} ),
+		[ data.length ]
+	);
+
+	const [ selection, setSelection ] = useState( [] );
 
 	return (
 		<div className="wp-admin-shell-app-themes">
-			<Stack
-				direction="row"
-				align="center"
-				gap="md"
-				className="wp-admin-shell-app-themes__header"
-			>
-				<Text variant="heading-md" render={ <h2 /> }>
-					{ __( 'Themes', 'wp-admin-shell' ) }
-				</Text>
-				<Text variant="body-sm">
-					{ themes.length } { __( 'installed', 'wp-admin-shell' ) }
-				</Text>
-			</Stack>
-
-			<Grid columns={ 3 } gap={ 4 }>
-				{ sorted.map( ( theme ) => {
-					const isActive = theme.stylesheet === activeStylesheet;
-					const screenshot = theme.screenshot || '';
-					return (
-						<Card.Root key={ theme.stylesheet }>
-							{ screenshot && (
-								<CardMedia>
-									<img
-										src={ screenshot }
-										alt={ theme.name?.rendered || '' }
-									/>
-								</CardMedia>
-							) }
-							<Card.Content>
-								<Stack direction="column" gap="sm">
-									<Stack
-										direction="row"
-										align="center"
-										justify="space-between"
-									>
-										<Text variant="body-md">
-											<strong>
-												{ theme.name?.rendered }
-											</strong>
-										</Text>
-										{ isActive && (
-											<Text variant="body-sm">
-												{ __(
-													'Active',
-													'wp-admin-shell'
-												) }
-											</Text>
-										) }
-									</Stack>
-									<Text variant="body-sm">
-										{ stripTags(
-											theme.description?.rendered || ''
-										).slice( 0, 140 ) }
-									</Text>
-								</Stack>
-							</Card.Content>
-							<Card.Content>
-								<Stack
-									direction="row"
-									justify="space-between"
-									align="center"
-								>
-									<Button
-										tone="neutral"
-										variant="outline"
-										size="compact"
-										onClick={ () =>
-											setDetails( {
-												theme,
-												isActive,
-											} )
-										}
-									>
-										{ __( 'Details', 'wp-admin-shell' ) }
-									</Button>
-									{ ! isActive && (
-										<Button
-											tone="brand"
-											variant="solid"
-											size="compact"
-											onClick={ () => activate( theme ) }
-										>
-											<Icon icon={ check } size={ 16 } />
-											{ __(
-												'Activate',
-												'wp-admin-shell'
-											) }
-										</Button>
-									) }
-								</Stack>
-							</Card.Content>
-						</Card.Root>
-					);
-				} ) }
-			</Grid>
-
-			{ details && (
-				<Modal
-					title={ details.theme.name?.rendered }
-					onRequestClose={ () => setDetails( null ) }
-					size="medium"
-				>
-					<Stack direction="column" gap="md">
-						{ details.theme.screenshot && (
-							<img
-								src={ details.theme.screenshot }
-								alt=""
-								style={ { maxWidth: '100%' } }
-							/>
-						) }
-						<Text variant="body-md">
-							{ stripTags(
-								details.theme.description?.rendered || ''
-							) }
-						</Text>
-						<Text variant="body-sm">
-							{ __( 'Version', 'wp-admin-shell' ) }:{ ' ' }
-							{ details.theme.version } ·{ ' ' }
-							{ __( 'Author', 'wp-admin-shell' ) }:{ ' ' }
-							{ stripTags(
-								details.theme.author?.rendered || ''
-							) }
-						</Text>
-						<Stack direction="row" justify="flex-end" gap="sm">
-							{ details.theme.theme_uri && (
-								<Button
-									tone="neutral"
-									variant="outline"
-									onClick={ () =>
-										window.open(
-											details.theme.theme_uri,
-											'_blank'
-										)
-									}
-								>
-									<Icon icon={ external } size={ 16 } />
-									{ __( 'Theme site', 'wp-admin-shell' ) }
-								</Button>
-							) }
-							{ ! details.isActive && (
-								<Button
-									tone="brand"
-									variant="solid"
-									onClick={ () => activate( details.theme ) }
-								>
-									{ __( 'Activate', 'wp-admin-shell' ) }
-								</Button>
-							) }
-						</Stack>
-					</Stack>
-				</Modal>
-			) }
+			<DataViews
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ setView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				isLoading={ isResolving }
+				defaultLayouts={ viewConfig.defaultLayouts ?? {} }
+				selection={ selection }
+				onChangeSelection={ setSelection }
+				getItemId={ ( item ) => item.id }
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Converts `core:themes` from the hand-rolled `Card.Root` grid into a DataViews host bound to `(root, theme)` so admin.json / filters can override fields, actions, defaultView, and defaultLayouts via the C2 cascade.
- Baseline ships in `app.json#viewConfig`: grid-default view (`titleField: name`, `mediaField: screenshot`), six fields (name / screenshot / status / description / version / author), two actions (Activate eligibleWhen `status=inactive`, Details RenderModal).
- `index.js` reads via `useViewConfig('root','theme',config.variant)` and applies the post-E patterns from PostsApp: `FIELD_LABELS` + `ACTION_LABELS` + `STATUS_LABELS` tables (locale-agnostic JSON specs gain `__()` labels for app-authored ids; plugin extension ids fall through to `spec.label`), view-state resync `useEffect` keyed on `[ variant ]`, title-dedup (titleField never appears in `defaultView.fields`), graceful-fallback activate via `/wp-admin-shell/v1/activate-theme` with the wp-admin link fallback retained.
- Adds `check` icon to the `core-default` engine icon registry so the Activate action resolves its icon by name.
- `app.md` documents the C2 cascade flow + translation recipe + parity gaps vs `docs/screens/themes.md`.
- CLAUDE.md app table notes view-config consumption for `core:posts` + `core:themes`.

## Behavior parity

- Activate POSTs the shell's custom endpoint, falls back to `themes.php?action=activate&stylesheet=…` on failure.
- Details opens a modal with screenshot, description, version, author, Theme site link, and an inline Activate button when non-active.
- Active theme floats to the top via `defaultView.sort.field: "status"` ascending (`'active' < 'inactive'` lexicographically).

## Test plan

- [x] `npm run build` (clean; size warnings unchanged)
- [x] `npm run lint:js` (clean)
- [x] `npm run test:schema` — `src/apps/themes/app.json` validates against `admin-app-v2.json`
- [x] `npm run test:runtime` — full 20-file chain green
- [x] `npm run test:parity` — 4/4
- [x] `npm run test:engines` — 7/7 (dock-rail-registry chain)
- [ ] PHP suites — wp-env couldn't start in this worktree (port 8888 held by another instance); no PHP code touched, cascade plumbing unchanged
- [ ] Manual browser smoke: load the themes route in `developer-admin`, confirm grid renders with screenshots, Activate fires the REST call (or falls back), Details opens the modal
- [ ] Optional cascade override: drop a temporary `viewConfigs.root.theme._default` in `developer-admin.json` and verify the override wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)