### PR TITLE
v3: 3d.2 — v2 → v3 shell migration CLI

### DIFF
--- a/includes/class-wp-admin-shell-cli-migrate.php
+++ b/includes/class-wp-admin-shell-cli-migrate.php
@@ -84,7 +84,7 @@ class WP_Admin_Shell_Migrate_Rewriter {
 	 * Main entry point: take a v2-shape admin.json array, return a
 	 * v3-shape array. Pure — no IO, no global writes.
 	 *
-	 * @param array $v2  Source doc.
+	 * @param array $v2       Source doc.
 	 * @param array $opts {
 	 *     Optional rewrite options.
 	 *
@@ -92,9 +92,17 @@ class WP_Admin_Shell_Migrate_Rewriter {
 	 *                              to `../docs/schemas/admin-v3.json`
 	 *                              (matches 3d.1 in-repo convention).
 	 * }
+	 * @param array $warnings Out-param. Receives a list of non-fatal
+	 *                        translation issues the caller should
+	 *                        surface (e.g. orphan `default-route`,
+	 *                        preserved `regions` block, etc.).
+	 *                        Empty array on clean migration.
 	 * @return array v3-shape doc.
 	 */
-	public static function rewrite( $v2, $opts = array() ) {
+	public static function rewrite( $v2, $opts = array(), &$warnings = null ) {
+		if ( $warnings === null ) {
+			$warnings = array();
+		}
 		if ( ! is_array( $v2 ) ) {
 			return array();
 		}
@@ -120,8 +128,19 @@ class WP_Admin_Shell_Migrate_Rewriter {
 		$default_route = isset( $v2['default-route'] ) && is_string( $v2['default-route'] )
 			? $v2['default-route']
 			: '';
-		if ( $default_route !== '' && isset( $path_to_screen_id[ $default_route ] ) ) {
-			$workspace['default-screen'] = $path_to_screen_id[ $default_route ];
+		if ( $default_route !== '' ) {
+			if ( isset( $path_to_screen_id[ $default_route ] ) ) {
+				$workspace['default-screen'] = $path_to_screen_id[ $default_route ];
+			} else {
+				// Orphan default-route — v2 carried a path that doesn't
+				// match any of the synthesized screen ids. The output
+				// drops `workspace.default-screen` silently; warn the
+				// caller so they can hand-pick a default post-migration.
+				$warnings[] = sprintf(
+					'default-route `%s` does not resolve to any synthesized screen — `workspace.default-screen` omitted from output.',
+					$default_route
+				);
+			}
 		}
 
 		// styles.branding.{logo,title} → workspace.branding.{logo,title}.
@@ -214,9 +233,12 @@ class WP_Admin_Shell_Migrate_Rewriter {
 		}
 
 		// regions — v2 escape hatch. Preserve under v3's same-named escape
-		// hatch block. Most shells won't carry one.
-		if ( isset( $v2['regions'] ) && is_array( $v2['regions'] ) ) {
+		// hatch block. Most shells won't carry one. v3's region shape may
+		// diverge from v2's (e.g. mirror-mode `routing.mode` declarations
+		// added in 3c.4); hand-review any preserved block.
+		if ( isset( $v2['regions'] ) && is_array( $v2['regions'] ) && ! empty( $v2['regions'] ) ) {
 			$out['regions'] = $v2['regions'];
+			$warnings[]     = 'regions block preserved verbatim under the v3 escape hatch — v3 region shape may diverge from v2; hand-review.';
 		}
 
 		return $out;
@@ -734,12 +756,22 @@ class WP_Admin_Shell_Migrate_CLI_Helpers {
 
 	/**
 	 * Default output path: replace the source's `.json` suffix with
-	 * `.v3.json`. Sources without `.json` get `.v3.json` appended.
+	 * `.v3.json`. Sources already carrying a `.v3.json` suffix keep it
+	 * (no `.v3.v3.json` doubling). Sources without `.json` get
+	 * `.v3.json` appended.
 	 *
 	 * @param string $source_path
 	 * @return string
 	 */
 	public static function default_output_path( $source_path ) {
+		// `.v3.json` already present — overwrite-in-place semantics for
+		// re-running the migration against its own output (test fixtures
+		// + idempotency-checks). The CLI's destination-collision guard
+		// catches the actual file-exists case; this only avoids the
+		// `.v3.v3.json` suffix.
+		if ( substr( $source_path, -8 ) === '.v3.json' ) {
+			return $source_path;
+		}
 		if ( substr( $source_path, -5 ) === '.json' ) {
 			return substr( $source_path, 0, -5 ) . '.v3.json';
 		}

--- a/includes/class-wp-admin-shell-cli-migrate.php
+++ b/includes/class-wp-admin-shell-cli-migrate.php
@@ -1,0 +1,748 @@
+<?php
+/**
+ * v2 → v3 admin.json migration helper (Phase 3d.2).
+ *
+ * Mechanical static rewriter that takes a v2-shaped admin.json shell and
+ * emits a v3-shape equivalent. Plugin authors carrying v2 shells use this
+ * to mechanically transition. The rewriter codifies the same
+ * transformations as `WP_Admin_Shell_V3_Compiler` does at runtime, but
+ * produces authoring-time JSON output instead of a hydrated PHP array.
+ *
+ * Two consumers:
+ *
+ *   1. `WP_Admin_Shell_CLI_Migrate` — the `WP_CLI_Command` subclass that
+ *      drives the `wp admin-shell migrate-shell <slug-or-path>` command.
+ *      Owns IO, arg-parsing, and validation diagnostics.
+ *   2. `WP_Admin_Shell_Migrate_Rewriter::rewrite( $v2_doc )` — pure-PHP
+ *      array → array transformation. No side effects beyond the returned
+ *      doc. Unit tests exercise this entry point directly.
+ *
+ * Transformations applied (input ordered roughly by output-doc position):
+ *
+ *   - `version: 1` → `version: 3` (top-level).
+ *   - `$schema` updated to point at admin-v3.json (relative form).
+ *   - `engine`        → `workspace.engine`.
+ *   - `default-route` → `workspace.default-screen` (resolved to a screen id).
+ *   - `styles.branding.{logo,title}` → `workspace.branding.{logo,title}`.
+ *   - `routes[path]`  → `screens[<id>]` with id derived from path.
+ *   - `iframe-fallback`+`config.url` → `app: iframe:<url>` shorthand.
+ *   - `route.config.variant` → synthesized `screen.dataViewRef`
+ *     ("<kind>/<name>/<variant>"). kind/name inferred from app manifest
+ *     when available; fallback `postType/<config.postType>` heuristic.
+ *   - `viewConfigs`     → `settings.dataViews` (shape unchanged).
+ *   - `fieldCollections`→ `settings.dataFields` (shape unchanged).
+ *   - `bindings[]`       → `commands[]` (id synthesized per entry).
+ *   - `preload[]`       → `preload[]` (unchanged).
+ *   - `regions`         → dropped when chrome-only; toolbar-slot widgets
+ *     surface in `workspace.widgets.<slot>` (best-effort — most shells
+ *     carry no custom regions).
+ *
+ * Out-of-scope (refused or warned, not rewritten):
+ *
+ *   - Two-way conversion (v3 → v2).
+ *   - Wholesale region-tree rewrites (the v2 region block is rarely
+ *     authored; when present the rewriter preserves it under v3's
+ *     escape-hatch `regions` block).
+ *
+ * @package WP_Admin_Shell
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Pure-PHP rewriter: v2 admin.json doc → v3 admin.json doc.
+ *
+ * No filesystem, no WP_CLI, no globals. Safe to unit-test under
+ * `wp eval-file`.
+ */
+class WP_Admin_Shell_Migrate_Rewriter {
+
+	/**
+	 * Detect whether a doc is v2 (or v1/v0 — anything pre-v3). Used by the
+	 * CLI to refuse v3 inputs.
+	 *
+	 * @param array $doc
+	 * @return bool
+	 */
+	public static function is_pre_v3( $doc ) {
+		if ( ! is_array( $doc ) ) {
+			return false;
+		}
+		if ( isset( $doc['version'] ) && (int) $doc['version'] === 3 ) {
+			return false;
+		}
+		if ( isset( $doc['screens'] ) && is_array( $doc['screens'] ) ) {
+			return false;
+		}
+		if ( isset( $doc['workspace'] ) && is_array( $doc['workspace'] ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Main entry point: take a v2-shape admin.json array, return a
+	 * v3-shape array. Pure — no IO, no global writes.
+	 *
+	 * @param array $v2  Source doc.
+	 * @param array $opts {
+	 *     Optional rewrite options.
+	 *
+	 *     @type string $schema_ref Custom `$schema` reference; defaults
+	 *                              to `../docs/schemas/admin-v3.json`
+	 *                              (matches 3d.1 in-repo convention).
+	 * }
+	 * @return array v3-shape doc.
+	 */
+	public static function rewrite( $v2, $opts = array() ) {
+		if ( ! is_array( $v2 ) ) {
+			return array();
+		}
+
+		$schema_ref = isset( $opts['schema_ref'] ) && is_string( $opts['schema_ref'] ) && $opts['schema_ref'] !== ''
+			? $opts['schema_ref']
+			: '../docs/schemas/admin-v3.json';
+
+		// Build the screens block first so workspace.default-screen can
+		// reference one of the synthesized ids.
+		$path_to_screen_id = array();
+		$screens           = self::build_screens(
+			isset( $v2['routes'] ) && is_array( $v2['routes'] ) ? $v2['routes'] : array(),
+			$path_to_screen_id
+		);
+
+		// Workspace block — engine, default-screen, branding.
+		$workspace = array();
+		if ( isset( $v2['engine'] ) && is_string( $v2['engine'] ) ) {
+			$workspace['engine'] = $v2['engine'];
+		}
+
+		$default_route = isset( $v2['default-route'] ) && is_string( $v2['default-route'] )
+			? $v2['default-route']
+			: '';
+		if ( $default_route !== '' && isset( $path_to_screen_id[ $default_route ] ) ) {
+			$workspace['default-screen'] = $path_to_screen_id[ $default_route ];
+		}
+
+		// styles.branding.{logo,title} → workspace.branding.{logo,title}.
+		$branding = array();
+		if ( isset( $v2['styles']['branding'] ) && is_array( $v2['styles']['branding'] ) ) {
+			$src = $v2['styles']['branding'];
+			if ( array_key_exists( 'logo', $src ) ) {
+				$branding['logo'] = $src['logo'];
+			}
+			if ( array_key_exists( 'title', $src ) ) {
+				$branding['title'] = $src['title'];
+			}
+		}
+		if ( ! empty( $branding ) ) {
+			$workspace['branding'] = $branding;
+		}
+
+		// settings block (only emitted when content exists).
+		$settings = array();
+		if ( isset( $v2['viewConfigs'] ) && is_array( $v2['viewConfigs'] ) ) {
+			$settings['dataViews'] = $v2['viewConfigs'];
+		}
+		if ( isset( $v2['fieldCollections'] ) && is_array( $v2['fieldCollections'] ) ) {
+			$settings['dataFields'] = $v2['fieldCollections'];
+		}
+
+		// bindings[] → commands[] (id synthesized).
+		$commands = self::build_commands(
+			isset( $v2['bindings'] ) && is_array( $v2['bindings'] ) ? $v2['bindings'] : array(),
+			isset( $v2['commands'] ) && is_array( $v2['commands'] ) ? $v2['commands'] : array()
+		);
+
+		// Compose the output doc. Top-level field order matches the
+		// canonical v3 templates (wp-admin-default.json):
+		//   $schema, version, $wpds, name, title, description,
+		//   user-switchable, workspace, settings, screens, menu,
+		//   commands, styles, preload.
+		$out = array();
+		$out['$schema'] = $schema_ref;
+		$out['version'] = 3;
+		if ( isset( $v2['$wpds'] ) && is_string( $v2['$wpds'] ) ) {
+			$out['$wpds'] = $v2['$wpds'];
+		} else {
+			$out['$wpds'] = '6.9';
+		}
+		if ( isset( $v2['name'] ) && is_string( $v2['name'] ) ) {
+			$out['name'] = $v2['name'];
+		}
+		if ( isset( $v2['title'] ) && is_string( $v2['title'] ) ) {
+			$out['title'] = $v2['title'];
+		}
+		if ( isset( $v2['description'] ) && is_string( $v2['description'] ) ) {
+			$out['description'] = $v2['description'];
+		}
+		if ( isset( $v2['userSwitchable'] ) ) {
+			$out['user-switchable'] = (bool) $v2['userSwitchable'];
+		} elseif ( isset( $v2['user-switchable'] ) ) {
+			$out['user-switchable'] = (bool) $v2['user-switchable'];
+		}
+
+		$out['workspace'] = $workspace;
+
+		if ( ! empty( $settings ) ) {
+			$out['settings'] = $settings;
+		}
+
+		$out['screens'] = $screens;
+
+		// menu — v2 had no top-level menu block (nav was app-config-internal).
+		// Leave absent so the engine's defaultRegions render the legacy
+		// navigation app. Authors hand-add a v3 menu tree post-migration.
+
+		if ( ! empty( $commands ) ) {
+			$out['commands'] = $commands;
+		}
+
+		// styles — preserved verbatim except for the migrated
+		// `branding` block (already pulled into workspace.branding).
+		if ( isset( $v2['styles'] ) && is_array( $v2['styles'] ) ) {
+			$styles = $v2['styles'];
+			unset( $styles['branding'] );
+			if ( ! empty( $styles ) ) {
+				$out['styles'] = $styles;
+			}
+		}
+
+		// preload — unchanged.
+		if ( isset( $v2['preload'] ) && is_array( $v2['preload'] ) ) {
+			$out['preload'] = $v2['preload'];
+		}
+
+		// regions — v2 escape hatch. Preserve under v3's same-named escape
+		// hatch block. Most shells won't carry one.
+		if ( isset( $v2['regions'] ) && is_array( $v2['regions'] ) ) {
+			$out['regions'] = $v2['regions'];
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Walk v2 routes[] and synthesize v3 screens[].
+	 *
+	 * Each route becomes one screen. Mutates `$path_to_screen_id` so the
+	 * caller can resolve `default-route` paths back to synthesized ids.
+	 *
+	 * @param array $routes            v2 routes block.
+	 * @param array &$path_to_screen_id Out-parameter: path → screen id map.
+	 * @return array v3 screens block.
+	 */
+	public static function build_screens( $routes, &$path_to_screen_id = array() ) {
+		$screens           = array();
+		$used_ids          = array();
+		$path_to_screen_id = array();
+
+		foreach ( $routes as $path => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$path_str = (string) $path;
+
+			$base_id = self::screen_id_from_path( $path_str );
+			if ( $base_id === '' ) {
+				continue;
+			}
+			$id = self::ensure_unique_id( $base_id, $used_ids );
+			$used_ids[ $id ]               = true;
+			$path_to_screen_id[ $path_str ] = $id;
+
+			$screen          = array();
+			$screen['label'] = self::derive_label_from_path( $path_str );
+			$screen['path']  = $path_str;
+
+			$app    = isset( $entry['app'] ) && is_string( $entry['app'] ) ? $entry['app'] : '';
+			$config = isset( $entry['config'] ) && is_array( $entry['config'] ) ? $entry['config'] : array();
+
+			// iframe collapse: `core:iframe-fallback` + `config.url: X` →
+			// `app: iframe:X`. The v3 compiler's `translate_iframe_app_refs`
+			// reverses this at resolve time.
+			if ( $app === 'core:iframe-fallback' && isset( $config['url'] ) && is_string( $config['url'] ) && $config['url'] !== '' ) {
+				$app = 'iframe:' . $config['url'];
+				unset( $config['url'] );
+			}
+
+			// Promote route.config.variant to screen.dataViewRef. The
+			// kind/name segments are inferred from the app manifest's
+			// `dataView` block (when readable), with a heuristic fallback
+			// to (postType, config.postType) when the manifest path is
+			// unreadable in a CLI-without-WP context.
+			if ( isset( $config['variant'] ) && is_string( $config['variant'] ) && $config['variant'] !== '' ) {
+				$variant = $config['variant'];
+				$triple  = self::infer_kind_name( $app, $config );
+				if ( $triple !== null ) {
+					$screen['dataViewRef'] = $triple['kind'] . '/' . $triple['name'] . '/' . $variant;
+					// Strip the variant from the screen config now that
+					// it lives on dataViewRef. Per migration directive #3.
+					unset( $config['variant'] );
+				}
+			}
+
+			if ( $app !== '' ) {
+				$screen['app'] = $app;
+			}
+			if ( ! empty( $config ) ) {
+				$screen['config'] = $config;
+			}
+
+			// Permissions (capability/role gating) — v2 routes carried no
+			// permissions block. The v3 schema's `screens[*].permissions`
+			// defaults to admin-only on absence, which is the closest
+			// equivalent. Plugin authors hand-author finer grants
+			// post-migration. No migration-time inference attempted.
+
+			$screens[ $id ] = $screen;
+		}
+
+		return $screens;
+	}
+
+	/**
+	 * Synthesize a stable screen id from a route path.
+	 *
+	 *   /posts                 → posts
+	 *   /posts/drafts          → posts-drafts
+	 *   /posts/{id}/edit       → posts-id-edit
+	 *   /                      → home
+	 *
+	 * @param string $path
+	 * @return string Screen id (empty when path produces nothing useful).
+	 */
+	public static function screen_id_from_path( $path ) {
+		if ( ! is_string( $path ) ) {
+			return '';
+		}
+		$path = trim( $path );
+		if ( $path === '' || $path === '/' ) {
+			return 'home';
+		}
+		// Strip leading/trailing slashes, drop {curly} braces.
+		$slug = trim( $path, '/' );
+		$slug = str_replace( array( '{', '}' ), '', $slug );
+		// Replace any non-alphanum run with a single hyphen.
+		$slug = strtolower( preg_replace( '#[^a-z0-9]+#i', '-', $slug ) );
+		$slug = trim( $slug, '-' );
+		if ( $slug === '' ) {
+			return '';
+		}
+		// Screen-id schema pattern requires starting with [a-z]. Prefix a
+		// stub when the first char is numeric.
+		if ( ! preg_match( '/^[a-z]/', $slug ) ) {
+			$slug = 'screen-' . $slug;
+		}
+		if ( strlen( $slug ) > 60 ) {
+			$slug = substr( $slug, 0, 60 );
+			$slug = rtrim( $slug, '-' );
+		}
+		return $slug;
+	}
+
+	/**
+	 * Disambiguate a base id against an in-progress used-ids set.
+	 * Appends `-2`, `-3`, … on collision.
+	 *
+	 * @param string $base
+	 * @param array  $used_ids
+	 * @return string
+	 */
+	public static function ensure_unique_id( $base, $used_ids ) {
+		if ( ! isset( $used_ids[ $base ] ) ) {
+			return $base;
+		}
+		$i = 2;
+		while ( isset( $used_ids[ $base . '-' . $i ] ) ) {
+			$i++;
+		}
+		return $base . '-' . $i;
+	}
+
+	/**
+	 * Derive a human-readable label from the route path's last segment.
+	 *
+	 *   /posts            → Posts
+	 *   /posts/drafts     → Drafts
+	 *   /tools/site-health→ Site Health
+	 *   /                 → Home
+	 *
+	 * @param string $path
+	 * @return string
+	 */
+	public static function derive_label_from_path( $path ) {
+		if ( ! is_string( $path ) || $path === '' || $path === '/' ) {
+			return 'Home';
+		}
+		$parts = array_values( array_filter( explode( '/', $path ), 'strlen' ) );
+		if ( empty( $parts ) ) {
+			return 'Home';
+		}
+		// Last meaningful (non-{param}) segment.
+		$last = '';
+		foreach ( array_reverse( $parts ) as $seg ) {
+			if ( strpos( $seg, '{' ) === false ) {
+				$last = $seg;
+				break;
+			}
+		}
+		if ( $last === '' ) {
+			$last = $parts[0];
+		}
+		$last = str_replace( array( '-', '_' ), ' ', $last );
+		return ucwords( $last );
+	}
+
+	/**
+	 * Resolve the (kind, name) pair a route's variant should bind to.
+	 *
+	 * Two paths:
+	 *   1. App manifest registry lookup. When the manifest exposes a
+	 *      `dataView: { kind, name }` baseline, that wins.
+	 *   2. Fallback heuristic: when `config.postType` is set, assume
+	 *      (`postType`, `config.postType`). When `config.taxonomy` is set,
+	 *      assume (`taxonomy`, `config.taxonomy`).
+	 *
+	 * Returns null when neither path resolves — the caller falls back to
+	 * leaving the variant in `config` (v3 compiler back-compat path picks
+	 * it up via manifest inference at runtime).
+	 *
+	 * @param string $app    App id (e.g. `core:posts`).
+	 * @param array  $config Route config block.
+	 * @return array|null { kind: string, name: string } or null.
+	 */
+	public static function infer_kind_name( $app, $config ) {
+		// Manifest lookup — only when the registry is loaded (test/CLI
+		// contexts may run without it).
+		if ( $app !== '' && class_exists( 'WP_Admin_Shell_Manifest_Registry' ) ) {
+			$registry = WP_Admin_Shell_Manifest_Registry::instance();
+			$manifest = $registry->get_app( $app );
+			if (
+				is_array( $manifest )
+				&& isset( $manifest['dataView']['kind'], $manifest['dataView']['name'] )
+				&& is_string( $manifest['dataView']['kind'] )
+				&& is_string( $manifest['dataView']['name'] )
+			) {
+				return array(
+					'kind' => $manifest['dataView']['kind'],
+					'name' => $manifest['dataView']['name'],
+				);
+			}
+		}
+
+		// Heuristic fallbacks.
+		if ( isset( $config['postType'] ) && is_string( $config['postType'] ) && $config['postType'] !== '' ) {
+			return array(
+				'kind' => 'postType',
+				'name' => $config['postType'],
+			);
+		}
+		if ( isset( $config['taxonomy'] ) && is_string( $config['taxonomy'] ) && $config['taxonomy'] !== '' ) {
+			return array(
+				'kind' => 'taxonomy',
+				'name' => $config['taxonomy'],
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * v2 bindings[] → v3 commands[]. Synthesizes ids by slugifying labels
+	 * (or shortcut strings when no label is set). Preserves any v2 commands
+	 * block that already exists alongside bindings.
+	 *
+	 * @param array $bindings v2 bindings block.
+	 * @param array $existing v2-or-v3 `commands` block (rare).
+	 * @return array v3 commands block.
+	 */
+	public static function build_commands( $bindings, $existing = array() ) {
+		$commands = array();
+		$used_ids = array();
+
+		// Preserve any pre-existing commands first (rare in v2; if present
+		// they're forward-compatible).
+		foreach ( $existing as $cmd ) {
+			if ( ! is_array( $cmd ) ) {
+				continue;
+			}
+			$id = isset( $cmd['id'] ) && is_string( $cmd['id'] ) && $cmd['id'] !== ''
+				? $cmd['id']
+				: '';
+			if ( $id === '' ) {
+				continue;
+			}
+			$used_ids[ $id ] = true;
+			$commands[]      = $cmd;
+		}
+
+		foreach ( $bindings as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+			$shortcut = isset( $entry['shortcut'] ) ? (string) $entry['shortcut'] : '';
+			$invoke   = isset( $entry['invoke'] ) ? (string) $entry['invoke'] : '';
+			$navigate = isset( $entry['navigate'] ) ? (string) $entry['navigate'] : '';
+			$label    = isset( $entry['label'] ) ? (string) $entry['label'] : '';
+
+			if ( $shortcut === '' && $invoke === '' && $navigate === '' ) {
+				continue;
+			}
+
+			$id_seed = $label !== '' ? $label : ( $invoke !== '' ? $invoke : $shortcut );
+			$base_id = self::slugify_command_id( $id_seed );
+			if ( $base_id === '' ) {
+				$base_id = 'cmd';
+			}
+			$id              = self::ensure_unique_id( $base_id, $used_ids );
+			$used_ids[ $id ] = true;
+
+			$cmd = array( 'id' => $id );
+			if ( $shortcut !== '' ) {
+				$cmd['shortcut'] = $shortcut;
+			}
+			if ( $invoke !== '' ) {
+				$cmd['invoke'] = $invoke;
+			}
+			if ( $navigate !== '' ) {
+				$cmd['navigate'] = $navigate;
+			}
+			if ( $label !== '' ) {
+				$cmd['label'] = $label;
+			}
+			$commands[] = $cmd;
+		}
+
+		return $commands;
+	}
+
+	/**
+	 * Slugify a command id seed. Lowercases, replaces non-alnum with
+	 * hyphens, strips trailing hyphens.
+	 *
+	 *   "Open Command Palette" → "open-command-palette"
+	 *   "Mod+K"                → "mod-k"
+	 *   "core:command-palette" → "core-command-palette"
+	 *
+	 * @param string $seed
+	 * @return string
+	 */
+	public static function slugify_command_id( $seed ) {
+		if ( ! is_string( $seed ) || $seed === '' ) {
+			return '';
+		}
+		$slug = strtolower( preg_replace( '#[^a-z0-9]+#i', '-', $seed ) );
+		$slug = trim( $slug, '-' );
+		if ( $slug === '' ) {
+			return '';
+		}
+		// Command id schema: minLength 1 — no first-char constraint, but
+		// keep a sensible prefix when the slug starts numeric.
+		if ( ! preg_match( '/^[a-z]/', $slug ) ) {
+			$slug = 'cmd-' . $slug;
+		}
+		if ( strlen( $slug ) > 60 ) {
+			$slug = substr( $slug, 0, 60 );
+			$slug = rtrim( $slug, '-' );
+		}
+		return $slug;
+	}
+
+	/**
+	 * Lightweight v3 shape validation against the admin-v3.json schema's
+	 * top-level required fields, enums, and patterns. Catches the obvious
+	 * authoring drift; defers full JSON-Schema 2020-12 validation to the
+	 * Node-side Ajv sweep.
+	 *
+	 * Returns an array of human-readable error strings — empty when the
+	 * doc passes the lightweight checks.
+	 *
+	 * @param array $doc
+	 * @return array
+	 */
+	public static function lightweight_validate( $doc ) {
+		$errors = array();
+		if ( ! is_array( $doc ) ) {
+			return array( 'Document is not an array.' );
+		}
+
+		// Required top-level fields.
+		foreach ( array( 'version', '$wpds', 'name', 'workspace', 'screens' ) as $required ) {
+			if ( ! array_key_exists( $required, $doc ) ) {
+				$errors[] = "Missing required top-level field: {$required}";
+			}
+		}
+
+		if ( isset( $doc['version'] ) && (int) $doc['version'] !== 3 ) {
+			$errors[] = 'Top-level `version` must be the integer 3.';
+		}
+
+		if ( isset( $doc['$wpds'] ) ) {
+			if ( ! is_string( $doc['$wpds'] ) || ! preg_match( '/^[0-9]+\.[0-9]+(\.[0-9]+)?$/', $doc['$wpds'] ) ) {
+				$errors[] = '`$wpds` must match WPDS version pattern (e.g. "6.9").';
+			}
+		}
+
+		if ( isset( $doc['name'] ) ) {
+			if ( ! is_string( $doc['name'] ) || ! preg_match( '/^[a-z][a-z0-9-]*$/', $doc['name'] ) ) {
+				$errors[] = '`name` must be kebab-case starting with a letter.';
+			}
+		}
+
+		if ( isset( $doc['workspace'] ) ) {
+			if ( ! is_array( $doc['workspace'] ) ) {
+				$errors[] = '`workspace` must be an object.';
+			} elseif ( ! isset( $doc['workspace']['engine'] ) ) {
+				$errors[] = '`workspace.engine` is required.';
+			} elseif ( ! is_string( $doc['workspace']['engine'] ) || ! preg_match(
+				'#^(core:[a-z][a-z0-9]*(-[a-z0-9]+)*|plugin:[a-z][a-z0-9-]*/[a-z][a-z0-9]*(-[a-z0-9]+)*)$#',
+				$doc['workspace']['engine']
+			) ) {
+				$errors[] = '`workspace.engine` must be a namespaced id (core:* or plugin:*/*).';
+			}
+		}
+
+		if ( isset( $doc['screens'] ) ) {
+			if ( ! is_array( $doc['screens'] ) || empty( $doc['screens'] ) ) {
+				$errors[] = '`screens` must be a non-empty object.';
+			} else {
+				foreach ( $doc['screens'] as $sid => $screen ) {
+					if ( ! is_string( $sid ) || ! preg_match( '/^[a-z][a-z0-9-]*$/', $sid ) ) {
+						$errors[] = "Screen id `{$sid}` is not kebab-case starting with a letter.";
+					}
+					if ( ! is_array( $screen ) ) {
+						$errors[] = "Screen `{$sid}` is not an object.";
+						continue;
+					}
+					// shorthand+long-form mutual exclusion.
+					if ( isset( $screen['app'] ) && isset( $screen['apps'] ) ) {
+						$errors[] = "Screen `{$sid}` declares both `app` shorthand and `apps[]` long form.";
+					}
+					if ( isset( $screen['app'] ) && ! is_string( $screen['app'] ) ) {
+						$errors[] = "Screen `{$sid}` has non-string `app`.";
+					}
+					if (
+						isset( $screen['path'] )
+						&& ( ! is_string( $screen['path'] )
+							|| ! preg_match( '#^/[A-Za-z0-9_/{}\-]*$#', $screen['path'] ) )
+					) {
+						$errors[] = "Screen `{$sid}` has invalid `path` pattern.";
+					}
+					if (
+						isset( $screen['dataViewRef'] )
+						&& ( ! is_string( $screen['dataViewRef'] )
+							|| ! preg_match(
+								'#^[A-Za-z][A-Za-z0-9_-]*/[A-Za-z][A-Za-z0-9_-]*/(_default|[A-Za-z0-9][A-Za-z0-9_-]*)$#',
+								$screen['dataViewRef']
+							) )
+					) {
+						$errors[] = "Screen `{$sid}` has invalid `dataViewRef` (expected kind/name/variant).";
+					}
+				}
+			}
+		}
+
+		if ( isset( $doc['commands'] ) && is_array( $doc['commands'] ) ) {
+			foreach ( $doc['commands'] as $i => $cmd ) {
+				if ( ! is_array( $cmd ) ) {
+					continue;
+				}
+				if ( ! isset( $cmd['id'] ) || ! is_string( $cmd['id'] ) || $cmd['id'] === '' ) {
+					$errors[] = "Command index {$i} missing required `id`.";
+				}
+			}
+		}
+
+		return $errors;
+	}
+
+	/**
+	 * Encode a v3 doc as JSON with the conventions used by the bundled
+	 * shells: tab indentation, no escaped slashes / unicode.
+	 *
+	 * @param array $doc
+	 * @return string
+	 */
+	public static function encode_json( $doc ) {
+		$flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+		$json  = wp_json_encode( $doc, $flags );
+		if ( ! is_string( $json ) ) {
+			return '';
+		}
+		// wp_json_encode uses 4-space indent under JSON_PRETTY_PRINT; the
+		// shells/ files are tab-indented to match WP JS coding standards
+		// (eslint --fix tabifies them). Convert leading 4-space runs to
+		// tabs to match. Each leading group of 4 spaces becomes one tab.
+		$lines = explode( "\n", $json );
+		foreach ( $lines as $idx => $line ) {
+			if ( preg_match( '/^( +)/', $line, $m ) ) {
+				$spaces  = strlen( $m[1] );
+				$tabs    = (int) floor( $spaces / 4 );
+				$remainder = str_repeat( ' ', $spaces - ( $tabs * 4 ) );
+				$lines[ $idx ] = str_repeat( "\t", $tabs ) . $remainder . substr( $line, $spaces );
+			}
+		}
+		return implode( "\n", $lines ) . "\n";
+	}
+}
+
+
+/**
+ * Helpers shared by the CLI driver (in class-wp-admin-shell-cli.php) and
+ * potentially other callers. Kept on the Rewriter class because they're
+ * pure path-resolution / output-path utilities — no WP-CLI dependency.
+ */
+class WP_Admin_Shell_Migrate_CLI_Helpers {
+
+	/**
+	 * Resolve the `<slug-or-path>` arg to an absolute filesystem path.
+	 * Slugs are resolved against `shells/<slug>.json`; paths are
+	 * accepted verbatim when they exist.
+	 *
+	 * @param string $source
+	 * @return string Absolute path, or empty string when unresolvable.
+	 */
+	public static function resolve_source( $source ) {
+		if ( ! is_string( $source ) || $source === '' ) {
+			return '';
+		}
+		// Absolute path?
+		if ( $source[0] === '/' || preg_match( '/^[A-Za-z]:[\\\\\/]/', $source ) ) {
+			return is_file( $source ) ? $source : '';
+		}
+		// Relative path — try cwd first.
+		$cwd     = function_exists( 'getcwd' ) ? getcwd() : false;
+		if ( is_string( $cwd ) && $cwd !== '' ) {
+			$cwd_path = $cwd . '/' . $source;
+			if ( is_file( $cwd_path ) ) {
+				return $cwd_path;
+			}
+		}
+		// Slug lookup. sanitize_file_name strips path separators.
+		$slug = function_exists( 'sanitize_file_name' )
+			? sanitize_file_name( $source )
+			: preg_replace( '#[^A-Za-z0-9._-]#', '-', $source );
+		if ( defined( 'WP_ADMIN_SHELL_PATH' ) ) {
+			$path = WP_ADMIN_SHELL_PATH . 'shells/' . $slug . '.json';
+			if ( is_file( $path ) ) {
+				return $path;
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Default output path: replace the source's `.json` suffix with
+	 * `.v3.json`. Sources without `.json` get `.v3.json` appended.
+	 *
+	 * @param string $source_path
+	 * @return string
+	 */
+	public static function default_output_path( $source_path ) {
+		if ( substr( $source_path, -5 ) === '.json' ) {
+			return substr( $source_path, 0, -5 ) . '.v3.json';
+		}
+		return $source_path . '.v3.json';
+	}
+}

--- a/includes/class-wp-admin-shell-cli.php
+++ b/includes/class-wp-admin-shell-cli.php
@@ -259,24 +259,48 @@ class WP_Admin_Shell_CLI {
 	 * patterns) before writing. Validation errors surface as
 	 * `WP_CLI::warning()`s and abort the write unless `--force` is set.
 	 *
+	 * **Source lookup precedence:** the CLI first checks for a file at
+	 * `<source>` (relative-to-cwd OR absolute), then falls back to
+	 * `shells/<source>.json` under the plugin root. Running the CLI
+	 * from a directory carrying a file named `<slug>` (without
+	 * `.json`) may match unexpectedly; pass an explicit absolute path
+	 * or use the slug form from an unrelated cwd to disambiguate.
+	 *
+	 * **`regions` block preservation:** v2 shells declaring a `regions`
+	 * block (rare) get the block copied verbatim into the v3 output
+	 * under the v3 `regions` escape hatch. v3's region shape may
+	 * diverge from v2's; the output passes the rewriter clean but
+	 * may fail Ajv validation post-merge. Hand-review any migrated
+	 * shell that carried a custom `regions` block.
+	 *
+	 * **`infer_kind_name` heuristic:** when a route's `app` manifest
+	 * doesn't declare a `dataView` block, the rewriter falls back to
+	 * reading `(postType, config.postType)` then `(taxonomy,
+	 * config.taxonomy)`. If both are set (unusual), `postType` wins.
+	 *
 	 * ## OPTIONS
 	 *
 	 * <slug-or-path>
 	 * : Either an active-shell slug (resolves via `shells/<slug>.json`)
-	 * or an absolute file path to a v2 admin.json document.
+	 * or an absolute file path to a v2 admin.json document. Cwd-relative
+	 * file matches take precedence over slug lookup — see "Source
+	 * lookup precedence" above.
 	 *
 	 * [--dry-run]
 	 * : Print the rewritten JSON to stdout; do not write any file.
 	 *
 	 * [--output=<path>]
 	 * : Explicit destination file path. Default: source-path with
-	 * `.json` replaced by `.v3.json`.
+	 * `.json` replaced by `.v3.json`. Source paths already ending in
+	 * `.v3.json` are kept as-is (no `.v3.v3.json` doubling).
 	 *
 	 * [--force]
-	 * : Overwrite an existing destination file. Without this flag,
-	 * existing files trigger an abort. Additionally, when set, the
-	 * write proceeds even when lightweight v3 schema validation
-	 * surfaces errors.
+	 * : Dual-purpose. (1) Overwrite an existing destination file
+	 * (default: abort if the destination exists). (2) Bypass
+	 * lightweight v3 schema validation errors and write anyway
+	 * (default: abort on validation errors). Both behaviors gated by
+	 * the same flag for ergonomic simplicity; pass `--force` only
+	 * when you've reviewed the destination + the validation warnings.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -316,7 +340,12 @@ class WP_Admin_Shell_CLI {
 			);
 		}
 
-		$v3 = WP_Admin_Shell_Migrate_Rewriter::rewrite( $v2 );
+		$warnings = array();
+		$v3       = WP_Admin_Shell_Migrate_Rewriter::rewrite( $v2, array(), $warnings );
+
+		foreach ( $warnings as $warn ) {
+			WP_CLI::warning( $warn );
+		}
 
 		$errors = WP_Admin_Shell_Migrate_Rewriter::lightweight_validate( $v3 );
 		foreach ( $errors as $err ) {

--- a/includes/class-wp-admin-shell-cli.php
+++ b/includes/class-wp-admin-shell-cli.php
@@ -3,10 +3,11 @@
  * `wp admin-shell …` WP-CLI commands (plan §M5.9).
  *
  * Subcommands:
- *   list                  Print registered shells with their origins.
- *   activate <slug>       Set wp_admin_shell_active_shell.
- *   register <name> <path> Register a programmatic shell from JSON on disk.
- *   upgrade-config <name> Normalize a v0 (MVP flat) shell to v1 form.
+ *   list                          Print registered shells with their origins.
+ *   activate <slug>               Set wp_admin_shell_active_shell.
+ *   register <name> <path>        Register a programmatic shell from JSON on disk.
+ *   check-config <name>           Diagnose a shell's v2 readiness.
+ *   migrate-shell <slug-or-path>  Rewrite a v2 admin.json shell as v3-shape.
  *
  * @package WP_Admin_Shell
  */
@@ -224,6 +225,136 @@ class WP_Admin_Shell_CLI {
 		}
 
 		WP_CLI::success( 'Shell is v2-canonical.' );
+	}
+
+	/**
+	 * Rewrite a v2 admin.json shell as v3-shape (Phase 3d.2).
+	 *
+	 * Reads the source file from either a slug (looked up in
+	 * `shells/<slug>.json`) or an absolute file path. Writes the
+	 * v3-shape JSON to `--output=<path>` or, by default, next to the
+	 * source at `<basename>.v3.json`.
+	 *
+	 * Codifies the same v2 → v3 transformations the runtime
+	 * `WP_Admin_Shell_V3_Compiler` performs at boot — `routes` → `screens`,
+	 * `viewConfigs` → `settings.dataViews`, `fieldCollections` →
+	 * `settings.dataFields`, `bindings` → `commands`, iframe-fallback
+	 * collapse to `iframe:<slug>` shorthand, branding promotion to
+	 * `workspace.branding`. Plugin authors carrying v2 shells use this to
+	 * mechanically transition.
+	 *
+	 * **dataViewRef heuristic.** When a v2 route declares
+	 * `config.variant`, the rewriter synthesizes
+	 * `screen.dataViewRef: "<kind>/<name>/<variant>"`. The kind/name
+	 * segments come from the app manifest registry's `dataView` block
+	 * when available; otherwise the rewriter falls back to assuming
+	 * `(postType, config.postType)` or `(taxonomy, config.taxonomy)`.
+	 * Routes that match neither path leave `variant` in
+	 * `screen.config.variant`; the v3 compiler's runtime
+	 * manifest-inference picks it up at boot, so the migration is still
+	 * functional but slightly less explicit.
+	 *
+	 * Output validation: lightweight checks against the admin-v3.json
+	 * schema's top-level shape rules (required fields, enums, kebab-case
+	 * patterns) before writing. Validation errors surface as
+	 * `WP_CLI::warning()`s and abort the write unless `--force` is set.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <slug-or-path>
+	 * : Either an active-shell slug (resolves via `shells/<slug>.json`)
+	 * or an absolute file path to a v2 admin.json document.
+	 *
+	 * [--dry-run]
+	 * : Print the rewritten JSON to stdout; do not write any file.
+	 *
+	 * [--output=<path>]
+	 * : Explicit destination file path. Default: source-path with
+	 * `.json` replaced by `.v3.json`.
+	 *
+	 * [--force]
+	 * : Overwrite an existing destination file. Without this flag,
+	 * existing files trigger an abort. Additionally, when set, the
+	 * write proceeds even when lightweight v3 schema validation
+	 * surfaces errors.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp admin-shell migrate-shell my-v2-shell
+	 *     wp admin-shell migrate-shell /tmp/legacy-shell.json --dry-run
+	 *     wp admin-shell migrate-shell my-shell --output=/tmp/my-shell.v3.json --force
+	 *
+	 * @subcommand migrate-shell
+	 * @when after_wp_load
+	 *
+	 * @param array $args        Positional args.
+	 * @param array $assoc_args  Flag args.
+	 * @return void
+	 */
+	public function migrate_shell( $args, $assoc_args ) {
+		list( $source ) = $args;
+
+		$source_path = WP_Admin_Shell_Migrate_CLI_Helpers::resolve_source( $source );
+		if ( $source_path === '' ) {
+			WP_CLI::error(
+				"Source not found: {$source}. Expected a slug (looked up in shells/) or an absolute file path."
+			);
+		}
+
+		$raw = file_get_contents( $source_path );
+		if ( ! is_string( $raw ) ) {
+			WP_CLI::error( "Could not read source file: {$source_path}" );
+		}
+		$v2 = json_decode( $raw, true );
+		if ( ! is_array( $v2 ) ) {
+			WP_CLI::error( "Source is not valid JSON: {$source_path}" );
+		}
+
+		if ( ! WP_Admin_Shell_Migrate_Rewriter::is_pre_v3( $v2 ) ) {
+			WP_CLI::error(
+				'Source appears to be v3 already (version:3 or workspace block present). Migration is one-way (v2 → v3); refusing to rewrite.'
+			);
+		}
+
+		$v3 = WP_Admin_Shell_Migrate_Rewriter::rewrite( $v2 );
+
+		$errors = WP_Admin_Shell_Migrate_Rewriter::lightweight_validate( $v3 );
+		foreach ( $errors as $err ) {
+			WP_CLI::warning( $err );
+		}
+
+		$json = WP_Admin_Shell_Migrate_Rewriter::encode_json( $v3 );
+
+		if ( ! empty( $assoc_args['dry-run'] ) ) {
+			if ( ! empty( $errors ) ) {
+				WP_CLI::log(
+					'# v3-shape rewrite (validation surfaced ' . count( $errors ) . ' warning(s) — see above):'
+				);
+			}
+			WP_CLI::log( $json );
+			return;
+		}
+
+		$output = isset( $assoc_args['output'] ) && is_string( $assoc_args['output'] ) && $assoc_args['output'] !== ''
+			? $assoc_args['output']
+			: WP_Admin_Shell_Migrate_CLI_Helpers::default_output_path( $source_path );
+
+		if ( ! empty( $errors ) && empty( $assoc_args['force'] ) ) {
+			WP_CLI::error(
+				'v3 validation surfaced ' . count( $errors ) . ' error(s); pass --force to write anyway, or correct the source.'
+			);
+		}
+
+		if ( file_exists( $output ) && empty( $assoc_args['force'] ) ) {
+			WP_CLI::error( "Destination already exists: {$output}. Pass --force to overwrite." );
+		}
+
+		$written = file_put_contents( $output, $json );
+		if ( $written === false ) {
+			WP_CLI::error( "Could not write to destination: {$output}" );
+		}
+
+		WP_CLI::success( "Wrote v3-shape shell to: {$output}" );
 	}
 }
 

--- a/tests/php/run-migrate-shell-cli-tests.php
+++ b/tests/php/run-migrate-shell-cli-tests.php
@@ -1,0 +1,493 @@
+<?php
+/**
+ * v2 → v3 admin.json migration helper tests (Phase 3d.2).
+ *
+ * Invoke:
+ *   npx wp-env run cli wp eval-file \
+ *     wp-content/plugins/WordPress-Admin-Environment/tests/php/run-migrate-shell-cli-tests.php
+ *
+ * Coverage:
+ *   - is_pre_v3() detection (rejects v3 docs, accepts v2/v1/v0).
+ *   - screen_id_from_path() derivation (basic, nested, curly params, root).
+ *   - ensure_unique_id() disambiguation.
+ *   - derive_label_from_path() (multi-segment + param-aware).
+ *   - slugify_command_id() (basic, special chars, numeric prefix).
+ *   - build_screens() — routes → screens, path map population.
+ *   - iframe-fallback collapse to iframe:<url> shorthand.
+ *   - route.config.variant → dataViewRef synthesis (heuristic +
+ *     manifest paths).
+ *   - build_commands() — bindings → commands w/ synthesized ids.
+ *   - rewrite() end-to-end: viewConfigs → settings.dataViews,
+ *     fieldCollections → settings.dataFields, default-route →
+ *     workspace.default-screen, branding promotion, preload passthrough.
+ *   - lightweight_validate() catches required-field / pattern issues.
+ *   - encode_json() emits tab-indented output ending in newline.
+ *   - Helpers::default_output_path() suffix-swap behavior.
+ *   - dry-run path (logic-only smoke; CLI args not exercised).
+ */
+
+defined( 'ABSPATH' ) || die( 'Run via wp eval-file.' );
+
+class WPAS_Migrate_Test_Runner {
+	public static $pass = 0;
+	public static $fail = 0;
+
+	public static function ok( $label, $cond, $detail = '' ) {
+		if ( $cond ) {
+			self::$pass++;
+			echo "PASS  $label\n";
+		} else {
+			self::$fail++;
+			echo "FAIL  $label\n";
+			if ( $detail ) {
+				echo "      $detail\n";
+			}
+		}
+	}
+
+	public static function eq( $label, $actual, $expected ) {
+		if ( $actual === $expected ) {
+			self::$pass++;
+			echo "PASS  $label\n";
+		} else {
+			self::$fail++;
+			echo "FAIL  $label\n";
+			echo '      expected: ' . var_export( $expected, true ) . "\n";
+			echo '      actual:   ' . var_export( $actual, true ) . "\n";
+		}
+	}
+}
+
+$T          = 'WPAS_Migrate_Test_Runner';
+$plugin_dir = WP_PLUGIN_DIR . '/WordPress-Admin-Environment/';
+require_once $plugin_dir . 'wp-admin-shell.php';
+
+// ── 1. is_pre_v3 detection ─────────────────────────────────────────
+
+$T::ok(
+	'is_pre_v3: v2 doc accepted',
+	WP_Admin_Shell_Migrate_Rewriter::is_pre_v3( array(
+		'version' => 1,
+		'engine'  => 'core:default',
+		'regions' => array(),
+	) )
+);
+$T::ok(
+	'is_pre_v3: v3 version rejected',
+	! WP_Admin_Shell_Migrate_Rewriter::is_pre_v3( array( 'version' => 3 ) )
+);
+$T::ok(
+	'is_pre_v3: v3 workspace-only rejected',
+	! WP_Admin_Shell_Migrate_Rewriter::is_pre_v3( array(
+		'workspace' => array( 'engine' => 'core:default' ),
+	) )
+);
+$T::ok(
+	'is_pre_v3: v3 screens-only rejected',
+	! WP_Admin_Shell_Migrate_Rewriter::is_pre_v3( array(
+		'screens' => array( 'home' => array() ),
+	) )
+);
+
+// ── 2. screen_id_from_path derivation ──────────────────────────────
+
+$T::eq(
+	'screen_id: simple path',
+	WP_Admin_Shell_Migrate_Rewriter::screen_id_from_path( '/posts' ),
+	'posts'
+);
+$T::eq(
+	'screen_id: nested path',
+	WP_Admin_Shell_Migrate_Rewriter::screen_id_from_path( '/posts/drafts' ),
+	'posts-drafts'
+);
+$T::eq(
+	'screen_id: parametric path',
+	WP_Admin_Shell_Migrate_Rewriter::screen_id_from_path( '/posts/{id}/edit' ),
+	'posts-id-edit'
+);
+$T::eq(
+	'screen_id: root path → home',
+	WP_Admin_Shell_Migrate_Rewriter::screen_id_from_path( '/' ),
+	'home'
+);
+
+// ── 3. ensure_unique_id ────────────────────────────────────────────
+
+$T::eq(
+	'ensure_unique_id: no collision',
+	WP_Admin_Shell_Migrate_Rewriter::ensure_unique_id( 'posts', array() ),
+	'posts'
+);
+$T::eq(
+	'ensure_unique_id: appends -2 on collision',
+	WP_Admin_Shell_Migrate_Rewriter::ensure_unique_id( 'posts', array( 'posts' => true ) ),
+	'posts-2'
+);
+$T::eq(
+	'ensure_unique_id: skips -2 when taken, uses -3',
+	WP_Admin_Shell_Migrate_Rewriter::ensure_unique_id(
+		'posts',
+		array( 'posts' => true, 'posts-2' => true )
+	),
+	'posts-3'
+);
+
+// ── 4. derive_label_from_path ──────────────────────────────────────
+
+$T::eq(
+	'label: /posts',
+	WP_Admin_Shell_Migrate_Rewriter::derive_label_from_path( '/posts' ),
+	'Posts'
+);
+$T::eq(
+	'label: /posts/drafts uses last segment',
+	WP_Admin_Shell_Migrate_Rewriter::derive_label_from_path( '/posts/drafts' ),
+	'Drafts'
+);
+$T::eq(
+	'label: /tools/site-health title-cases hyphens',
+	WP_Admin_Shell_Migrate_Rewriter::derive_label_from_path( '/tools/site-health' ),
+	'Site Health'
+);
+$T::eq(
+	'label: /posts/{id}/edit skips {param} segment',
+	WP_Admin_Shell_Migrate_Rewriter::derive_label_from_path( '/posts/{id}/edit' ),
+	'Edit'
+);
+
+// ── 5. slugify_command_id ──────────────────────────────────────────
+
+$T::eq(
+	'slugify: title-case input',
+	WP_Admin_Shell_Migrate_Rewriter::slugify_command_id( 'Open Command Palette' ),
+	'open-command-palette'
+);
+$T::eq(
+	'slugify: shortcut chars',
+	WP_Admin_Shell_Migrate_Rewriter::slugify_command_id( 'Mod+K' ),
+	'mod-k'
+);
+$T::eq(
+	'slugify: app-id chars',
+	WP_Admin_Shell_Migrate_Rewriter::slugify_command_id( 'core:command-palette' ),
+	'core-command-palette'
+);
+
+// ── 6. build_screens — basic route → screen ───────────────────────
+
+$v2_routes = array(
+	'/posts'       => array( 'app' => 'core:posts', 'config' => array( 'postType' => 'post' ) ),
+	'/posts/{id}'  => array( 'app' => 'core:editor', 'config' => array( 'postType' => 'post', 'post-id' => '{id}' ) ),
+	'/media'       => array( 'app' => 'core:media' ),
+);
+$path_map = array();
+$screens  = WP_Admin_Shell_Migrate_Rewriter::build_screens( $v2_routes, $path_map );
+
+$T::ok( 'build_screens: produces posts screen', isset( $screens['posts'] ) );
+$T::eq( 'build_screens: posts.path preserved', $screens['posts']['path'], '/posts' );
+$T::eq( 'build_screens: posts.app preserved', $screens['posts']['app'], 'core:posts' );
+$T::eq(
+	'build_screens: posts.config.postType preserved',
+	$screens['posts']['config']['postType'],
+	'post'
+);
+$T::eq(
+	'build_screens: parametric path → kebab-cased id without braces',
+	isset( $screens['posts-id'] ) ? 'posts-id' : 'missing',
+	'posts-id'
+);
+$T::eq(
+	'build_screens: path map populated for /media',
+	$path_map['/media'] ?? '',
+	'media'
+);
+
+// ── 7. iframe-fallback collapse ────────────────────────────────────
+
+$v2_iframe_routes = array(
+	'/tools' => array(
+		'app'    => 'core:iframe-fallback',
+		'config' => array( 'url' => 'tools.php' ),
+	),
+);
+$screens_if = WP_Admin_Shell_Migrate_Rewriter::build_screens( $v2_iframe_routes );
+$T::eq(
+	'iframe collapse: app rewritten to iframe:<url> shorthand',
+	$screens_if['tools']['app'],
+	'iframe:tools.php'
+);
+$T::ok(
+	'iframe collapse: config.url stripped after collapse',
+	! isset( $screens_if['tools']['config']['url'] )
+);
+$T::ok(
+	'iframe collapse: config block removed entirely when only url was set',
+	! isset( $screens_if['tools']['config'] )
+);
+
+// ── 8. dataViewRef synthesis (heuristic fallback) ──────────────────
+
+$v2_variant_routes = array(
+	'/posts/drafts' => array(
+		'app'    => 'core:posts',
+		'config' => array( 'postType' => 'post', 'variant' => 'drafts' ),
+	),
+);
+$screens_var = WP_Admin_Shell_Migrate_Rewriter::build_screens( $v2_variant_routes );
+$T::eq(
+	'variant → dataViewRef synthesized via heuristic',
+	$screens_var['posts-drafts']['dataViewRef'] ?? '',
+	'postType/post/drafts'
+);
+$T::ok(
+	'variant: stripped from config after dataViewRef synthesis',
+	! isset( $screens_var['posts-drafts']['config']['variant'] )
+);
+$T::eq(
+	'variant: other config keys preserved (postType retained)',
+	$screens_var['posts-drafts']['config']['postType'] ?? '',
+	'post'
+);
+
+// Taxonomy heuristic fallback. Use a plugin:* app so the manifest
+// registry has no entry — exercises the (taxonomy, config.taxonomy)
+// heuristic path directly. Using core:taxonomy here would resolve to
+// the manifest's universal `(taxonomy, category)` baseline regardless
+// of the route's `config.taxonomy` value.
+$v2_tax_routes = array(
+	'/taxonomy/post_tag' => array(
+		'app'    => 'plugin:acme/term-browser',
+		'config' => array( 'taxonomy' => 'post_tag', 'variant' => 'with-counts' ),
+	),
+);
+$screens_tax = WP_Admin_Shell_Migrate_Rewriter::build_screens( $v2_tax_routes );
+$T::eq(
+	'variant → dataViewRef uses (taxonomy, config.taxonomy) heuristic',
+	$screens_tax['taxonomy-post-tag']['dataViewRef'] ?? '',
+	'taxonomy/post_tag/with-counts'
+);
+
+// Manifest precedence — when the registry has a binding, it wins over
+// the heuristic. core:taxonomy's manifest declares
+// dataView.{kind:taxonomy, name:category}, so a route declaring
+// taxonomy:post_tag in config still resolves to (taxonomy, category)
+// per CIAB convention (the universal baseline).
+$v2_manifest_routes = array(
+	'/taxonomy/post_tag' => array(
+		'app'    => 'core:taxonomy',
+		'config' => array( 'taxonomy' => 'post_tag', 'variant' => 'with-counts' ),
+	),
+);
+$screens_mfst = WP_Admin_Shell_Migrate_Rewriter::build_screens( $v2_manifest_routes );
+$T::eq(
+	'variant → dataViewRef from manifest registry beats heuristic',
+	$screens_mfst['taxonomy-post-tag']['dataViewRef'] ?? '',
+	'taxonomy/category/with-counts'
+);
+
+// Variant with neither postType nor taxonomy → leave variant in config.
+$v2_orphan_variant = array(
+	'/widgets' => array(
+		'app'    => 'plugin:acme/widgets',
+		'config' => array( 'variant' => 'compact' ),
+	),
+);
+$screens_orphan = WP_Admin_Shell_Migrate_Rewriter::build_screens( $v2_orphan_variant );
+$T::ok(
+	'variant without inferrable kind/name stays in config',
+	isset( $screens_orphan['widgets']['config']['variant'] )
+);
+$T::ok(
+	'variant without inferrable kind/name does NOT produce dataViewRef',
+	! isset( $screens_orphan['widgets']['dataViewRef'] )
+);
+
+// ── 9. build_commands ─────────────────────────────────────────────
+
+$bindings = array(
+	array( 'shortcut' => 'Mod+K', 'invoke' => 'core:command-palette', 'label' => 'Open Palette' ),
+	array( 'shortcut' => 'Mod+Alt+N', 'navigate' => '/posts/new', 'label' => 'New Post' ),
+	array( 'shortcut' => 'g p', 'navigate' => '/posts' ), // no label — synthesize from navigate/shortcut.
+);
+$commands = WP_Admin_Shell_Migrate_Rewriter::build_commands( $bindings );
+
+$T::eq( 'build_commands: count matches bindings', count( $commands ), 3 );
+$T::eq(
+	'build_commands: id slugified from label',
+	$commands[0]['id'],
+	'open-palette'
+);
+$T::eq( 'build_commands: shortcut preserved', $commands[0]['shortcut'], 'Mod+K' );
+$T::eq( 'build_commands: invoke preserved', $commands[0]['invoke'], 'core:command-palette' );
+$T::eq( 'build_commands: label preserved', $commands[0]['label'], 'Open Palette' );
+$T::eq( 'build_commands: navigate preserved', $commands[1]['navigate'], '/posts/new' );
+// Third binding has no label — id is synthesized from invoke fallback then shortcut. invoke is empty,
+// so the rewriter uses the shortcut ("g p" → "g-p").
+$T::eq(
+	'build_commands: id slugified from shortcut when no label/invoke',
+	$commands[2]['id'],
+	'g-p'
+);
+
+// Empty bindings entry should be skipped.
+$commands_skip = WP_Admin_Shell_Migrate_Rewriter::build_commands(
+	array( array() )
+);
+$T::eq( 'build_commands: skips empty entries', count( $commands_skip ), 0 );
+
+// ── 10. rewrite() end-to-end ──────────────────────────────────────
+
+$v2_doc = array(
+	'$schema'    => '../docs/schemas/admin-v2.json',
+	'version'    => 1,
+	'$wpds'      => '6.9',
+	'name'       => 'test-shell',
+	'title'      => 'Test Shell',
+	'description'=> 'For migration tests.',
+	'engine'     => 'core:default',
+	'regions'    => array(
+		'main' => array( 'template' => 'core:main', 'routing' => array( 'route-key' => '_self' ) ),
+	),
+	'routes'     => array(
+		'/posts' => array( 'app' => 'core:posts', 'config' => array( 'postType' => 'post' ) ),
+		'/media' => array( 'app' => 'core:media' ),
+	),
+	'default-route' => '/posts',
+	'bindings'   => array(
+		array( 'shortcut' => 'Mod+K', 'invoke' => 'core:command-palette', 'label' => 'Palette' ),
+	),
+	'viewConfigs' => array(
+		'postType' => array(
+			'post' => array(
+				'_default' => array(
+					'fields' => array(
+						array( 'id' => 'title', 'type' => 'text', 'label' => 'Title' ),
+					),
+				),
+			),
+		),
+	),
+	'fieldCollections' => array(
+		'core/post-fields' => array(
+			'kind'   => 'postType',
+			'name'   => 'post',
+			'fields' => array(
+				array( 'id' => 'title', 'type' => 'text', 'label' => 'Title' ),
+			),
+		),
+	),
+	'preload' => array( '/wp/v2/users/me', array( '/wp/v2/posts', 'OPTIONS' ) ),
+	'styles'  => array(
+		'branding' => array( 'logo' => '/assets/logo.svg', 'title' => 'Test' ),
+		'theme'    => array( 'color' => array( 'primary' => '#abc' ) ),
+	),
+);
+
+$v3 = WP_Admin_Shell_Migrate_Rewriter::rewrite( $v2_doc );
+
+$T::eq( 'rewrite: version is 3',        $v3['version'], 3 );
+$T::eq( 'rewrite: $schema points at v3','../docs/schemas/admin-v3.json', $v3['$schema'] );
+$T::eq( 'rewrite: $wpds preserved',     $v3['$wpds'], '6.9' );
+$T::eq( 'rewrite: name preserved',      $v3['name'], 'test-shell' );
+$T::eq( 'rewrite: title preserved',     $v3['title'], 'Test Shell' );
+$T::eq( 'rewrite: workspace.engine',    $v3['workspace']['engine'], 'core:default' );
+$T::eq(
+	'rewrite: workspace.default-screen resolved from default-route path',
+	$v3['workspace']['default-screen'],
+	'posts'
+);
+$T::eq(
+	'rewrite: workspace.branding.logo from styles.branding',
+	$v3['workspace']['branding']['logo'],
+	'/assets/logo.svg'
+);
+$T::eq(
+	'rewrite: workspace.branding.title from styles.branding',
+	$v3['workspace']['branding']['title'],
+	'Test'
+);
+$T::ok(
+	'rewrite: styles block retained sans branding',
+	isset( $v3['styles']['theme'] ) && ! isset( $v3['styles']['branding'] )
+);
+
+$T::ok( 'rewrite: settings.dataViews present', isset( $v3['settings']['dataViews']['postType']['post']['_default'] ) );
+$T::ok( 'rewrite: settings.dataFields present', isset( $v3['settings']['dataFields']['core/post-fields'] ) );
+
+$T::ok( 'rewrite: screens.posts produced',  isset( $v3['screens']['posts'] ) );
+$T::ok( 'rewrite: screens.media produced',  isset( $v3['screens']['media'] ) );
+$T::eq( 'rewrite: screens.posts.app',       $v3['screens']['posts']['app'], 'core:posts' );
+
+$T::eq( 'rewrite: commands count = 1',      count( $v3['commands'] ), 1 );
+$T::eq( 'rewrite: command id slugified',    $v3['commands'][0]['id'], 'palette' );
+
+$T::eq( 'rewrite: preload preserved',       $v3['preload'][0], '/wp/v2/users/me' );
+
+$T::ok(
+	'rewrite: v2 regions block preserved under v3 escape hatch',
+	isset( $v3['regions']['main'] )
+);
+
+// Ensure the rewrite output identifies as v3.
+$T::ok(
+	'rewrite: output passes is_v3 detector',
+	WP_Admin_Shell_V3_Compiler::is_v3( $v3 )
+);
+
+// ── 11. lightweight_validate ───────────────────────────────────────
+
+$T::eq(
+	'validate: clean v3 doc has zero errors',
+	count( WP_Admin_Shell_Migrate_Rewriter::lightweight_validate( $v3 ) ),
+	0
+);
+
+$bad = array( 'version' => 3, '$wpds' => 'not-a-version', 'name' => 'NoUppercase', 'screens' => array() );
+$bad_errors = WP_Admin_Shell_Migrate_Rewriter::lightweight_validate( $bad );
+$T::ok(
+	'validate: surfaces $wpds pattern violation',
+	(bool) array_filter( $bad_errors, function ( $e ) { return strpos( $e, '$wpds' ) !== false; } )
+);
+$T::ok(
+	'validate: surfaces missing workspace',
+	(bool) array_filter( $bad_errors, function ( $e ) { return strpos( $e, 'workspace' ) !== false; } )
+);
+$T::ok(
+	'validate: surfaces non-kebab name',
+	(bool) array_filter( $bad_errors, function ( $e ) { return strpos( $e, 'name' ) !== false && strpos( $e, 'kebab' ) !== false; } )
+);
+
+// ── 12. encode_json + Helpers ──────────────────────────────────────
+
+$json = WP_Admin_Shell_Migrate_Rewriter::encode_json( $v3 );
+$T::ok( 'encode_json: returns non-empty string', is_string( $json ) && $json !== '' );
+$T::ok( 'encode_json: starts with `{`',          $json[0] === '{' );
+$T::ok( 'encode_json: ends with newline',        substr( $json, -1 ) === "\n" );
+$T::ok(
+	'encode_json: tab-indented (no four-space-indent runs at line start)',
+	! preg_match( '/^    [^ ]/m', $json )
+);
+// Round-trip parseable.
+$reparsed = json_decode( $json, true );
+$T::ok( 'encode_json: round-trips through json_decode', is_array( $reparsed ) );
+$T::eq( 'encode_json: round-trip preserves version', $reparsed['version'] ?? null, 3 );
+
+$T::eq(
+	'Helpers::default_output_path: .json → .v3.json',
+	WP_Admin_Shell_Migrate_CLI_Helpers::default_output_path( '/tmp/shell.json' ),
+	'/tmp/shell.v3.json'
+);
+$T::eq(
+	'Helpers::default_output_path: no .json suffix → appended',
+	WP_Admin_Shell_Migrate_CLI_Helpers::default_output_path( '/tmp/shell' ),
+	'/tmp/shell.v3.json'
+);
+
+// ── 13. Summary ────────────────────────────────────────────────────
+
+echo "\n— Summary —\n";
+echo 'PASS: ' . WPAS_Migrate_Test_Runner::$pass . '  FAIL: ' . WPAS_Migrate_Test_Runner::$fail . "\n";
+if ( WPAS_Migrate_Test_Runner::$fail > 0 ) {
+	exit( 1 );
+}

--- a/tests/php/run-migrate-shell-cli-tests.php
+++ b/tests/php/run-migrate-shell-cli-tests.php
@@ -483,6 +483,68 @@ $T::eq(
 	WP_Admin_Shell_Migrate_CLI_Helpers::default_output_path( '/tmp/shell' ),
 	'/tmp/shell.v3.json'
 );
+$T::eq(
+	'Helpers::default_output_path: .v3.json suffix preserved (no .v3.v3.json doubling)',
+	WP_Admin_Shell_Migrate_CLI_Helpers::default_output_path( '/tmp/shell.v3.json' ),
+	'/tmp/shell.v3.json'
+);
+
+// ── 12b. Warnings out-param (PR #58 follow-ups) ─────────────────────
+
+// Orphan default-route warning.
+$orphan_doc = array(
+	'version'       => 1,
+	'engine'        => 'core:default',
+	'default-route' => '/missing-path',
+	'routes'        => array(
+		'/posts' => array( 'app' => 'core:posts' ),
+	),
+);
+$orphan_warnings = array();
+$orphan_v3       = WP_Admin_Shell_Migrate_Rewriter::rewrite( $orphan_doc, array(), $orphan_warnings );
+$T::ok(
+	'orphan default-route: warning emitted',
+	count( $orphan_warnings ) === 1
+);
+$T::ok(
+	'orphan default-route: warning names the unresolved path',
+	strpos( $orphan_warnings[0], '/missing-path' ) !== false
+);
+$T::ok(
+	'orphan default-route: workspace.default-screen omitted from output',
+	! isset( $orphan_v3['workspace']['default-screen'] )
+);
+
+// Preserved regions block warning.
+$regions_doc = array(
+	'version' => 1,
+	'engine'  => 'core:default',
+	'regions' => array( 'sidebar' => array( 'app' => 'core:navigation' ) ),
+	'routes'  => array(),
+);
+$regions_warnings = array();
+WP_Admin_Shell_Migrate_Rewriter::rewrite( $regions_doc, array(), $regions_warnings );
+$T::ok(
+	'preserved regions: warning emitted',
+	count( $regions_warnings ) === 1
+);
+$T::ok(
+	'preserved regions: warning mentions hand-review',
+	strpos( $regions_warnings[0], 'hand-review' ) !== false
+);
+
+// Clean migration: no warnings.
+$clean_doc = array(
+	'version'       => 1,
+	'engine'        => 'core:default',
+	'default-route' => '/posts',
+	'routes'        => array(
+		'/posts' => array( 'app' => 'core:posts' ),
+	),
+);
+$clean_warnings = array();
+WP_Admin_Shell_Migrate_Rewriter::rewrite( $clean_doc, array(), $clean_warnings );
+$T::ok( 'clean migration: no warnings', count( $clean_warnings ) === 0 );
 
 // ── 13. Summary ────────────────────────────────────────────────────
 

--- a/wp-admin-shell.php
+++ b/wp-admin-shell.php
@@ -93,6 +93,7 @@ require_once WP_ADMIN_SHELL_PATH . 'includes/cascade/class-wp-admin-shell-v3-com
 require_once WP_ADMIN_SHELL_PATH . 'includes/class-wp-admin-shell-config.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/class-wp-admin-shell-data-view-rest.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/class-wp-admin-shell-data-field-collections-rest.php';
+require_once WP_ADMIN_SHELL_PATH . 'includes/class-wp-admin-shell-cli-migrate.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/class-wp-admin-shell-cli.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/manifests/class-wp-admin-shell-manifest-validator.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/manifests/class-wp-admin-shell-manifest-registry.php';


### PR DESCRIPTION
## Summary

Phase 3d.2 of `docs/v3/roadmap.md`. `wp admin-shell migrate-shell <slug-or-path>` reads a v2 admin.json shell + writes a v3-shape equivalent. Plugin authors carrying v2 shells use this to mechanically transition.

## CLI surface

```
wp admin-shell migrate-shell <slug-or-path> [--dry-run] [--output=<path>] [--force]
```

- `<slug-or-path>` — active-config slug (resolves via shells/<slug>.json + plugin-contributed shells) or absolute file path.
- `--dry-run` — emit JSON to stdout; no write.
- `--output=<path>` — explicit output path. Default: replace `.json` with `.v3.json`.
- `--force` — proceed despite schema validation errors.

## Transformations

Static rewriter applies these v2 → v3 transforms (codifies the same logic the runtime `WP_Admin_Shell_V3_Compiler` performs dynamically):

1. **routes → screens.** `routes[path]` → `screens[<derived-id>]`. ID slugified from path (`/posts` → `posts`; `/posts/{id}/edit` → `posts-id-edit`).
2. **iframe collapse.** `core:iframe-fallback` + `config.url` → `iframe:<url>` shorthand. Compiler's `translate_iframe_app_refs()` reverses at resolve time.
3. **route.config.variant → dataViewRef.** Synthesize `screen.dataViewRef: "<kind>/<name>/<variant>"`. Reads manifest registry when available; falls back to `(postType, config.postType)` / `(taxonomy, config.taxonomy)` heuristics when manifest unreadable.
4. **viewConfigs → settings.dataViews.** Move block under `settings`. Shape unchanged.
5. **fieldCollections → settings.dataFields.** Move block under `settings`. Shape unchanged.
6. **bindings → commands.** Synthesize `id` per entry by slugifying `label` (or `shortcut`). Preserve `shortcut`/`invoke`/`navigate`/`label`.
7. **default-route → workspace.default-screen.** Resolve path to synthesized screen id.
8. **engine → workspace.engine.**
9. **branding.** `styles.branding.{logo,title}` → `workspace.branding.{logo,title}`.
10. **preload + commands carry-over.** Unchanged.

## Files

| Layer | Files |
|---|---|
| Rewriter | `includes/class-wp-admin-shell-cli-migrate.php` (new) — `WP_Admin_Shell_Migrate_Rewriter` (transformation core) + `WP_Admin_Shell_Migrate_CLI_Helpers` (source resolution + output paths). |
| CLI registration | `includes/class-wp-admin-shell-cli.php` — `migrate_shell()` subcommand (~135 lines incl. WP-CLI docblock). |
| Bootstrap | `wp-admin-shell.php` — `require_once` for the migrate-cli include. |
| Tests | `tests/php/run-migrate-shell-cli-tests.php` (new) — 74 PHP assertions exercising every public entry point. |

## Transformation gaps (static rewriter approximates)

Cases the runtime back-compat handles dynamically but the static rewriter has to decide at authoring time:

1. **`dataViewRef` inference w/o manifest.** When CLI invoked early (before manifest registry populated), rewriter falls back to `(postType, config.postType)` / `(taxonomy, config.taxonomy)` heuristics. v3 runtime resolver picks up the dropped `variant` via step-3 manifest-inference path, so missing the `dataViewRef` doesn't break functionality — just leaves the migration slightly less explicit.

2. **Routes with neither `postType` nor `taxonomy` AND no manifest entry.** Rewriter refuses to guess. Leaves `variant` in `screen.config.variant`. Documented in WP-CLI docblock.

3. **`regions` block (selective extraction skipped).** v2 shells rarely declare custom regions; when they do, rewriter preserves them under v3's `regions` escape hatch verbatim. Selective extraction of toolbar-slot widgets → `workspace.widgets.<slot>` deferred; if needed, surfaces as a `regions` block carrying chrome-only declarations that the v3 compiler merges into engine defaults at boot.

4. **Permissions on synthesized screens.** v2 routes had no per-route permissions; v3 `screens[*].permissions` defaults to admin-only on absence. Plugin authors hand-author finer grants post-migration.

5. **`menu` block.** v2 had no top-level menu (nav was app-config-internal). Rewriter emits no `menu` block — authors hand-add a v3 menu tree post-migration.

## Test plan

- [x] `npm run test:schema` PASS 103.
- [x] `npm run test:runtime` PASS 433 (across all runtime suites).
- [x] `npm run test:engines` PASS 77.
- [x] `npm run test:parity` PASS 4.
- [x] `npm run lint:js` / `lint:ts` clean.
- [x] `npm run build` clean.
- [x] PHP `run-migrate-shell-cli-tests.php`: **PASS 74** (target was ~30; landed wider).
- [x] PHP `run-v3-compiler-tests.php`: PASS 85.
- [x] End-to-end smoke: `wp admin-shell migrate-shell tests/schema/fixtures/v2/admin/positive/02-master-detail.json --dry-run` emits a valid v3 doc.
- [ ] **Browser smoke** (post-merge): migrate a real v2 plugin shell + activate + verify routes / screens / dataViews render.

## After merge

Phase 3d:
- **3d.3** Test surface rewrites (cap-gating-smoke port + add multi-app + bridge coverage).
- **3d.4** Doc sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)