### PR TITLE
SiteIcon: resolve icon from branding → REST site_icon_url → default

### DIFF
--- a/src/apps/site-hub/SiteIcon.js
+++ b/src/apps/site-hub/SiteIcon.js
@@ -1,8 +1,15 @@
 import { Icon, wordpress } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
 
 /**
- * Site icon — renders the branding logo from config, or falls back to the
- * WordPress icon.
+ * Site icon — resolves the icon in priority order:
+ *   1. Author-declared `branding.logo` from the admin.json styles cascade.
+ *   2. The site's REST `site_icon_url` (from `root/__unstableBase`) — the
+ *      Site Icon a user sets in Settings → General, matching the Site
+ *      Editor's SiteIcon behavior.
+ *   3. The default WordPress mark.
  *
  * Hardening notes:
  *   - `config?.branding` is null-guarded so callers that pass an empty
@@ -13,11 +20,26 @@ import { Icon, wordpress } from '@wordpress/icons';
  *     *and* protocol-relative absolute paths (`/wp-content/uploads/…`).
  *     Anything else is treated as plugin-relative and prefixed with
  *     `wpAdminShell.pluginUrl`.
+ *   - While `__unstableBase` is still resolving and no icon URL is known
+ *     yet, an empty sized placeholder renders so the fallback mark doesn't
+ *     flash before a configured site icon paints (mirrors edit-site).
  * @param {Object} root0
  * @param {*}      root0.config
  */
 export default function SiteIcon( { config } ) {
 	const branding = config?.branding || {};
+
+	const { isRequestingSite, siteIconUrl } = useSelect( ( select ) => {
+		const siteData = select( coreStore ).getEntityRecord(
+			'root',
+			'__unstableBase',
+			undefined
+		);
+		return {
+			isRequestingSite: ! siteData,
+			siteIconUrl: siteData?.site_icon_url,
+		};
+	}, [] );
 
 	if ( branding.logo ) {
 		const isAbsolute = /^(https?:|\/)/.test( branding.logo );
@@ -29,7 +51,21 @@ export default function SiteIcon( { config } ) {
 		return (
 			<img
 				src={ src }
-				alt=""
+				alt={ __( 'Site Icon', 'wp-admin-shell' ) }
+				className="wp-admin-shell-site-icon__image"
+			/>
+		);
+	}
+
+	if ( isRequestingSite && ! siteIconUrl ) {
+		return <div className="wp-admin-shell-site-icon__image" />;
+	}
+
+	if ( siteIconUrl ) {
+		return (
+			<img
+				src={ siteIconUrl }
+				alt={ __( 'Site Icon', 'wp-admin-shell' ) }
 				className="wp-admin-shell-site-icon__image"
 			/>
 		);
@@ -37,7 +73,7 @@ export default function SiteIcon( { config } ) {
 
 	return (
 		<div className="wp-admin-shell-site-icon__default">
-			<Icon icon={ wordpress } size={ 32 } />
+			<Icon icon={ wordpress } size={ 48 } />
 		</div>
 	);
 }

--- a/src/apps/site-hub/app.json
+++ b/src/apps/site-hub/app.json
@@ -15,7 +15,7 @@
 	},
 	"script": "wp-admin-shell",
 	"documentation": {
-		"purpose": "Branded header at the top of the navigation sidebar. Renders site icon (linked to the dashboard URL) + site title (linked to the home URL, opens in new tab) + a command-palette toggle. Site icon respects `styles.branding.*` cascade values; site title comes from `useEntityRecord('root', 'site').record.title` with HTML-entity decoding and a window-global fallback.",
+		"purpose": "Branded header at the top of the navigation sidebar. Renders site icon (linked to the dashboard URL) + site title (linked to the home URL, opens in new tab) + a command-palette toggle. Site icon resolves in priority order: `styles.branding.*` cascade logo → REST `site_icon_url` (Settings → General) → default WordPress mark. Site title comes from `useEntityRecord('root', 'site').record.title` with HTML-entity decoding and a window-global fallback.",
 		"data": {
 			"reads": [
 				{
@@ -25,9 +25,15 @@
 					"fields": [ "title", "url" ]
 				},
 				{
+					"source": "root/__unstableBase",
+					"via": "core-data",
+					"purpose": "Home URL for the site-title anchor (`home`) and the REST Site Icon fallback when no branding logo is configured (`site_icon_url`). Mirrors edit-site SiteHub/SiteIcon.",
+					"fields": [ "home", "site_icon_url" ]
+				},
+				{
 					"source": "config.styles.branding",
 					"via": "kernel-config",
-					"purpose": "Branded site icon — branding object read from the resolved admin.json tree via `useKernel()` and passed to SiteIcon helper."
+					"purpose": "Branded site icon — branding object read from the resolved admin.json tree via `useKernel()` and passed to SiteIcon helper. Takes precedence over the REST `site_icon_url`."
 				},
 				{
 					"source": "window.wpAdminShell.siteName",
@@ -37,12 +43,13 @@
 				{
 					"source": "window.wpAdminShell.homeUrl | siteUrl | dashboardUrl",
 					"via": "window-global",
-					"purpose": "Anchor hrefs for the site-icon button (dashboard) and the site-title button (home, new tab)."
+					"purpose": "Anchor href for the site-icon button (dashboard); fallback href for the site-title button (home, new tab) when `root/__unstableBase.home` has not resolved."
 				}
 			]
 		},
 		"states": [
 			{ "id": "ready", "when": "Always (renders with whatever data is available; falls back gracefully)", "renders": "Site icon + title + command-palette icon button. Title falls back to filterURLForDisplay(site.url) when title is empty but URL is set." },
+			{ "id": "icon-loading", "when": "No branding logo configured AND `root/__unstableBase` not yet resolved", "renders": "An empty sized placeholder for the icon (no fallback-mark flash) until `site_icon_url` resolves or is confirmed absent." },
 			{ "id": "transparent-icon", "when": "appConfig.isTransparent === true", "renders": "Site-icon container drops its background — useful when the engine's chrome already provides the surface." }
 		],
 		"interactions": [
@@ -67,8 +74,7 @@
 			{ "concern": "stack-flex-defense", "note": "`@wordpress/ui` Stack flex rules live in `@layer wp-ui-components` and lose to unlayered WP-admin CSS. The bundled `core:default` engine ships an unlayered `[class*=\"__stack\"] { display: flex }` defensive rule. A rebuild using Stack-style flex must defeat unlayered host CSS the same way." }
 		],
 		"design-system-leakage": [
-			{ "import": "@wordpress/ui#Button, IconButton, Stack", "purpose": "Three controls + layout primitives." },
-			{ "import": "@wordpress/components#VisuallyHidden", "purpose": "Visually-hidden `(opens in a new tab)` hint." },
+			{ "import": "@wordpress/ui#Button, IconButton, Stack, VisuallyHidden", "purpose": "Three controls + layout primitives + visually-hidden `(opens in a new tab)` hint." },
 			{ "import": "@wordpress/icons#search", "purpose": "Command-palette icon." },
 			{ "import": "@wordpress/commands#store", "purpose": "Open the global palette via `dispatch('core/commands').open()`." },
 			{ "import": "@wordpress/keycodes#displayShortcut", "purpose": "Format the `Mod+K` shortcut hint for the palette button." },

--- a/src/apps/site-hub/app.md
+++ b/src/apps/site-hub/app.md
@@ -12,7 +12,7 @@ The title-source-of-truth distinction matters: `useEntityRecord('root','site').r
 
 `memo + forwardRef` wrapping is deliberate. Engines may attach refs to measure the hub's rendered size for layout calculations; the forwardRef keeps that contract usable. `memo` is a defensive optimization — the hub re-renders on every kernel state change otherwise.
 
-`SiteIcon` (sibling helper) renders the branded icon — reads `styles.branding.*` from the cascade and resolves to whatever asset path is set, or falls back to a default WordPress mark.
+`SiteIcon` (sibling helper) resolves the icon in priority order: the author-declared `styles.branding.*` logo from the cascade → the site's REST `site_icon_url` (read from `root/__unstableBase`, the icon a user sets in Settings → General) → the default WordPress mark. While `__unstableBase` is still resolving and no branding logo is set, it renders an empty sized placeholder so the fallback mark doesn't flash before a configured icon paints — mirroring edit-site's `SiteIcon`.
 
 The ellipsis-in-flex pattern for the title is the one CLAUDE.md calls out: `display: flex; min-width: 0;` on the wrapper + `flex-grow: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap` on the Button. Both halves are required — WPDS Button is `inline-flex` by default; the wrapper's `min-width: 0` overrides the default `min-width: auto`; the wrapper's `display: flex` makes the Button's `flex-grow` actually stretch.
 
@@ -29,7 +29,7 @@ A non-WPDS rebuild needs:
 
 ## Known limitations
 
-- **Site icon doesn't honor `site_icon` REST field.** It uses the engine's branding cascade. A future iteration could fall back to the REST `site_icon` URL when no engine branding is configured.
 - **No notification badge.** wp-admin shows update counts as a badge on the admin bar; the shell omits this here.
+- **No mobile variant.** edit-site ships a separate `SiteHubMobile` with back-navigation logic (block theme → `/`, classic-with-StyleBook → `/`, else → `/pattern`, root → dashboard) and an admin-bar-aware back-arrow-vs-icon swap. The shell renders one hub for the sidebar engine.
 - **Command palette shortcut is shell-level.** The `Mod+K` binding is declared in admin.json's `bindings` block, not by this app. The hub only renders the shortcut hint.
 - **`isTransparent` prop is engine-specific.** Single-pane engine uses it; default engine doesn't. Documented as a per-engine convention rather than a stable contract.

--- a/src/apps/site-hub/index.js
+++ b/src/apps/site-hub/index.js
@@ -1,13 +1,12 @@
 import './index.css';
-import { Button, IconButton, Stack } from '@wordpress/ui';
-import { VisuallyHidden } from '@wordpress/components';
+import { Button, IconButton, Stack, VisuallyHidden } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
 import { search } from '@wordpress/icons';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useEntityRecord } from '@wordpress/core-data';
+import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import { filterURLForDisplay } from '@wordpress/url';
 import { memo, forwardRef } from '@wordpress/element';
 
@@ -34,6 +33,14 @@ const SiteHubApp = memo(
 		const isTransparent = !! appConfig?.isTransparent;
 		const { open: openCommandCenter } = useDispatch( commandsStore );
 		const { record: site } = useEntityRecord( 'root', 'site' );
+		const restHomeUrl = useSelect(
+			( select ) =>
+				select( coreStore ).getEntityRecord(
+					'root',
+					'__unstableBase'
+				)?.home,
+			[]
+		);
 
 		const resolvedTitle =
 			! site?.title && !! site?.url
@@ -41,7 +48,9 @@ const SiteHubApp = memo(
 				: site?.title || window.wpAdminShell?.siteName || '';
 		const siteTitle = decodeEntities( resolvedTitle );
 		const homeUrl =
-			window.wpAdminShell?.homeUrl || window.wpAdminShell?.siteUrl;
+			restHomeUrl ||
+			window.wpAdminShell?.homeUrl ||
+			window.wpAdminShell?.siteUrl;
 		const dashboardUrl = window.wpAdminShell?.dashboardUrl;
 
 		return (
@@ -95,7 +104,7 @@ const SiteHubApp = memo(
 								}
 							>
 								{ siteTitle }
-								<VisuallyHidden as="span">
+								<VisuallyHidden render={ <span /> }>
 									{ __(
 										'(opens in a new tab)',
 										'wp-admin-shell'


### PR DESCRIPTION
## Summary

Enhances the `SiteIcon` component to resolve the site icon in priority order: author-declared `branding.logo` from the admin.json cascade → the site's REST `site_icon_url` (from `root/__unstableBase`, matching the Site Icon users set in Settings → General) → the default WordPress mark. This mirrors the behavior of edit-site's `SiteIcon` component and removes a known limitation.

## Key Changes

- **SiteIcon component (`src/apps/site-hub/SiteIcon.js`)**
  - Added `useSelect` hook to fetch `root/__unstableBase` entity record from core-data, reading `site_icon_url` and `home` fields
  - Implemented three-tier icon resolution: branding logo → REST site icon → WordPress default mark
  - Added loading state: renders an empty sized placeholder while `__unstableBase` is resolving (prevents fallback mark flash before configured icon paints)
  - Improved accessibility: changed empty `alt=""` to `alt={ __( 'Site Icon', 'wp-admin-shell' ) }`
  - Increased default WordPress icon size from 32 to 48 for better visibility

- **SiteHubApp component (`src/apps/site-hub/index.js`)**
  - Added `useSelect` hook to fetch `root/__unstableBase.home` for the site-title anchor href
  - Updated home URL resolution to prioritize REST `home` field over window globals (`restHomeUrl || window.wpAdminShell?.homeUrl || window.wpAdminShell?.siteUrl`)
  - Consolidated imports: moved `VisuallyHidden` from `@wordpress/components` to `@wordpress/ui`
  - Updated `VisuallyHidden` usage from `as="span"` to `render={ <span /> }` (API change in `@wordpress/ui`)

- **Documentation updates (`src/apps/site-hub/app.json` and `src/apps/site-hub/app.md`)**
  - Updated purpose description to document the three-tier icon resolution priority
  - Added `root/__unstableBase` to the data reads section with fields `home` and `site_icon_url`
  - Documented the loading state behavior (empty placeholder during REST resolution)
  - Removed "Site icon doesn't honor `site_icon` REST field" from known limitations
  - Updated design-system-leakage imports documentation

## Implementation Details

- The loading placeholder uses the same `wp-admin-shell-site-icon__image` class as the image fallback, ensuring consistent sizing during resolution
- The REST `site_icon_url` resolution is non-blocking: the component renders gracefully at any stage (loading, resolved with icon, resolved without icon)
- Branding logo continues to take precedence over REST icon, preserving author control via the admin.json cascade
- Home URL now sources from REST when available, improving consistency with the site's actual home URL configuration

https://claude.ai/code/session_01SMki71gDPurhqUW2mauFkL