### PR TITLE
Rename wpas_collect_nav_item_caps to wp_admin_shell_ prefix

### DIFF
--- a/wp-admin-shell.php
+++ b/wp-admin-shell.php
@@ -553,7 +553,7 @@ function wp_admin_shell_resolve_capabilities( $config ) {
 			}
 			$items = $region['config']['items'] ?? null;
 			if ( is_array( $items ) ) {
-				wpas_collect_nav_item_caps( $items, $declared );
+				wp_admin_shell_collect_nav_item_caps( $items, $declared );
 			}
 			if ( ! empty( $region['regions'] ) && is_array( $region['regions'] ) ) {
 				$collect_from_regions( $region['regions'] );
@@ -643,7 +643,7 @@ function wpas_collect_menu_item_caps( $menu, &$declared ) {
  * and collect every `capability` declaration. Recurses into `screen`/
  * `group` children.
  */
-function wpas_collect_nav_item_caps( $items, &$declared ) {
+function wp_admin_shell_collect_nav_item_caps( $items, &$declared ) {
 	if ( ! is_array( $items ) ) {
 		return;
 	}
@@ -655,7 +655,7 @@ function wpas_collect_nav_item_caps( $items, &$declared ) {
 			$declared[ $item['capability'] ] = true;
 		}
 		if ( isset( $item['items'] ) && is_array( $item['items'] ) ) {
-			wpas_collect_nav_item_caps( $item['items'], $declared );
+			wp_admin_shell_collect_nav_item_caps( $item['items'], $declared );
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Renames the private helper `wpas_collect_nav_item_caps()` to `wp_admin_shell_collect_nav_item_caps()` so it matches the `wp_admin_shell_*` prefix used throughout the file, ahead of the public-API freeze. Pure rename — no behavior change.

The function is a private helper called only within `wp-admin-shell.php`. Updated the definition and both call sites (the entry call and the recursive self-call).

## Files changed

- `wp-admin-shell.php` — 3 occurrences renamed (definition + 2 call sites)

## Notes

Grepped the entire tree for `wpas_collect_nav_item_caps`; the only other mention was in `docs/feedback.md` line 59, which is the triage-log entry describing this very task (a historical record, not a code reference), so it was left intact.

Closes #82

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGYDqHhZjMnMgaxvsmgpEq)_