### PR TITLE
Add cache-invalidation signal to WP_Admin_Shell_Data_Field_Collections

### DIFF
--- a/includes/cascade/class-wp-admin-shell-data-field-collections.php
+++ b/includes/cascade/class-wp-admin-shell-data-field-collections.php
@@ -231,3 +231,14 @@ add_filter( 'wp_admin_shell_data_plugin', function ( $doc ) {
 	}
 	return $doc;
 }, 5 );
+
+// Registry state lives in static class memory — invisible to the
+// default cache-signal map. Hook into the cache layer's filter so a
+// field-collection registration delta forces a fresh resolver run cross-request.
+add_filter( 'wp_admin_shell_cache_signals', function ( $signals ) {
+	$registry = WP_Admin_Shell_Data_Field_Collections::all();
+	if ( ! empty( $registry ) ) {
+		$signals['data_field_collections'] = md5( wp_json_encode( $registry ) );
+	}
+	return $signals;
+} );

--- a/tests/php/run-data-view-tests.php
+++ b/tests/php/run-data-view-tests.php
@@ -1045,6 +1045,52 @@ WPAS_Data_View_Test_Runner::assert_eq(
 	array()
 );
 
+// --- Cache-fingerprint signal — registry mutations contribute to the cache key
+
+WP_Admin_Shell_Data_Field_Collections::reset();
+
+$baseline_signals = apply_filters( 'wp_admin_shell_cache_signals', array(), array() );
+WPAS_Data_View_Test_Runner::assert_true(
+	'cache signals — no data_field_collections key when registry empty',
+	! isset( $baseline_signals['data_field_collections'] )
+);
+
+wp_admin_shell_register_data_field_collection(
+	'core/cache-fp',
+	'postType',
+	'post',
+	array( array( 'id' => 'sku', 'type' => 'text', 'label' => 'SKU' ) )
+);
+$after_first = apply_filters( 'wp_admin_shell_cache_signals', array(), array() );
+WPAS_Data_View_Test_Runner::assert_true(
+	'field-collection registration adds data_field_collections fingerprint',
+	isset( $after_first['data_field_collections'] )
+);
+WPAS_Data_View_Test_Runner::assert_eq(
+	'fingerprint matches md5 of all() contents',
+	$after_first['data_field_collections'],
+	md5( wp_json_encode( WP_Admin_Shell_Data_Field_Collections::all() ) )
+);
+
+wp_admin_shell_register_data_field_collection(
+	'core/cache-fp-2',
+	'postType',
+	'page',
+	array( array( 'id' => 'template', 'type' => 'text', 'label' => 'Template' ) )
+);
+$after_second = apply_filters( 'wp_admin_shell_cache_signals', array(), array() );
+WPAS_Data_View_Test_Runner::assert_true(
+	'second registration changes data_field_collections fingerprint',
+	$after_first['data_field_collections'] !== $after_second['data_field_collections']
+);
+
+WP_Admin_Shell_Data_Field_Collections::reset();
+$cleared_signals = apply_filters( 'wp_admin_shell_cache_signals', array(), array() );
+WPAS_Data_View_Test_Runner::assert_true(
+	'reset clears data_field_collections fingerprint',
+	! isset( $cleared_signals['data_field_collections'] )
+);
+
 
 // --- Summary ---------------------------------------------------------------
 

--- a/tests/php/run-data-view-tests.php
+++ b/tests/php/run-data-view-tests.php
@@ -1091,7 +1091,6 @@ WPAS_Data_View_Test_Runner::assert_true(
 	! isset( $cleared_signals['data_field_collections'] )
 );
 
-
 // --- Summary ---------------------------------------------------------------
 
 $total = WPAS_Data_View_Test_Runner::$pass + WPAS_Data_View_Test_Runner::$fail;


### PR DESCRIPTION
## Summary

`WP_Admin_Shell_Data_Field_Collections` holds its registry in static class memory, which is invisible to `WP_Admin_Shell_Cache::key_for()`'s default signal map (disk mtime / option / user-meta surfaces only). As a result, deltas between page loads — e.g. a feature-flagged plugin toggling `wp_admin_shell_register_data_field_collection()` calls — would not invalidate the cached resolver tree, serving a stale cascade cross-request.

This PR closes that gap by hooking the `wp_admin_shell_cache_signals` filter (spec §13 #12) and contributing `md5( wp_json_encode( WP_Admin_Shell_Data_Field_Collections::all() ) )` under the `data_field_collections` signal key.

## Pattern followed

Mirrors the established convention used by the three sibling cascade contributors that already hold static registry state:
- `includes/cascade/class-wp-admin-shell-admin-routes.php` (`admin_routes` signal)
- `includes/cascade/class-wp-admin-shell-menu-items.php` (`menu_items` signal)
- `includes/cascade/class-wp-admin-shell-classic-menu-bridge.php`

Same filter, same callback shape (empty-registry guard → `md5(wp_json_encode(...))`), same signal-array key-naming style. The accessor used is the existing public `::all()` method.

## Tests

Added 5 assertions to `tests/php/run-data-view-tests.php` (a "Cache-fingerprint signal" block analogous to the menu-item/admin-route signal tests in `run-menu-route-shims-tests.php`):
- no `data_field_collections` key when registry empty
- registration adds the fingerprint
- fingerprint equals `md5(wp_json_encode(::all()))`
- a second registration changes the fingerprint
- `::reset()` clears the fingerprint

## Test status

Both changed PHP files pass `php -l`. The PHP suite could **not** be executed in this environment: `npx wp-env` returns a 404 (Docker/wp-env is not installed here), so the change was verified by careful review against the three sibling implementations rather than a live run. The added asserts follow the exact pattern of the passing menu-item/admin-route signal tests.

Closes #77

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGYDqHhZjMnMgaxvsmgpEq)_