### PR TITLE
Add customizable definition to admin.json schema

### DIFF
--- a/docs/public/admin-json-reference.md
+++ b/docs/public/admin-json-reference.md
@@ -24,6 +24,7 @@ This reference covers the admin.json workspace schema (`admin.json`).
 - [styles](#styles)
 - [preload](#preload)
 - [regions / routes](#regions--routes-escape-hatches)
+- [customizable](#customizable)
 - [v2 surfaces (deprecated)](#v2-surfaces-deprecated)
 
 ## JSON Schema
@@ -434,3 +435,36 @@ Across origins the resolved value is the concatenation of every origin's `preloa
 The kernel synthesizes the runtime regions map + routes table from `screens[]` + the active engine's `defaultRegions` (`src/runtime/compile/`). Authors who need a region or route the `screens` shape can't express write top-level `regions` / `routes` blocks — admin.json's escape-hatch declarations win on per-region-id / per-pattern collision against the synthesis.
 
 See [§5 of the design spec](../wp-admin-shell-design-spec.md#5-region-vocabulary) for region declarations and [§6.2](../wp-admin-shell-design-spec.md#62-routes-block) for route patterns. Avoid these blocks when the `screens` surface can express the same thing.
+
+## customizable
+
+`customizable` is a per-entry write allowlist: it declares what the consumer cascade origins (`role`, `user`) may write to that entry and its descendants. Trust-tier origins (`core`, `engine`, `plugin`, `site`) author the declaration and are exempt from it — the field is *their* statement about what downstream consumers may touch. Enforcement runs server-side in `WP_Admin_Shell_Customizable` before the merge, so blocked fields never enter the resolved tree.
+
+Three accepted shapes:
+
+| Value                  | Meaning                                                                                                          |
+|------------------------|------------------------------------------------------------------------------------------------------------------|
+| `true`                 | Every field on this entry (and its descendants) is writable by consumer origins.                                 |
+| `[ "dotted.path", … ]` | Only the listed dotted paths — relative to the declaring entry — are writable; everything else is locked.        |
+| `false` / absent       | Locked. No fields writable downstream (default-deny — same posture as block supports).                           |
+
+The array form requires unique, non-empty strings; the closest `customizable` declaration to a leaf wins as the cascade walks ancestors.
+
+Entry types that honor `customizable`: `workspace`, each `screens[id]`, each `menu` item (and its nested `items`), each `commands` entry, each `workspace.widgets.<slot>[]` entry, `styles`, each `regions[id]` (and nested child regions), and each `routes` entry.
+
+Two limits always apply regardless of the declaration:
+
+- **Consumer origins are shrink-only.** `role` / `user` can REMOVE entries (e.g. drop a capability from `screens[].permissions`) but never grow an OR-set or add new structure beyond what an allowlist permits.
+- **A hardcoded deny-list blocks security-sensitive paths even when listed.** `screens.*.permissions`, `screens.*.app`, `commands.*.invoke`, and `workspace.engine` are rejected for consumer origins even with a matching `customizable` allowlist entry.
+
+```json
+{
+	"workspace": {
+		"engine": "core:default",
+		"default-screen": "dashboard-home",
+		"customizable": [ "default-screen", "branding.title" ]
+	}
+}
+```
+
+See [§4.4.2 of the design sketch](../schema-sketch.md) for the full trust-tier rationale and `#/$defs/customizable` in [`docs/schemas/admin.json`](../schemas/admin.json) for the schema definition.

--- a/docs/schemas/admin.json
+++ b/docs/schemas/admin.json
@@ -97,6 +97,10 @@
 							"items": { "$ref": "#/$defs/workspaceWidget" }
 						}
 					}
+				},
+				"customizable": {
+					"$ref": "#/$defs/customizable",
+					"description": "Consumer-origin write allowlist for the `workspace` block (e.g. `[ \"default-screen\", \"branding.title\" ]`; relative paths cover `branding.*`, `notices.*`, `widgets.*`). Note the hardcoded deny-list still blocks `workspace.engine` from `role`/`user` writes even if listed here. See `#/$defs/customizable`."
 				}
 			}
 		},

--- a/docs/schemas/admin.json
+++ b/docs/schemas/admin.json
@@ -205,6 +205,23 @@
 	},
 
 	"$defs": {
+		"customizable": {
+			"oneOf": [
+				{
+					"type": "boolean"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string",
+						"minLength": 1
+					},
+					"uniqueItems": true
+				}
+			],
+			"description": "Per-entry consumer-origin write allowlist (spec §4.4.2). Declares what `role` and `user` origins may write to THIS entry (and its descendants) during the cascade. Three shapes: `true` — every field on this entry is writable downstream; `false` — the entry is locked, no fields writable; `[ \"dotted.path\", ... ]` — only the listed dotted paths (relative to this entry) are writable, everything else is locked. Absence is equivalent to `false` (default-deny — same posture as block supports). Enforcement runs server-side in `WP_Admin_Shell_Customizable` BEFORE the merge step, so blocked fields never enter the resolved tree; the closest `customizable` declaration to a leaf wins as the cascade walks ancestors. Trust tiers: `core`/`engine`/`plugin`/`site` origins author the declaration and are exempt from enforcement — this field is THEIR statement about what downstream consumers may touch. The hardcoded deny-list (`screens.*.permissions`, `screens.*.app`, `commands.*.invoke`, `workspace.engine`) is rejected for consumer origins even with a matching allowlist entry. Object / number / other types are treated as locked. See schema-sketch.md §4.4.2 and `docs/public/admin-json-reference.md`."
+		},
+
 		"namespacedId": {
 			"type": "string",
 			"pattern": "^(core:[a-z][a-z0-9]*(-[a-z0-9]+)*|plugin:[a-z][a-z0-9-]*/[a-z][a-z0-9]*(-[a-z0-9]+)*|iframe:[A-Za-z0-9_./?=&\\-]+)$",
@@ -345,6 +362,10 @@
 					"type": "boolean",
 					"default": false,
 					"description": "When true, the screen is hidden from menu rendering but still routable by URL. Useful for palette-only screens, drill-target screens reached only via in-app links, modal-mounted screens. Different from tombstoning the screen entirely (`screens.<id>: null`) — `hidden: true` keeps the URL working."
+				},
+				"customizable": {
+					"$ref": "#/$defs/customizable",
+					"description": "Consumer-origin write allowlist for this screen. Note the hardcoded deny-list still blocks `permissions` and `app` from `role`/`user` writes even if listed here. See `#/$defs/customizable`."
 				}
 			},
 
@@ -468,6 +489,10 @@
 					"type": "boolean",
 					"default": false,
 					"description": "When true, the item is suppressed from rendering. The subtree is still addressable by cascade (so a higher origin can un-hide), unlike a `null` tombstone which removes the entry entirely."
+				},
+				"customizable": {
+					"$ref": "#/$defs/customizable",
+					"description": "Consumer-origin write allowlist for this menu item (and its nested `items`). Allowlist paths are relative to this node, e.g. `[ \"label\", \"position\" ]` or `[ \"items.posts.position\" ]`. See `#/$defs/customizable`."
 				}
 			}
 		},
@@ -501,6 +526,10 @@
 					"type": "string",
 					"minLength": 1,
 					"description": "Human-readable command label for the palette UI. Surfaces the command even when keyboard-only. Translatable."
+				},
+				"customizable": {
+					"$ref": "#/$defs/customizable",
+					"description": "Consumer-origin write allowlist for this command. Note the hardcoded deny-list still blocks `invoke` from `role`/`user` writes even if listed here. See `#/$defs/customizable`."
 				}
 			}
 		},
@@ -528,6 +557,10 @@
 					"type": "boolean",
 					"default": false,
 					"description": "When true, the widget is suppressed from the slot. Use site/role/user origins to hide widgets the workspace ships with."
+				},
+				"customizable": {
+					"$ref": "#/$defs/customizable",
+					"description": "Consumer-origin write allowlist for this widget entry (e.g. `[ \"hidden\", \"config.label\" ]`). See `#/$defs/customizable`."
 				}
 			}
 		},
@@ -728,6 +761,10 @@
 			"additionalProperties": true,
 			"description": "WPDS-shaped style tree. Top-level subtrees mirror the WPDS token matrix at the pinned `$wpds` version: `color`, `dimension`, `border`, `elevation`, `font`, `density`. Plus `chrome` (shell-only slots), `regions` (per-region overrides), `applications` (per-app overrides). Slot values may be DTCG token aliases (`{color.brand.500}`), literal CSS values (`#3858e9`, `16px`), or inline DTCG objects. The schema is intentionally loose at this level: WPDS slot validation is delegated to the runtime resolver against the pinned `$wpds` matrix, since the slot list grows with WordPress versions and embedding it here would freeze the schema to a specific version. Authors get IDE feedback on slot names from a runtime-generated companion schema rather than this static document.",
 			"properties": {
+				"customizable": {
+					"$ref": "#/$defs/customizable",
+					"description": "Consumer-origin write allowlist for the `styles` tree. This is the primary surface AppearanceApp reads to decide which appearance controls to render — e.g. `[ \"theme.density\", \"theme.color.primary\" ]` lets `user`-origin prefs override density and accent only. `true` exposes the whole tree to user customization; absence (default) locks it. The `core:default` engine's `compileStyles` treats this key as a non-token directive, not a CSS slot. See `#/$defs/customizable`."
+				},
 				"theme": {
 					"type": "object",
 					"additionalProperties": false,
@@ -857,6 +894,10 @@
 				"config": {
 					"type": "object",
 					"description": "Configuration object passed to the mounted app at mount time. Only meaningful when `app` is set."
+				},
+				"customizable": {
+					"$ref": "#/$defs/customizable",
+					"description": "Consumer-origin write allowlist for this region (and its nested child `regions`). See `#/$defs/customizable`."
 				},
 				"regions": {
 					"type": "object",
@@ -1015,6 +1056,10 @@
 				"config": {
 					"type": "object",
 					"description": "Configuration passed to the mounted app. URL parameter substitution applies: `{paramname}` strings in values resolve against captured route params."
+				},
+				"customizable": {
+					"$ref": "#/$defs/customizable",
+					"description": "Consumer-origin write allowlist for this route entry. See `#/$defs/customizable`."
 				}
 			}
 		},


### PR DESCRIPTION
## Summary

The `customizable` field is fully implemented in the PHP cascade (`WP_Admin_Shell_Customizable`) and the runtime (`compileStyles` `NON_TOKEN_KEYS`, `AppearanceApp`), but `docs/schemas/admin.json` declared no `$defs/customizable` definition and none of the entry types referenced it. Hand-authored shells therefore got no IDE/Ajv validation for per-entry `customizable` declarations.

This adds a `$defs/customizable` definition and references it from every entry type that genuinely honors the field.

## Shape

`$defs/customizable` is a `oneOf` of:
- `boolean` — `true` (entry fully writable by consumer origins) / `false` (locked)
- `array` of non-empty `string` dotted paths, `uniqueItems: true` — only the listed paths are writable

Absence is documented as equivalent to `false` (default-deny — same posture as block supports). This matches `WP_Admin_Shell_Customizable::read_decl` / `filter_writes` exactly: `true` → all; `null`/`false`/non-array → locked; array → string dot-paths only. The description also records the hardcoded deny-list (`screens.*.permissions`, `screens.*.app`, `commands.*.invoke`, `workspace.engine`) that blocks consumer-origin writes even with a matching allowlist entry.

## Entry types that gained the property

Derived from the PHP enforcement surfaces (`V3_TOP_LEVEL_BLOCKS` + `filter_doc`'s styles handling + per-entry `read_decl`):

- `screen`
- `menuItem`
- `command`
- `workspaceWidget`
- `styles`
- `region`
- `route`

(`settings.applications`/`settings.regions` referenced by the legacy `filter_settings` path are not part of the v3 `settings` block — v3 moved per-app/per-region overrides under `styles.applications`/`styles.regions`, already covered by `styles`' `additionalProperties: true` — so no schema change there. The `userCustomizable` legacy fallback is obsolete and was not added.)

## Validation

`npm run test:schema` passes — 59 PASS / 0 FAIL, including every bundled shell. No bundled shell currently declares `customizable`, so the change is purely additive with no validation regression.

Closes #80

https://claude.ai/code/session_01NGYDqHhZjMnMgaxvsmgpEq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGYDqHhZjMnMgaxvsmgpEq)_