### PR TITLE
refactor(styles): token + CSS pipeline hygiene (salvaged from #67)

### DIFF
--- a/docs/engines-and-design-systems.md
+++ b/docs/engines-and-design-systems.md
@@ -210,8 +210,25 @@ Two engine-side paths (never kernel):
 Kernel `src/index.css` is ~10 lines: body positioning + a11y fallback
 only. `chrome.canvas.*` is the author entry point for shell-wide
 bg/fg; `chrome.{sidebar,toolbar,site-hub,content}.*` cover per-surface
-chrome. Inside WPDS-flavored app/engine code, never hardcode hex —
-use `var(--wpds-*)` so provider seeds flow through.
+chrome. `core:main`/`core:detail` also expose
+`chrome.content.card-{background,radius,shadow,margin}` /
+`chrome.detail.card-{background,radius,shadow}` so authors retune card
+chrome without per-region inline rules. Inside WPDS-flavored app/engine
+code, never hardcode hex — use `var(--wpds-*)` so provider seeds flow
+through.
+
+**Token-payload short-circuit.** PHP
+`wp_admin_shell_styles_reference_tokens()` scans the resolved `styles`
+tree and skips serializing the whole DTCG `tokens` table to the page
+(emits `{}` via `(object) array()`) when it references zero *foreign*
+aliases — `{path}` not starting `styles.`. Within-doc aliases
+(`{styles.path}`) resolve from admin.json directly and don't need the
+table; the default shell ships seeds + slot overrides only, so the DTCG
+layer is dead weight on the wire. **Contract:** DTCG aliases are valid
+ONLY under `admin.json#styles`. App manifests, engine `default-style`
+blocks, and other surfaces MUST NOT carry `{tokens.*}` references — the
+detector doesn't scan them, so a stray alias outside `styles` silently
+emits a `var(--token-…)` fallback at runtime.
 
 ## `default-style` value tiers + what's themeable
 
@@ -368,7 +385,14 @@ theme resets) that stomp `@wordpress/ui` defaults.
   .wp-admin-shell-site-hub`, …). Buttons/IconButtons/Stacks inside
   inherit the chrome palette automatically. **Do not** add
   `.wp-admin-shell-*-button { color }` rules — extend the bindings
-  table. Engine-private; a non-WPDS engine ships its own.
+  table. Engine-private; a non-WPDS engine ships its own. The `canvas`
+  surface (`.wp-admin-shell-layout`) binds **foreground only** —
+  binding its background to `--wpds-color-bg-surface-neutral` would
+  re-darken the `core:main`/`core:detail` cards that consume that ramp
+  as their final fallback. The canvas paints its own background via the
+  chrome slot directly in `index.css`; the WPDS bridge only re-themes
+  `@wordpress/ui` foreground content rendered directly under the layout.
+  Guarded by `tests/runtime/compile-styles-tokens.test.mjs`.
 - **`Stack` stomped to `display: block`** → children flow vertically
   regardless of inline `flex-direction: row`. `core:default/index.css`
   ships a defensive unlayered `.wp-admin-shell [class*="__stack"]

--- a/src/apps/desktop-iframe/index.css
+++ b/src/apps/desktop-iframe/index.css
@@ -3,7 +3,10 @@
  * `.wp-admin-shell-region__app` flex-fill rule (engine CSS). The
  * wrapper becomes a flex column; this root div inherits `flex: 1 1
  * 0` from the engine's `* > *` rule and the iframe element below
- * fills via its own flex declaration.
+ * fills via its own flex declaration. Background is transparent —
+ * the window body region paints its own surface so the iframe
+ * loading state inherits the surrounding chrome color via the
+ * parent's painted background.
  */
 .wp-admin-shell-desktop-iframe {
 	display: flex;
@@ -12,10 +15,6 @@
 	min-block-size: 0;
 	inline-size: 100%;
 	position: relative;
-	background: var(
-		--wp-admin-shell--chrome--window-frame--body-background,
-		#1c1c28
-	);
 }
 
 .wp-admin-shell-desktop-iframe__frame {
@@ -32,9 +31,5 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: var(
-		--wp-admin-shell--chrome--window-frame--body-background,
-		#1c1c28
-	);
 	z-index: 1;
 }

--- a/src/runtime/engines/core-default/compileStyles.mjs
+++ b/src/runtime/engines/core-default/compileStyles.mjs
@@ -54,7 +54,7 @@ const NON_TOKEN_KEYS = new Set( [
 
 /**
  * Chrome surface → WPDS token bindings. Each entry maps a chrome surface
- * (sidebar / toolbar / site-hub) to its container CSS selector plus the
+ * (canvas / sidebar / toolbar / site-hub) to its container CSS selector plus the
  * `chrome.<surface>.<slot>` → `--wpds-<token>` mappings the compiler emits
  * inside that scope. When a binding's source slot has a value in the
  * resolved chrome tree, the corresponding WPDS variable is set under the
@@ -62,6 +62,20 @@ const NON_TOKEN_KEYS = new Set( [
  * `@wordpress/ui` re-theming.
  */
 const CHROME_WPDS_BINDINGS = {
+	canvas: {
+		selector: '.wp-admin-shell-layout',
+		bindings: {
+			// `background` is intentionally NOT bound. `--wpds-color-bg-
+			// surface-neutral` is the surface ramp `core:main` / `core:detail`
+			// cards consume as their final fallback — binding canvas.background
+			// to it would darken cards under the shell scope. The canvas
+			// itself paints via the chrome slot directly (engine `index.css`
+			// reads `--wp-admin-shell--chrome--canvas--background`); the WPDS
+			// bridge only needs to retheme @wordpress/ui foreground content
+			// rendered directly under `.wp-admin-shell-layout`.
+			foreground: '--wpds-color-fg-content-neutral',
+		},
+	},
 	sidebar: {
 		selector: '.wp-admin-shell-nav, .wp-admin-shell-site-hub',
 		bindings: {

--- a/src/runtime/engines/core-default/engine.json
+++ b/src/runtime/engines/core-default/engine.json
@@ -137,9 +137,9 @@
 				"overflow-y": "auto",
 				"overflow-x": "hidden",
 				"background": "var(--wp-admin-shell--chrome--content--card-background, var(--wpds-color-bg-surface-neutral-strong))",
-				"border-radius": "var(--wpds-border-radius-lg)",
-				"box-shadow": "var(--wpds-elevation-xs)",
-				"margin": "0"
+				"border-radius": "var(--wp-admin-shell--chrome--content--card-radius, var(--wpds-border-radius-lg))",
+				"box-shadow": "var(--wp-admin-shell--chrome--content--card-shadow, var(--wpds-elevation-xs))",
+				"margin": "var(--wp-admin-shell--chrome--content--card-margin, 0)"
 			}
 		},
 
@@ -155,8 +155,8 @@
 				"overflow-y": "auto",
 				"overflow-x": "hidden",
 				"background": "var(--wp-admin-shell--chrome--detail--card-background, var(--wpds-color-bg-surface-neutral-strong))",
-				"border-radius": "var(--wpds-border-radius-lg)",
-				"box-shadow": "var(--wpds-elevation-sm)"
+				"border-radius": "var(--wp-admin-shell--chrome--detail--card-radius, var(--wpds-border-radius-lg))",
+				"box-shadow": "var(--wp-admin-shell--chrome--detail--card-shadow, var(--wpds-elevation-sm))"
 			}
 		},
 

--- a/src/runtime/engines/core-desktop/index.css
+++ b/src/runtime/engines/core-desktop/index.css
@@ -17,9 +17,12 @@
 	overflow: hidden;
 	background: var(
 		--wp-admin-shell--chrome--canvas--background,
-		#0a0a1a
+		var( --wpds-color-bg-surface-neutral-strong )
 	);
-	color: var( --wp-admin-shell--chrome--canvas--foreground, #f0f0f5 );
+	color: var(
+		--wp-admin-shell--chrome--canvas--foreground,
+		var( --wpds-color-fg-content-neutral )
+	);
 	font-family: var( --wpds-font-family-sans, -apple-system, system-ui, sans-serif );
 }
 
@@ -70,7 +73,10 @@
 .wp-admin-shell-desktop-dock__separator {
 	inline-size: 1px;
 	block-size: 36px;
-	background: rgba( 255, 255, 255, 0.18 );
+	background: var(
+		--wp-admin-shell--chrome--dock--separator,
+		rgba( 255, 255, 255, 0.18 )
+	);
 	margin-inline: 4px;
 }
 
@@ -117,7 +123,10 @@
 
 .wp-admin-shell-desktop-dock__tile:hover,
 .wp-admin-shell-desktop-dock__tile:focus-visible {
-	background: rgba( 255, 255, 255, 0.12 );
+	background: var(
+		--wp-admin-shell--chrome--dock--tile-hover,
+		rgba( 255, 255, 255, 0.12 )
+	);
 	outline: none;
 }
 
@@ -150,14 +159,17 @@
 	flex-direction: column;
 	background: var(
 		--wp-admin-shell--chrome--window-frame--background,
-		#2a2a3a
+		var( --wpds-color-bg-surface-neutral-strong )
 	);
 	color: var(
 		--wp-admin-shell--chrome--window-frame--foreground,
-		#f0f0f5
+		var( --wpds-color-fg-content-neutral )
 	);
 	border: 1px solid
-		var( --wp-admin-shell--chrome--window-frame--border, #404050 );
+		var(
+			--wp-admin-shell--chrome--window-frame--border,
+			var( --wpds-color-stroke-surface-neutral )
+		);
 	border-block-end: 0;
 	border-start-start-radius: 8px;
 	border-start-end-radius: 8px;
@@ -195,15 +207,24 @@
 }
 
 .wp-admin-shell-desktop-window-frame__control--close {
-	background: #ff5f57;
+	background: var(
+		--wp-admin-shell--chrome--window-frame--control-close,
+		#ff5f57
+	);
 }
 
 .wp-admin-shell-desktop-window-frame__control--minimize {
-	background: #febc2e;
+	background: var(
+		--wp-admin-shell--chrome--window-frame--control-minimize,
+		#febc2e
+	);
 }
 
 .wp-admin-shell-desktop-window-frame__control--maximize {
-	background: #28c840;
+	background: var(
+		--wp-admin-shell--chrome--window-frame--control-maximize,
+		#28c840
+	);
 }
 
 /*
@@ -371,14 +392,17 @@
 	[ data-region-id*='/body' ] {
 	background: var(
 		--wp-admin-shell--chrome--window-frame--body-background,
-		#1c1c28
+		var( --wpds-color-bg-surface-neutral )
 	);
 	color: var(
 		--wp-admin-shell--chrome--window-frame--body-foreground,
-		#f0f0f5
+		var( --wpds-color-fg-content-neutral )
 	);
 	border: 1px solid
-		var( --wp-admin-shell--chrome--window-frame--border, #404050 );
+		var(
+			--wp-admin-shell--chrome--window-frame--border,
+			var( --wpds-color-stroke-surface-neutral )
+		);
 	border-block-start: 0;
 	border-end-start-radius: 8px;
 	border-end-end-radius: 8px;

--- a/tests/runtime/compile-styles-tokens.test.mjs
+++ b/tests/runtime/compile-styles-tokens.test.mjs
@@ -86,6 +86,45 @@ console.log( '\n— missing tokens arg keeps var() fallback —' );
 	ok( 'missing tokens emits var()', value && value.startsWith( 'var(' ) );
 }
 
+console.log( '\n— canvas binding does not darken card surface —' );
+{
+	// Regression guard: a previous shape bound `canvas.background` to
+	// `--wpds-color-bg-surface-neutral` inside the layout scope, which
+	// then re-darkened every `core:main` / `core:detail` card (their
+	// `default-style` reads `--wpds-color-bg-surface-neutral` as the
+	// final fallback when no chrome-content-card-background slot is
+	// authored). The canvas binding now ships `foreground` only;
+	// authoring `chrome.canvas.background` must not emit a scoped WPDS
+	// override that descends into card content.
+	const styles = {
+		theme: { color: { bg: '#ffffff' } },
+		chrome: {
+			canvas: { background: '#1e1e1e', foreground: '#e0e0e0' },
+		},
+	};
+	const compiled = compileStyles( styles, {} );
+	const canvasScope = ( compiled.scoped || [] ).find(
+		( entry ) => entry.selector === '.wp-admin-shell-layout'
+	);
+	const offending = canvasScope?.vars?.[ '--wpds-color-bg-surface-neutral' ];
+	ok(
+		'canvas.background does not emit --wpds-color-bg-surface-neutral',
+		offending === undefined,
+		offending !== undefined
+			? `surface-neutral scoped to .wp-admin-shell-layout = ${ offending } (darkens cards)`
+			: ''
+	);
+	ok(
+		'canvas.foreground still binds (--wpds-color-fg-content-neutral)',
+		canvasScope?.vars?.[ '--wpds-color-fg-content-neutral' ] === '#e0e0e0'
+	);
+	const topBg = compiled.top[ '--wp-admin-shell--chrome--canvas--background' ];
+	ok(
+		'canvas.background still emits the chrome slot at top scope',
+		topBg === '#1e1e1e'
+	);
+}
+
 console.log( '\n— Summary —' );
 console.log( `PASS: ${ pass }  FAIL: ${ fail }` );
 if ( fail > 0 ) {

--- a/wp-admin-shell.php
+++ b/wp-admin-shell.php
@@ -552,8 +552,16 @@ function wp_admin_shell_enqueue_assets( $hook = '' ) {
 		// V2.M5 — DTCG primitives layer. Site → theme → plugin → core
 		// origins merged here. Empty object when no origin contributes.
 		// `compileStyles` consumes this when resolving non-`styles.*`
-		// curly-brace aliases in admin.json `styles`.
-		'tokens'        => WP_Admin_Shell_Tokens::resolve(),
+		// curly-brace aliases in admin.json `styles`. Token serialization
+		// is skipped entirely when the resolved styles tree references
+		// zero token aliases — the DTCG layer is dead weight for shells
+		// that only set seeds + slot overrides. The empty-path cast to
+		// stdClass keeps the JS shape stable: `wp_json_encode( array() )`
+		// emits `[]`, but the kernel + downstream typedef `tokens` as an
+		// object — `(object) array()` serializes as `{}`.
+		'tokens'        => wp_admin_shell_styles_reference_tokens( $config )
+			? WP_Admin_Shell_Tokens::resolve()
+			: (object) array(),
 		// v3 — flattened engine-modes catalog. The active engine's
 		// `modes` block is walked for `extends` chains (depth-limited),
 		// then the `wp_admin_shell_engine_modes_{engineId}` filter runs
@@ -943,6 +951,61 @@ function wp_admin_shell_collect_nav_item_caps( $items, &$declared ) {
 			wp_admin_shell_collect_nav_item_caps( $item['items'], $declared );
 		}
 	}
+}
+
+/**
+ * Scan the resolved styles tree for any token alias. Returns true if any
+ * string leaf matches the alias pattern `{<path>}` where `<path>` does
+ * NOT start with `styles.` (within-doc aliases are resolved without
+ * touching the DTCG tokens table). Used to skip token serialization when
+ * the shell ships seeds + slot overrides only — the DTCG layer would be
+ * dead weight on the wire.
+ *
+ * Contract: DTCG aliases are valid ONLY under `admin.json#styles`. App
+ * manifests (`app.json#dataView`, etc.), engine `default-style` blocks,
+ * and any other config surface MUST NOT carry `{tokens.*}` references —
+ * the detector deliberately does not scan them, so a stray alias outside
+ * `styles` would silently emit `var(--token-…)` fallbacks at runtime.
+ * Author tokens under `styles` (top-level, per-region, or per-app) and
+ * cross-reference from other config surfaces via `{styles.path}` if
+ * needed.
+ *
+ * @param array $config Resolved admin.json config.
+ * @return bool
+ */
+function wp_admin_shell_styles_reference_tokens( $config ) {
+	if ( ! is_array( $config ) || empty( $config['styles'] ) || ! is_array( $config['styles'] ) ) {
+		return false;
+	}
+	return wp_admin_shell_tree_has_token_alias( $config['styles'] );
+}
+
+/**
+ * Recursively test whether a styles subtree contains a foreign token alias.
+ *
+ * @param mixed $node Styles node (string leaf or nested array).
+ * @return bool
+ */
+function wp_admin_shell_tree_has_token_alias( $node ) {
+	if ( is_string( $node ) ) {
+		if ( ! preg_match( '/^\{([^}]+)\}$/', $node, $m ) ) {
+			return false;
+		}
+		// Within-doc aliases (`{styles.path}`) resolve from admin.json
+		// directly; they don't reach the tokens table. Only "foreign"
+		// aliases (`{color.brand.500}`, `{size.lg}`, etc.) need the
+		// DTCG tree.
+		return strpos( $m[1], 'styles.' ) !== 0;
+	}
+	if ( ! is_array( $node ) ) {
+		return false;
+	}
+	foreach ( $node as $value ) {
+		if ( wp_admin_shell_tree_has_token_alias( $value ) ) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /**


### PR DESCRIPTION
Re-applies the **non-regressive** subset of #67 (salvaged from the abandoned #52) onto **current `main`**. #67 was conflicting and its headline change had gone stale: main's design-refinement work moved `core:default` to a **light** theme, so #67's "dark chrome + light cards" identity (S4/S5) is now backwards. This PR drops that part and ships only the hygiene that main never picked up.

## What's here

| Item | Change |
|---|---|
| **B3** | `wp_admin_shell_styles_reference_tokens()` skips serializing the DTCG `tokens` tree to the page when the resolved `styles` references zero *foreign* (`{path}` not starting `styles.`) aliases. Default shell ships none → `tokens` emits `{}` (`(object) array()` keeps the JS object shape). |
| **O2/O3/S1/S2** | `core-desktop/index.css` hardcoded rgba/hex fallbacks chain through WPDS surface tokens (canvas / window-frame / body bg+fg+border, dock separator + tile-hover). macOS traffic-light controls kept as slot fallbacks, **not** token-chained. `desktop-iframe` drops duplicate body-background paints — the window body region paints its own surface. |
| **O1** | `core:main` / `core:detail` expose `chrome.content/detail.card-{radius,shadow,margin}` so authors retune card chrome without per-region inline rules. |
| **S6** | `canvas` added to `CHROME_WPDS_BINDINGS`, **foreground only** — binding its background would re-darken `core:main`/`core:detail` cards consuming the surface ramp. Regression-guarded. |

## Dropped from #67 (regressive / already done)
- **S4/S5** dark-chrome `default-styles` + shell `theme.color.bg:#1e1e1e` removals — main is light now; the shell-side removals already landed (`developer-admin.json` deleted, `wp-admin-default.json` bg override gone).

## Test plan
- [x] `npm run lint:js` — clean
- [x] `npm run test:runtime` — pass (incl. new canvas-binding guard)
- [x] `npm run test:schema` — pass
- [x] `npm run test:parity` — pass
- [x] `npm run test:engines` — pass
- [x] `php -l wp-admin-shell.php` — clean
- [ ] PHP `wp-env` suites (not run in this env)
- [ ] Manual visual smoke (desktop engine: dock / window chrome should be unchanged — token fallbacks resolve to the same surface palette)

Supersedes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)