### PR TITLE
fix(themes): register activate-theme REST route; drop nonce-less fallback

### DIFF
--- a/includes/class-wp-admin-shell-themes-rest.php
+++ b/includes/class-wp-admin-shell-themes-rest.php
@@ -60,8 +60,10 @@ class WP_Admin_Shell_Themes_REST {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public static function activate( $request ) {
+		// REST sanitizes `stylesheet` to a string before dispatch; `required`
+		// asserts presence, not non-emptiness, so an empty value reaches here.
 		$stylesheet = $request->get_param( 'stylesheet' );
-		if ( ! is_string( $stylesheet ) || '' === $stylesheet ) {
+		if ( '' === $stylesheet ) {
 			return new WP_Error(
 				'rest_invalid_param',
 				__( 'A theme stylesheet is required.', 'wp-admin-shell' ),
@@ -78,12 +80,36 @@ class WP_Admin_Shell_Themes_REST {
 			);
 		}
 
+		// Mirror core themes.php: on multisite a site admin with `switch_themes`
+		// must not activate a theme the super-admin network/site-disabled.
+		// `is_allowed()` returns true on single-site, so this is multisite-only.
+		if ( ! $theme->is_allowed() ) {
+			return new WP_Error(
+				'rest_theme_not_allowed',
+				__( 'This theme is not allowed on this site.', 'wp-admin-shell' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$errors = $theme->errors();
 		if ( $errors instanceof WP_Error ) {
 			return new WP_Error(
 				'rest_theme_broken',
 				/* translators: %s: theme error message. */
 				sprintf( __( 'The theme cannot be activated: %s', 'wp-admin-shell' ), $errors->get_error_message() ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// `WP_Theme::errors()` reports only missing/broken files — never
+		// RequiresWP/RequiresPHP. Without this pre-check an intact-but-
+		// incompatible theme reaches switch_theme(), which wp_die()s mid-REST
+		// (a 500 carrying literal <strong> markup). Validate up front instead.
+		$requirements = validate_theme_requirements( $theme->get_stylesheet() );
+		if ( is_wp_error( $requirements ) ) {
+			return new WP_Error(
+				'rest_theme_requirements',
+				wp_strip_all_tags( $requirements->get_error_message() ),
 				array( 'status' => 400 )
 			);
 		}

--- a/includes/class-wp-admin-shell-themes-rest.php
+++ b/includes/class-wp-admin-shell-themes-rest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * /wp-admin-shell/v1/activate-theme — switch the active theme.
+ *
+ * Shell-side workaround: WordPress core ships no writable themes REST
+ * endpoint (upstream parity ticket #143), so `core:themes` has no
+ * canonical `/wp/v2/themes` mutation to call. This endpoint is a thin
+ * transport over `switch_theme()`, gated on `switch_themes`.
+ *
+ * The previous client fallback navigated to a nonce-less
+ * `themes.php?action=activate&...` link, which silently failed — so theme
+ * activation was non-functional on a clean install. This route replaces
+ * that fallback. apiFetch's `wp-api-fetch` middleware sends the REST
+ * nonce automatically.
+ *
+ * @package WP_Admin_Shell
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+class WP_Admin_Shell_Themes_REST {
+
+	const NAMESPACE = 'wp-admin-shell/v1';
+
+	public static function register() {
+		register_rest_route(
+			self::NAMESPACE,
+			'/activate-theme',
+			array(
+				array(
+					'methods'             => 'POST',
+					'callback'            => array( __CLASS__, 'activate' ),
+					'permission_callback' => array( __CLASS__, 'permission_check' ),
+					'args'                => array(
+						'stylesheet' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Switching the active theme is security-sensitive — gate on the same
+	 * capability core's themes.php uses for activation.
+	 *
+	 * @return bool
+	 */
+	public static function permission_check() {
+		return current_user_can( 'switch_themes' );
+	}
+
+	/**
+	 * Validate the requested theme and switch to it.
+	 *
+	 * @param WP_REST_Request $request Request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public static function activate( $request ) {
+		$stylesheet = $request->get_param( 'stylesheet' );
+		if ( ! is_string( $stylesheet ) || '' === $stylesheet ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				__( 'A theme stylesheet is required.', 'wp-admin-shell' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$theme = wp_get_theme( $stylesheet );
+		if ( ! $theme->exists() ) {
+			return new WP_Error(
+				'rest_theme_not_found',
+				__( 'The requested theme is not installed.', 'wp-admin-shell' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$errors = $theme->errors();
+		if ( $errors instanceof WP_Error ) {
+			return new WP_Error(
+				'rest_theme_broken',
+				/* translators: %s: theme error message. */
+				sprintf( __( 'The theme cannot be activated: %s', 'wp-admin-shell' ), $errors->get_error_message() ),
+				array( 'status' => 400 )
+			);
+		}
+
+		switch_theme( $theme->get_stylesheet() );
+
+		return rest_ensure_response(
+			array(
+				'stylesheet' => $theme->get_stylesheet(),
+				'name'       => $theme->get( 'Name' ),
+				'active'     => true,
+			)
+		);
+	}
+}
+
+add_action( 'rest_api_init', array( 'WP_Admin_Shell_Themes_REST', 'register' ) );

--- a/src/apps/themes/app.json
+++ b/src/apps/themes/app.json
@@ -171,7 +171,7 @@
 			},
 			{
 				"concern": "error-surfacing",
-				"note": "If the endpoint rejects (missing/broken theme, insufficient caps), the app shows an error snackbar with the decoded WP_Error message rather than navigating away."
+				"note": "If the endpoint rejects (missing/broken/incompatible/disallowed theme, insufficient caps), the app shows an error snackbar with the decoded WP_Error message rather than navigating away. `activate()` returns a success boolean so the details-modal Activate button only closes on success."
 			}
 		],
 		"design-system-leakage": [

--- a/src/apps/themes/app.json
+++ b/src/apps/themes/app.json
@@ -66,7 +66,7 @@
 		"icon": "layout"
 	},
 	"documentation": {
-		"purpose": "DataViews host over the `root/theme` entity. Default grid layout shows screenshot + name + status + truncated description; table layout offers sortable columns for power users. The Activate action (eligible only when status=inactive) calls the shell's custom `/wp-admin-shell/v1/activate-theme` endpoint with a wp-admin fallback. The Details action opens a modal with full description + version + author + theme-site link.",
+		"purpose": "DataViews host over the `root/theme` entity. Default grid layout shows screenshot + name + status + truncated description; table layout offers sortable columns for power users. The Activate action (eligible only when status=inactive) calls the shell's custom `/wp-admin-shell/v1/activate-theme` endpoint (gated on `switch_themes`); on failure it surfaces an error snackbar. The Details action opens a modal with full description + version + author + theme-site link.",
 		"rebuilds": "themes",
 		"data": {
 			"reads": [
@@ -140,7 +140,7 @@
 		"interactions": [
 			{
 				"trigger": "Activate row action",
-				"effect": "POST `/wp-admin-shell/v1/activate-theme` with `{ stylesheet }`; on success invalidate `root/theme`. On failure: `window.location.href` to `themes.php?action=activate&stylesheet=...` so the user falls back to wp-admin.",
+				"effect": "POST `/wp-admin-shell/v1/activate-theme` with `{ stylesheet }`; on success invalidate `root/theme` and show a success snackbar. On failure show an error snackbar with the decoded WP_Error message.",
 				"guards": [
 					"item.status === 'inactive'"
 				]
@@ -167,11 +167,11 @@
 			},
 			{
 				"concern": "no-core-rest-theme-switch",
-				"note": "WordPress core REST does not expose a theme-switch operation. The shell ships a custom `/wp-admin-shell/v1/activate-theme` endpoint; rebuilds must provide the equivalent or implement the wp-admin link fall-back."
+				"note": "WordPress core REST does not expose a theme-switch operation (upstream parity #143). The shell ships a custom `/wp-admin-shell/v1/activate-theme` endpoint (`WP_Admin_Shell_Themes_REST`, gated on `switch_themes`, validates the stylesheet via `wp_get_theme()` then calls `switch_theme()`); rebuilds must provide the equivalent server-side hook."
 			},
 			{
-				"concern": "graceful-fallback",
-				"note": "If the custom endpoint 404s (older shell version or stripped feature), the app navigates to wp-admin's `themes.php` flow so the user can complete the action — preserves the right outcome even without the optimized path."
+				"concern": "error-surfacing",
+				"note": "If the endpoint rejects (missing/broken theme, insufficient caps), the app shows an error snackbar with the decoded WP_Error message rather than navigating away."
 			}
 		],
 		"design-system-leakage": [

--- a/src/apps/themes/app.md
+++ b/src/apps/themes/app.md
@@ -20,8 +20,10 @@ Four pieces of state drive the app:
 The Activate action calls a `useCallback` `activate(theme)` that:
 
 1. POSTs `/wp-admin-shell/v1/activate-theme` with `{ stylesheet }`.
-2. On success: `invalidateResolution` on the theme query + emits a success snackbar.
-3. On failure: emits an error snackbar with the decoded WP_Error message (no navigation away).
+2. On success: `invalidateResolution` on the theme query + emits a success snackbar; returns `true`.
+3. On failure: emits an error snackbar with the decoded WP_Error message (no navigation away); returns `false`.
+
+The inline Activate button in the details modal awaits that boolean and only calls `closeModal()` on `true`, so a failed activation keeps the modal open (with the error snackbar) rather than dismissing as if it succeeded.
 
 The Details action uses DataViews' `RenderModal` shape — DataViews owns the focus trap, backdrop, and dismiss handling. Inside the modal the app renders the full description + version + author + Theme site link + an inline Activate button (visible only when `status !== 'active'`).
 

--- a/src/apps/themes/app.md
+++ b/src/apps/themes/app.md
@@ -21,7 +21,7 @@ The Activate action calls a `useCallback` `activate(theme)` that:
 
 1. POSTs `/wp-admin-shell/v1/activate-theme` with `{ stylesheet }`.
 2. On success: `invalidateResolution` on the theme query + emits a success snackbar.
-3. On failure: `window.location.href = adminUrl + 'themes.php?action=activate&stylesheet=...'` so the user lands in wp-admin's flow.
+3. On failure: emits an error snackbar with the decoded WP_Error message (no navigation away).
 
 The Details action uses DataViews' `RenderModal` shape — DataViews owns the focus trap, backdrop, and dismiss handling. Inside the modal the app renders the full description + version + author + Theme site link + an inline Activate button (visible only when `status !== 'active'`).
 
@@ -73,7 +73,7 @@ For a non-WPDS / non-DataViews rebuild:
 
 - **List/grid component** with media-aware grid cards + sortable table fallback. MUI's `DataGrid` works for the table half; the grid half is a flex/grid layout + media field renderer.
 - **REST/core-data adapter** that exposes `root/theme` records with `{ context: 'edit', status: 'active,inactive' }`.
-- **Custom theme-switch endpoint** (or fall back to wp-admin's `themes.php?action=activate&stylesheet=...&_wpnonce=…` link). Rebuilds need their own server-side hook.
+- **Custom theme-switch endpoint.** The shell ships `WP_Admin_Shell_Themes_REST` (`POST /wp-admin-shell/v1/activate-theme`, gated on `switch_themes`, validates the stylesheet via `wp_get_theme()` then calls `switch_theme()`). Rebuilds need their own equivalent server-side hook — WordPress core REST exposes no theme-switch operation (upstream parity #143).
 - **Action modal** that DataViews-style accepts `{ items, closeModal, onActionPerformed }`. Any modal primitive works; the contract is open-on-invoke, await close.
 
 Two patterns to preserve:
@@ -87,8 +87,7 @@ Two patterns to preserve:
 - No theme preview (live preview via Customizer or block-theme preview).
 - Screenshots are loaded directly from the theme record; no resizing or `srcset`.
 - Description truncation is hard 140 chars in the grid card. Full description lives in the details modal.
-- The fallback URL flow loses the user's place in the shell; we don't restore it on return.
-- **The classic-activate fallback link is missing `_wpnonce`.** `themes.php?action=activate&stylesheet=…` requires a fresh nonce or it silently bounces back to the themes list without activating. Per `docs/research/app-validation-2026-05-04.md`, this fallback path should either (a) call `wp_create_nonce('switch-theme_'.stylesheet)` from PHP and inject the resulting `&_wpnonce=…` into the link, or (b) route through a small PHP shim that performs the activation server-side. Until then, the fallback is best-effort only.
+- Activation runs entirely through the shell REST endpoint (`WP_Admin_Shell_Themes_REST`); apiFetch sends the REST nonce automatically. On failure the app surfaces an error snackbar instead of navigating away, so the user keeps their place in the shell.
 - DataViews' built-in client-side pagination is used (the full theme list returns in one request); the `paginationInfo` is hard-coded to `totalPages: 1` because themes-per-install rarely exceeds the page size.
 
 Parity gaps versus `docs/screens/themes.md` not surfaced in the v2 app:

--- a/src/apps/themes/index.js
+++ b/src/apps/themes/index.js
@@ -124,6 +124,8 @@ export default function ThemesApp( { config = {} } ) {
 		viewDefaults: VIEW_DEFAULTS,
 	} );
 
+	// Returns true on success / false on failure so callers (e.g. the details
+	// modal) can keep themselves open when activation fails.
 	const activate = useCallback(
 		async ( theme ) => {
 			try {
@@ -142,6 +144,7 @@ export default function ThemesApp( { config = {} } ) {
 					__( 'Theme activated.', 'wp-admin-shell' ),
 					{ type: 'snackbar' }
 				);
+				return true;
 			} catch ( err ) {
 				createNotice(
 					'error',
@@ -152,6 +155,7 @@ export default function ThemesApp( { config = {} } ) {
 						),
 					{ type: 'snackbar', isDismissible: true }
 				);
+				return false;
 			}
 		},
 		[ invalidateResolution, themesQuery, createNotice ]
@@ -210,8 +214,10 @@ export default function ThemesApp( { config = {} } ) {
 								tone="brand"
 								variant="solid"
 								onClick={ async () => {
-									await activate( item );
-									closeModal();
+									const ok = await activate( item );
+									if ( ok ) {
+										closeModal();
+									}
 								} }
 							>
 								{ __( 'Activate', 'wp-admin-shell' ) }

--- a/src/apps/themes/index.js
+++ b/src/apps/themes/index.js
@@ -143,12 +143,15 @@ export default function ThemesApp( { config = {} } ) {
 					{ type: 'snackbar' }
 				);
 			} catch ( err ) {
-				const target =
-					( window.wpAdminShell?.adminUrl || '/wp-admin/' ) +
-					`themes.php?action=activate&stylesheet=${ encodeURIComponent(
-						theme.stylesheet
-					) }`;
-				window.location.href = target;
+				createNotice(
+					'error',
+					err?.message ||
+						__(
+							'The theme could not be activated.',
+							'wp-admin-shell'
+						),
+					{ type: 'snackbar', isDismissible: true }
+				);
 			}
 		},
 		[ invalidateResolution, themesQuery, createNotice ]

--- a/wp-admin-shell.php
+++ b/wp-admin-shell.php
@@ -103,6 +103,7 @@ add_action( 'init', function () {
 
 require_once WP_ADMIN_SHELL_PATH . 'includes/class-wp-admin-shell-can-rest.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/class-wp-admin-shell-prefs-rest.php';
+require_once WP_ADMIN_SHELL_PATH . 'includes/class-wp-admin-shell-themes-rest.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/cascade/class-wp-admin-shell-merge.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/cascade/class-wp-admin-shell-customizable.php';
 require_once WP_ADMIN_SHELL_PATH . 'includes/cascade/class-wp-admin-shell-cache.php';


### PR DESCRIPTION
**Closes #97.**

Theme **Activate** was POSTing to `/wp-admin-shell/v1/activate-theme` — a route that was never registered — then falling back to a nonce-less `themes.php?action=activate` link that silently failed. Activation was non-functional on a clean install. (Core has no writable themes REST; that's upstream #143. This is the shell-side workaround.)

- New `WP_Admin_Shell_Themes_REST` registers `POST /wp-admin-shell/v1/activate-theme` (mirrors the can/prefs controller pattern), gated on `current_user_can('switch_themes')`, `stylesheet` sanitized; validates via `wp_get_theme()` (400 empty / 404 missing / 400 broken) then `switch_theme()`.
- ThemesApp now shows an **error Notice** on failure instead of the nonce-less redirect; success path (snackbar + `root/theme` invalidation) unchanged.

**Tests:** `lint:js` ✅ · `test:runtime` (33 files) ✅ · `php -l` ✅ · PHP cap tests **UNVERIFIED** (wp-env not running). Follow-up: a `switch_themes` permission-floor test (subscriber 403 / 404 / 400) would be worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)