### PR TITLE
fix(dataviews): persist per-screen view to user prefs (Screen Options parity)

### DIFF
--- a/src/apps/_shared/dataviews/dataViewPrefs.mjs
+++ b/src/apps/_shared/dataviews/dataViewPrefs.mjs
@@ -1,0 +1,118 @@
+/**
+ * Pure helpers for persisting a DataViews `view` to user preferences —
+ * the Screen-Options-equivalent (column visibility, sort, per-page, layout).
+ *
+ * Storage lives in the shell's `wp_admin_shell_user_prefs` user-meta, written
+ * through `POST /wp-admin-shell/v1/user-prefs` (partial deep-merge, `null`
+ * tombstones a key). The blob lives under a top-level `dataViews` key, sub-
+ * keyed by `screenId`:
+ *
+ *   { "dataViews": { "posts": { "fields": [...], "sort": {...}, ... } } }
+ *
+ * The cascade resolver's consumer-origin `customizable` walker only copies the
+ * recognized admin.json blocks (`settings` / `styles` / the v3 top-level
+ * blocks) into the merged doc, so a `dataViews` top-level key is **silently
+ * dropped from the resolved config** — no pollution — while remaining stored in
+ * the meta and readable via the `/user-prefs` GET endpoint (same pattern the
+ * `shell` / `default-route` prefs already use). These helpers are side-effect
+ * free so `tests/runtime/dataviews-shared.test.mjs` can import them directly.
+ */
+
+/** Top-level user-prefs key the view blobs live under. */
+export const PREFS_KEY = 'dataViews';
+
+/**
+ * View axes that persist (the Screen-Options-equivalent durable state). These
+ * survive navigation + reload. `search` / `filters` / `page` are deliberately
+ * excluded — they're transient query state, not remembered preferences (this
+ * matches what wp-admin Screen Options remembers: hidden columns + per-page,
+ * not the current search/filter/page).
+ */
+export const DURABLE_AXES = [
+	'type',
+	'fields',
+	'sort',
+	'perPage',
+	'layout',
+	'titleField',
+	'mediaField',
+	'descriptionField',
+	'showTitle',
+	'showMedia',
+	'showDescription',
+];
+
+/**
+ * Project a full `view` down to only the durable axes worth persisting.
+ *
+ * @param {Object} view A DataViews `view` object.
+ * @return {Object} A new object containing only present durable axes.
+ */
+export function pickDurableView( view ) {
+	const out = {};
+	if ( ! view || typeof view !== 'object' ) {
+		return out;
+	}
+	for ( const axis of DURABLE_AXES ) {
+		if ( view[ axis ] !== undefined ) {
+			out[ axis ] = view[ axis ];
+		}
+	}
+	return out;
+}
+
+/**
+ * Read the saved durable view for a screen out of a full prefs blob.
+ *
+ * @param {Object} prefs    The full user-prefs object (from GET /user-prefs).
+ * @param {string} screenId The active screen id.
+ * @return {Object|null} The saved durable view, or null when none is stored.
+ */
+export function readSavedView( prefs, screenId ) {
+	if ( ! prefs || typeof prefs !== 'object' || ! screenId ) {
+		return null;
+	}
+	const bucket = prefs[ PREFS_KEY ];
+	if ( ! bucket || typeof bucket !== 'object' ) {
+		return null;
+	}
+	const saved = bucket[ screenId ];
+	if ( ! saved || typeof saved !== 'object' ) {
+		return null;
+	}
+	return saved;
+}
+
+/**
+ * Build the partial POST body that persists a screen's durable view.
+ *
+ * The server deep-merges this onto the existing prefs, so only the touched
+ * screen's bucket is written; sibling screens' saved views are untouched.
+ *
+ * @param {string} screenId The active screen id.
+ * @param {Object} view     The full or durable `view` to persist.
+ * @return {Object|null} The POST body, or null when there's nothing to write.
+ */
+export function buildSavePatch( screenId, view ) {
+	if ( ! screenId ) {
+		return null;
+	}
+	return { [ PREFS_KEY ]: { [ screenId ]: pickDurableView( view ) } };
+}
+
+/**
+ * Merge a saved durable view over a freshly-seeded view. Saved durable axes
+ * win (so the user's Screen-Options state beats the resolved `defaultView` for
+ * the SAME screen), but only for the durable axes — transient axes (search /
+ * filters / page) keep the seed so a deep-linked filter/search isn't clobbered.
+ *
+ * @param {Object}      seed  The `viewDefaults` + `defaultView` seed.
+ * @param {Object|null} saved The saved durable view (or null).
+ * @return {Object} The reconciled view.
+ */
+export function applySavedView( seed, saved ) {
+	if ( ! saved || typeof saved !== 'object' ) {
+		return seed;
+	}
+	return { ...seed, ...pickDurableView( saved ) };
+}

--- a/src/apps/_shared/dataviews/useEntityDataView.js
+++ b/src/apps/_shared/dataviews/useEntityDataView.js
@@ -139,6 +139,27 @@ export function useEntityDataView( {
 		}
 		const durable = pickDurableView( rawView );
 		const serialized = JSON.stringify( durable );
+		// A view that exactly matches the screen's freshly-reconstructed
+		// state (seed + the currently-saved durable view for THIS screen) is
+		// not a user edit — it's the result of seeding, rehydrating saved
+		// prefs, or flipping to this screen. Skip writing it (keeping the
+		// baseline synced) so navigation between two screens served by the
+		// SAME app instance — Posts↔Pages / Categories↔Tags / Profile↔user-
+		// edit all reuse one MountedApp with only `screenId` flipping — can't
+		// write the destination screen's own view straight back to itself.
+		// The stale-render window during a screen flip (new screenId, old
+		// rawView) is still caught by the null-baseline guard below; this
+		// guard catches the follow-up commit (new rawView) where the baseline
+		// would otherwise hold the previous screen's durable. Only a genuine
+		// divergence from the saved/seeded state schedules a write.
+		const saved = readSavedView( prefsRef.current, screenId );
+		const clean = JSON.stringify(
+			pickDurableView( applySavedView( seed(), saved ) )
+		);
+		if ( serialized === clean ) {
+			lastPersisted.current = serialized;
+			return undefined;
+		}
 		// First run for this screen establishes the baseline (the seed/saved
 		// value just applied) without writing it back.
 		if ( lastPersisted.current === null ) {
@@ -172,6 +193,7 @@ export function useEntityDataView( {
 		// must NOT cancel an already-scheduled durable write. The debounce is
 		// enforced by the clearTimeout above (a fresh durable change replaces a
 		// pending one); unmount cleanup lives in its own effect below.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ rawView, screenId ] );
 
 	// Cancel any pending write on unmount so a debounced timer doesn't fire

--- a/src/apps/_shared/dataviews/useEntityDataView.js
+++ b/src/apps/_shared/dataviews/useEntityDataView.js
@@ -1,9 +1,23 @@
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+import {
+	applySavedView,
+	buildSavePatch,
+	pickDurableView,
+	readSavedView,
+} from './dataViewPrefs.mjs';
+
+/** User-prefs REST endpoint (read full blob / partial-merge write). */
+const PREFS_PATH = '/wp-admin-shell/v1/user-prefs';
+
+/** Debounce window before a view change is persisted (ms). */
+const PERSIST_DEBOUNCE_MS = 600;
 
 /**
  * Shared DataViews `view` + `selection` state for the entity-CRUD apps.
  *
- * Owns the three pieces every list app repeated verbatim:
+ * Owns the pieces every list app repeated verbatim:
  *
  * 1. **Seed** — `view` state initialized from `viewDefaults` spread under the
  *    resolved `dataViewConfig.defaultView`, so iterating `view.filters` /
@@ -22,9 +36,18 @@ import { useEffect, useMemo, useState } from '@wordpress/element';
  *    also clears `selection`: the prior screen's selected row ids don't exist
  *    in the new dataset, so a carried-over selection would point a subsequent
  *    bulk action at stale/absent ids.
+ * 5. **Prefs persistence (Screen-Options parity)** — the durable view axes
+ *    (fields / sort / perPage / layout / type — see `DURABLE_AXES`) are saved
+ *    per `screenId` to `wp_admin_shell_user_prefs` via the `/user-prefs` REST
+ *    surface (debounced), and rehydrated on mount + on every screen flip.
+ *    Saved durable axes WIN over the resolved `defaultView` for the SAME
+ *    screen; transient axes (search / filters / page) always come from the
+ *    fresh seed so deep-linked filters/search aren't clobbered. Prefs load is
+ *    async + non-blocking: the synchronous seed renders first (no flash), then
+ *    the saved view overlays once it arrives. See `dataViewPrefs.mjs`.
  *
  * @param {Object}      options
- * @param {string|null} options.screenId       Active screen id (resync key).
+ * @param {string|null} options.screenId       Active screen id (resync + prefs key).
  * @param {Object}      options.dataViewConfig Resolved doc from `useDataView`.
  * @param {Object}      options.viewDefaults   Per-app `VIEW_DEFAULTS`.
  * @param {Array}       [options.resyncKeys]   Extra resync deps (e.g. [ postType ]).
@@ -36,20 +59,131 @@ export function useEntityDataView( {
 	viewDefaults,
 	resyncKeys = [],
 } ) {
-	const [ rawView, setRawView ] = useState( () => ( {
+	const seed = () => ( {
 		...viewDefaults,
 		...( dataViewConfig.defaultView || {} ),
-	} ) );
+	} );
+
+	const [ rawView, setRawView ] = useState( seed );
 	const [ selection, setSelection ] = useState( [] );
 
+	// Full user-prefs blob (null until the first GET resolves). Held in a ref
+	// — reading it must not re-run the resync effect, and there's no render
+	// that depends on the blob directly (the resolved `rawView` does).
+	const prefsRef = useRef( null );
+
+	const persistTimer = useRef( null );
+	const lastPersisted = useRef( null );
+
+	// Load the saved prefs once, then overlay the saved durable view for the
+	// CURRENT screen over the synchronous seed. Runs on mount only; the
+	// resync effect handles subsequent screen flips (it reads prefsRef). A
+	// failed load leaves prefsRef null → falls back to seed everywhere.
 	useEffect( () => {
-		setRawView( {
-			...viewDefaults,
-			...( dataViewConfig.defaultView || {} ),
-		} );
+		let cancelled = false;
+		apiFetch( { path: PREFS_PATH } )
+			.then( ( result ) => {
+				if ( cancelled ) {
+					return;
+				}
+				prefsRef.current =
+					result && typeof result === 'object' ? result : {};
+				const saved = readSavedView( prefsRef.current, screenId );
+				if ( saved ) {
+					// Sync the persist baseline to the value we're applying so
+					// the resulting state change isn't written straight back.
+					lastPersisted.current = JSON.stringify(
+						pickDurableView( applySavedView( seed(), saved ) )
+					);
+					setRawView( ( current ) =>
+						applySavedView( current, saved )
+					);
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					prefsRef.current = {};
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+		// Mount-only: the resync effect covers screen changes.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
+	// Resync on screen / triple change. Re-seed from defaults + defaultView,
+	// then overlay any saved durable view for the NEW screen (saved wins over
+	// defaultView for the same screen, matching the mount-load behavior). When
+	// prefs haven't loaded yet, prefsRef is null and the bare seed is used —
+	// the mount-load effect will overlay once it resolves. Selection clears.
+	// Also resets the persist baseline so the new screen's first view value
+	// (its seed/saved overlay) isn't mistaken for an edit and written back.
+	// Declared BEFORE the persist effect so its baseline reset wins the same
+	// commit's effect ordering.
+	useEffect( () => {
+		const next = seed();
+		const saved = readSavedView( prefsRef.current, screenId );
+		setRawView( saved ? applySavedView( next, saved ) : next );
 		setSelection( [] );
+		lastPersisted.current = null;
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ screenId, ...resyncKeys ] );
+
+	// Persist durable view axes (debounced) whenever the view changes. Skips
+	// the initial render and any change that doesn't alter the durable axes
+	// (e.g. typing in search / paging) so we don't write on every keystroke.
+	useEffect( () => {
+		if ( ! screenId ) {
+			return undefined;
+		}
+		const durable = pickDurableView( rawView );
+		const serialized = JSON.stringify( durable );
+		// First run for this screen establishes the baseline (the seed/saved
+		// value just applied) without writing it back.
+		if ( lastPersisted.current === null ) {
+			lastPersisted.current = serialized;
+			return undefined;
+		}
+		if ( serialized === lastPersisted.current ) {
+			return undefined;
+		}
+		lastPersisted.current = serialized;
+		if ( persistTimer.current ) {
+			clearTimeout( persistTimer.current );
+		}
+		persistTimer.current = setTimeout( () => {
+			const patch = buildSavePatch( screenId, durable );
+			if ( ! patch ) {
+				return;
+			}
+			apiFetch( { path: PREFS_PATH, method: 'POST', data: patch } )
+				.then( ( result ) => {
+					if ( result && typeof result === 'object' ) {
+						prefsRef.current = result;
+					}
+				} )
+				// Persistence is best-effort: a failed write must not break
+				// the list. The in-memory view is unaffected; the user simply
+				// loses this particular save.
+				.catch( () => {} );
+		}, PERSIST_DEBOUNCE_MS );
+		// No per-run cleanup: an unrelated transient re-render (search / page)
+		// must NOT cancel an already-scheduled durable write. The debounce is
+		// enforced by the clearTimeout above (a fresh durable change replaces a
+		// pending one); unmount cleanup lives in its own effect below.
+	}, [ rawView, screenId ] );
+
+	// Cancel any pending write on unmount so a debounced timer doesn't fire
+	// after the component is gone.
+	useEffect(
+		() => () => {
+			if ( persistTimer.current ) {
+				clearTimeout( persistTimer.current );
+			}
+		},
+		[]
+	);
 
 	const view = useMemo( () => {
 		const titleField =

--- a/tests/runtime/dataviews-shared.test.mjs
+++ b/tests/runtime/dataviews-shared.test.mjs
@@ -20,6 +20,16 @@ const { compileEligibility } = await import(
 const { buildFields, elementsFromLabels, withElementCounts } = await import(
 	resolve( projectRoot, 'src/apps/_shared/dataviews/buildFields.mjs' )
 );
+const {
+	PREFS_KEY,
+	DURABLE_AXES,
+	pickDurableView,
+	readSavedView,
+	buildSavePatch,
+	applySavedView,
+} = await import(
+	resolve( projectRoot, 'src/apps/_shared/dataviews/dataViewPrefs.mjs' )
+);
 
 let pass = 0;
 let fail = 0;
@@ -215,6 +225,139 @@ const specCounted = buildFields(
 ok(
 	'elementCounts merge into spec-declared elements',
 	specCounted.elements[ 0 ].label === 'Editor (3)'
+);
+
+// --- dataViewPrefs (view persistence / Screen-Options parity) ------------
+const fullView = {
+	type: 'table',
+	search: 'hello',
+	filters: [ { field: 'status', value: 'draft' } ],
+	page: 3,
+	perPage: 50,
+	sort: { field: 'title', direction: 'asc' },
+	fields: [ 'title', 'author' ],
+	layout: { density: 'compact' },
+};
+
+const durable = pickDurableView( fullView );
+ok(
+	'pickDurableView keeps durable axes',
+	durable.type === 'table' &&
+		durable.perPage === 50 &&
+		durable.sort.field === 'title' &&
+		JSON.stringify( durable.fields ) === '["title","author"]' &&
+		durable.layout.density === 'compact'
+);
+ok(
+	'pickDurableView drops transient axes (search/filters/page)',
+	durable.search === undefined &&
+		durable.filters === undefined &&
+		durable.page === undefined
+);
+ok(
+	'pickDurableView only forwards axes from DURABLE_AXES',
+	Object.keys( durable ).every( ( k ) => DURABLE_AXES.includes( k ) )
+);
+ok(
+	'pickDurableView omits absent axes',
+	! ( 'titleField' in pickDurableView( { type: 'table' } ) )
+);
+ok(
+	'pickDurableView tolerates non-object',
+	JSON.stringify( pickDurableView( null ) ) === '{}' &&
+		JSON.stringify( pickDurableView( undefined ) ) === '{}'
+);
+
+// readSavedView
+const prefsBlob = {
+	[ PREFS_KEY ]: {
+		posts: { perPage: 25, fields: [ 'title' ] },
+	},
+	'default-route': '/posts',
+};
+ok(
+	'readSavedView returns the per-screen bucket',
+	readSavedView( prefsBlob, 'posts' ).perPage === 25
+);
+ok(
+	'readSavedView returns null for an unsaved screen',
+	readSavedView( prefsBlob, 'pages' ) === null
+);
+ok(
+	'readSavedView returns null when no dataViews bucket',
+	readSavedView( { 'default-route': '/x' }, 'posts' ) === null
+);
+ok(
+	'readSavedView null-safe on empty/absent inputs',
+	readSavedView( null, 'posts' ) === null &&
+		readSavedView( {}, '' ) === null &&
+		readSavedView( undefined, undefined ) === null
+);
+
+// buildSavePatch
+const patch = buildSavePatch( 'posts', fullView );
+ok(
+	'buildSavePatch nests under PREFS_KEY → screenId',
+	patch[ PREFS_KEY ].posts.perPage === 50
+);
+ok(
+	'buildSavePatch persists only durable axes',
+	patch[ PREFS_KEY ].posts.search === undefined &&
+		patch[ PREFS_KEY ].posts.page === undefined
+);
+ok(
+	'buildSavePatch returns null without a screenId',
+	buildSavePatch( '', fullView ) === null &&
+		buildSavePatch( null, fullView ) === null
+);
+
+// applySavedView — saved durable axes win, transient seed survives
+const seed = {
+	type: 'table',
+	search: 'seed-search',
+	filters: [ 'seed-filter' ],
+	page: 1,
+	perPage: 20,
+	sort: { field: 'date', direction: 'desc' },
+	fields: [ 'title', 'date', 'author' ],
+};
+const reconciled = applySavedView( seed, {
+	perPage: 100,
+	fields: [ 'title' ],
+	sort: { field: 'title', direction: 'asc' },
+} );
+ok(
+	'applySavedView: saved durable axes override the seed',
+	reconciled.perPage === 100 &&
+		JSON.stringify( reconciled.fields ) === '["title"]' &&
+		reconciled.sort.field === 'title'
+);
+ok(
+	'applySavedView: transient seed axes survive (search/filters/page)',
+	reconciled.search === 'seed-search' &&
+		reconciled.page === 1 &&
+		JSON.stringify( reconciled.filters ) === '["seed-filter"]'
+);
+ok(
+	'applySavedView: a transient key in the saved blob is ignored',
+	applySavedView( seed, { search: 'evil', perPage: 30 } ).search ===
+		'seed-search'
+);
+ok(
+	'applySavedView returns the seed untouched when saved is null',
+	applySavedView( seed, null ) === seed &&
+		applySavedView( seed, undefined ) === seed
+);
+
+// round-trip: buildSavePatch → readSavedView → applySavedView
+const rt = readSavedView(
+	{ [ PREFS_KEY ]: buildSavePatch( 'posts', fullView )[ PREFS_KEY ] },
+	'posts'
+);
+ok(
+	'round-trip: saved view rehydrates the durable axes',
+	applySavedView( seed, rt ).perPage === 50 &&
+		applySavedView( seed, rt ).search === 'seed-search'
 );
 
 console.log( `\n${ pass } passed, ${ fail } failed` );

--- a/tests/runtime/dataviews-shared.test.mjs
+++ b/tests/runtime/dataviews-shared.test.mjs
@@ -360,5 +360,25 @@ ok(
 		applySavedView( seed, rt ).search === 'seed-search'
 );
 
+// Clean-reconstruction idempotence — the invariant the persist effect's
+// "don't write a view that matches the freshly-reconstructed clean state"
+// guard relies on: re-projecting an already-reconciled view through the same
+// seed+saved reconstruction yields a byte-identical durable projection, so a
+// freshly-seeded / rehydrated / screen-flipped view never looks like an edit.
+const cleanSaved = { perPage: 25, fields: [ 'title' ], type: 'table' };
+const reconstructedOnce = pickDurableView( applySavedView( seed, cleanSaved ) );
+const reconstructedTwice = pickDurableView(
+	applySavedView( applySavedView( seed, cleanSaved ), cleanSaved )
+);
+ok(
+	'clean reconstruction is idempotent (no spurious-write on re-seed)',
+	JSON.stringify( reconstructedOnce ) === JSON.stringify( reconstructedTwice )
+);
+ok(
+	'a genuine edit diverges from the clean reconstruction',
+	JSON.stringify( pickDurableView( { ...seed, perPage: 999 } ) ) !==
+		JSON.stringify( reconstructedOnce )
+);
+
 console.log( `\n${ pass } passed, ${ fail } failed` );
 process.exit( fail > 0 ? 1 : 0 );


### PR DESCRIPTION
**Closes #131.**

DataViews view state (column visibility / sort / per-page / layout — the wp-admin Screen Options equivalent) was lost on navigation/reload because `useEntityDataView`'s resync effect re-seeded from `defaultView` every time. Now persisted per-screen to user prefs and rehydrated.

- New pure helper `dataViewPrefs.mjs` (`pickDurableView` / `readSavedView` / `buildSavePatch` / `applySavedView` + `DURABLE_AXES`).
- Persists **durable** axes only (type/fields/sort/perPage/layout/title-media-description) — **excludes** transient `search`/`filters`/`page` so a deep-linked filter isn't clobbered. Matches what Screen Options remembers.
- Reuses the existing `/wp-admin-shell/v1/user-prefs` REST surface (same one `core:appearance` uses) via `apiFetch`; storage under a `dataViews` key sub-keyed by `screenId`. Writes debounced 600ms, no-op/transient-only changes skipped.
- Reconciliation: synchronous seed renders first (no flash); a baseline ref prevents the rehydrated value being written straight back; genuinely different screens still re-seed, but the saved view wins over `defaultView` for the same screen. Title-dedup + selection reset unchanged; no call-site changes.

**Tests:** `test:runtime` ✅ (dataviews-shared: 47 passed, +17 new) · `lint:js` ✅ · **REST smoke against wp-env VERIFIED** — blob stores/reads through prefs meta, and the resolver drops the `dataViews` key from resolved config (no cascade pollution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)