### PR TITLE
Add cloud-environment setup for Claude Code on the web

### DIFF
--- a/docs/cloud-environment.md
+++ b/docs/cloud-environment.md
@@ -1,0 +1,103 @@
+# Cloud environment setup (Claude Code on the web)
+
+This repo's full toolchain — the Docker-based `wp-env` WordPress stack, every PHP
+test, and headless-browser screenshots — runs in a Claude Code cloud session.
+The heavy lifting lives in [`scripts/cloud-setup.sh`](../scripts/cloud-setup.sh);
+this doc covers the one-time UI configuration that **can't** be committed to the
+repo, plus how to use the environment in a session.
+
+## One-time configuration at claude.ai/code
+
+The setup script is configured in the cloud-environment UI, not in the repo
+(it runs as root on Ubuntu 24.04 *before* the agent launches; a non-zero exit
+aborts the session).
+
+1. Open **claude.ai/code** → click the environment chip → **Add / edit environment**.
+2. **Setup script** field — paste this single line:
+
+   ```bash
+   bash "$(git rev-parse --show-toplevel)/scripts/cloud-setup.sh"
+   ```
+
+   Keeping the logic in the committed script means changes ship with the repo;
+   only this one-liner lives in the UI.
+
+3. **Network access** — the default *Trusted* allowlist already covers Docker
+   Hub, npm, and GitHub, but **not** WordPress.org or the Playwright browser
+   CDN. Choose **Custom** (Trusted + the domains below) or **Full**:
+
+   | Why | Domains to allow |
+   |---|---|
+   | wp-env downloads WP core + the Gutenberg plugin zip | `*.wordpress.org` (covers `downloads.wordpress.org`, `api.wordpress.org`) |
+   | Playwright downloads the Chromium binary | `cdn.playwright.dev`, `playwright.download.prss.microsoft.com` |
+
+   Without `*.wordpress.org`, `wp-env start` fails (no WordPress to install).
+   Without the Playwright CDN, screenshots are unavailable but tests still run.
+
+That's it. New sessions re-run the setup script automatically. Docker **images**
+are cached between sessions; **containers** start fresh, so `wp-env start` runs
+each session (fast once images are cached).
+
+## What the setup script provisions
+
+| Step | Result |
+|---|---|
+| Start `dockerd` | Docker daemon available for wp-env |
+| `npm ci` + `npm run build` | Dependencies installed, plugin built into `build/` |
+| `npx wp-env start --update` | Dev site `http://localhost:8888`, test site `http://localhost:8889` |
+| `playwright install chromium` | Headless browser for screenshots (installed globally) |
+
+Sandbox resources: 4 vCPU / 16 GB RAM / 30 GB disk — ample for this stack.
+
+## Using it in a session
+
+### Run the test suites
+
+Node suites run directly:
+
+```bash
+npm run test:schema
+npm run test:runtime
+npm run test:engines
+npm run test:parity
+npm run lint:js
+npm run lint:ts
+```
+
+PHP suites run through the wp-env CLI container, exactly as in `CLAUDE.md`:
+
+```bash
+npx wp-env run cli wp eval-file wp-content/plugins/WordPress-Admin-Environment/tests/php/run-cascade-tests.php
+# ...and the rest of the run-*.php files under tests/php/
+```
+
+> **Path note:** wp-env mounts the repo at
+> `wp-content/plugins/<repo-dir-name>`. The commands above (and in `CLAUDE.md`)
+> assume the checkout dir is `WordPress-Admin-Environment`. If the cloud
+> checkout name differs, adjust the in-container path accordingly — confirm with
+> `npx wp-env run cli ls wp-content/plugins`.
+
+### Capture a screenshot for review
+
+[`scripts/screenshot.mjs`](../scripts/screenshot.mjs) logs into the dev site and
+saves a full-page PNG:
+
+```bash
+node scripts/screenshot.mjs /wp-admin/                 admin-home.png
+node scripts/screenshot.mjs "/wp-admin/index.php"      dashboard.png
+node scripts/screenshot.mjs /                          front.png
+```
+
+Defaults match wp-env (`admin` / `password` on `:8888`). Override via
+`WP_BASE_URL` (use `:8889` for the test site), `WP_USER`, `WP_PASS`,
+`WP_VIEWPORT`. The agent can then read the PNG inline to review rendering.
+
+## Troubleshooting
+
+- **`wp-env start` hangs or fails** — confirm `*.wordpress.org` is allowlisted
+  and `docker info` succeeds. Re-run `npx wp-env start`.
+- **`wp-cli not reachable`** — the DB container needs a few seconds after start;
+  retry the `wp eval-file` command.
+- **Screenshot can't find playwright** — the helper falls back to the global
+  install; if it still fails, run `npm install -g playwright && npx playwright install chromium`.
+- **Reset the stack** — `npx wp-env destroy && npx wp-env start`.

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Cloud-environment setup for WP Admin Shell (Claude Code on the web).
+#
+# This file is committed to the repo so it stays version-controlled, but the
+# Claude Code cloud "Setup script" field can't reference a repo path that
+# doesn't exist yet at provision time — so paste this ONE LINE into the
+# Setup script box at claude.ai/code  ▸ environment ▸ Setup script:
+#
+#     bash "$(git rev-parse --show-toplevel)/scripts/cloud-setup.sh"
+#
+# (The repo is already cloned when the setup script runs.)
+#
+# What it does, mirroring our local toolchain:
+#   1. Ensures the Docker daemon is running (wp-env needs it).
+#   2. npm ci + production build.
+#   3. `wp-env start` — boots the SAME WordPress stack we use locally
+#      (dev site :8888, test site :8889) so the agent can run every PHP test
+#      and anything that needs a live WP install.
+#   4. Installs headless Chromium so the agent can drive the site with
+#      Playwright and capture screenshots for review.
+#
+# Runs as root on Ubuntu 24.04 BEFORE the agent session starts. A non-zero
+# exit makes the whole session fail to launch, so every step is best-effort
+# and we always `exit 0` — the agent diagnoses failures from the logs below.
+#
+# NETWORK: requires egress to *.wordpress.org (WP core + Gutenberg zip) and the
+# Playwright browser CDN. Docker Hub / npm / GitHub are on the default Trusted
+# allowlist. See docs/cloud-environment.md for the exact domains to allow.
+
+set -uo pipefail
+
+log()  { printf '\n\033[1;34m[cloud-setup]\033[0m %s\n' "$*"; }
+warn() { printf '\n\033[1;33m[cloud-setup WARN]\033[0m %s\n' "$*"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+log "repo root: $REPO_ROOT"
+
+# --- 1. Docker daemon ------------------------------------------------------
+# Installed in the sandbox but not always started. wp-env is Docker-based.
+if ! docker info >/dev/null 2>&1; then
+	log "starting dockerd in the background..."
+	dockerd >/var/log/dockerd.log 2>&1 &
+	for _ in $(seq 1 30); do
+		docker info >/dev/null 2>&1 && break
+		sleep 1
+	done
+fi
+if docker info >/dev/null 2>&1; then
+	log "docker daemon is up"
+else
+	warn "docker is not available — wp-env (PHP tests / live WP) will not start"
+fi
+
+# --- 2. Node dependencies + plugin build ----------------------------------
+log "installing npm dependencies..."
+npm ci || npm install || warn "npm install failed"
+
+log "building the plugin (wp-scripts build)..."
+npm run build || warn "build failed — check the log above"
+
+# --- 3. WordPress via wp-env ----------------------------------------------
+# Pulls WP core + the Gutenberg plugin zip from *.wordpress.org and starts the
+# Docker stack. --update keeps core/plugins fresh; falls back to plain start.
+log "starting wp-env (first run pulls images + downloads WordPress)..."
+if npx wp-env start --update || npx wp-env start; then
+	log "wp-env is up — dev site http://localhost:8888  |  test site http://localhost:8889"
+	# Sanity check that wp-cli works inside the container (this is how PHP tests run).
+	npx wp-env run cli wp core version 2>/dev/null \
+		&& log "wp-cli reachable inside the container" \
+		|| warn "wp-cli not reachable yet — give the DB a moment, then retry in-session"
+else
+	warn "wp-env start failed — verify *.wordpress.org egress and that docker is up"
+fi
+
+# --- 4. Headless browser for screenshot review ----------------------------
+# Installed globally so it doesn't touch package.json / package-lock.json.
+# scripts/screenshot.mjs resolves playwright from either a global or local install.
+log "installing Playwright + Chromium for screenshots..."
+if npm install -g playwright >/dev/null 2>&1 \
+	&& npx --yes playwright install --with-deps chromium >/dev/null 2>&1; then
+	log "Playwright Chromium ready — use: node scripts/screenshot.mjs <path> [out.png]"
+else
+	warn "Playwright/Chromium install failed — allowlist the Playwright CDN (see docs/cloud-environment.md)"
+fi
+
+log "setup complete."
+exit 0

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Screenshot helper for reviewing the running wp-env site in a cloud session.
+ *
+ * Logs into the wp-env dev site and captures a full-page PNG so the agent can
+ * visually review a change. Pairs with scripts/cloud-setup.sh, which installs
+ * Playwright + Chromium.
+ *
+ * Usage:
+ *   node scripts/screenshot.mjs <path> [outfile.png]
+ *
+ * Examples:
+ *   node scripts/screenshot.mjs /wp-admin/                       admin-home.png
+ *   node scripts/screenshot.mjs "/wp-admin/index.php"            dashboard.png
+ *   node scripts/screenshot.mjs /                                front.png
+ *
+ * Env overrides (defaults match wp-env's out-of-the-box dev site):
+ *   WP_BASE_URL  (default http://localhost:8888 — use :8889 for the test site)
+ *   WP_USER      (default admin)
+ *   WP_PASS      (default password)
+ *   WP_VIEWPORT  (default 1440x900)
+ */
+import { createRequire } from 'node:module';
+import { execSync } from 'node:child_process';
+
+const require = createRequire( import.meta.url );
+
+// Resolve playwright whether it's a local devDependency or a global install
+// (cloud-setup.sh installs it globally to keep package.json untouched).
+function loadChromium() {
+	try {
+		return require( 'playwright' ).chromium;
+	} catch {
+		const globalRoot = execSync( 'npm root -g' ).toString().trim();
+		return require( `${ globalRoot }/playwright` ).chromium;
+	}
+}
+
+const BASE = process.env.WP_BASE_URL || 'http://localhost:8888';
+const USER = process.env.WP_USER || 'admin';
+const PASS = process.env.WP_PASS || 'password';
+const [ vw, vh ] = ( process.env.WP_VIEWPORT || '1440x900' )
+	.split( 'x' )
+	.map( ( n ) => parseInt( n, 10 ) );
+
+const target = process.argv[ 2 ] || '/wp-admin/';
+const out = process.argv[ 3 ] || 'screenshot.png';
+
+const chromium = loadChromium();
+const browser = await chromium.launch();
+try {
+	const ctx = await browser.newContext( {
+		viewport: { width: vw || 1440, height: vh || 900 },
+	} );
+	const page = await ctx.newPage();
+
+	// Authenticate (skipped automatically if already logged in / no form present).
+	await page.goto( `${ BASE }/wp-login.php`, { waitUntil: 'networkidle' } );
+	if ( await page.locator( '#user_login' ).count() ) {
+		await page.fill( '#user_login', USER );
+		await page.fill( '#user_pass', PASS );
+		await page.click( '#wp-submit' );
+		await page.waitForLoadState( 'networkidle' );
+	}
+
+	await page.goto( `${ BASE }${ target }`, { waitUntil: 'networkidle' } );
+	await page.screenshot( { path: out, fullPage: true } );
+	// eslint-disable-next-line no-console
+	console.log( `saved ${ out }  ←  ${ BASE }${ target }` );
+} finally {
+	await browser.close();
+}


### PR DESCRIPTION
## Summary

Provision the full local toolchain in a Claude Code cloud session so an agent can run every PHP test, anything needing a live WordPress install, and capture screenshots for visual review.

- **`scripts/cloud-setup.sh`** — starts `dockerd`, runs `npm ci` + `npm run build`, boots the same `wp-env` stack we use locally (dev `:8888` / test `:8889`), and installs Playwright + Chromium. Best-effort throughout and always `exit 0`, since a non-zero exit aborts cloud session launch — failures surface in the logs instead of blocking startup.
- **`scripts/screenshot.mjs`** — logs into the wp-env dev site and saves a full-page PNG. Resolves Playwright from a global *or* local install, so `package.json` / lockfile stay untouched.
- **`docs/cloud-environment.md`** — the UI config (the setup-script one-liner can't live in the repo), the required `*.wordpress.org` + Playwright-CDN network allowlist, and in-session usage for tests + screenshots.

## Configuration that can't be committed (in the PR doc)

The cloud setup script lives in the environment UI at claude.ai/code, not the repo. Paste this one-liner into the **Setup script** field:

\`\`\`bash
bash "\$(git rev-parse --show-toplevel)/scripts/cloud-setup.sh"
\`\`\`

And set network access to **Custom**/**Full** allowing `*.wordpress.org` (WP core + Gutenberg zip) and the Playwright CDN. Without `*.wordpress.org`, `wp-env start` can't download WordPress.

## Verification

- `bash -n scripts/cloud-setup.sh` ✅
- `node --check scripts/screenshot.mjs` ✅
- Not yet exercised end-to-end inside a live cloud sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)