### PR TITLE
Fix cloud setup-script one-liner (drop command substitution)

### DIFF
--- a/docs/cloud-environment.md
+++ b/docs/cloud-environment.md
@@ -16,11 +16,15 @@ aborts the session).
 2. **Setup script** field — paste this single line:
 
    ```bash
-   bash "$(git rev-parse --show-toplevel)/scripts/cloud-setup.sh"
+   bash scripts/cloud-setup.sh
    ```
 
    Keeping the logic in the committed script means changes ship with the repo;
-   only this one-liner lives in the UI.
+   only this one-liner lives in the UI. Use a **plain relative path** — do NOT
+   wrap it in `$(...)` command substitution. The platform re-wraps the setup
+   field in its own shell, where command substitution + quotes fail with
+   `syntax error near unexpected token ')'`. The repo is cloned and the working
+   directory is the repo root when the setup script runs.
 
 3. **Network access** — the default *Trusted* allowlist already covers Docker
    Hub, npm, and GitHub, but **not** WordPress.org or the Playwright browser

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -2,14 +2,16 @@
 #
 # Cloud-environment setup for WP Admin Shell (Claude Code on the web).
 #
-# This file is committed to the repo so it stays version-controlled, but the
-# Claude Code cloud "Setup script" field can't reference a repo path that
-# doesn't exist yet at provision time — so paste this ONE LINE into the
-# Setup script box at claude.ai/code  ▸ environment ▸ Setup script:
+# This file is committed to the repo so it stays version-controlled. Paste this
+# ONE LINE into the Setup script box at claude.ai/code ▸ environment:
 #
-#     bash "$(git rev-parse --show-toplevel)/scripts/cloud-setup.sh"
+#     bash scripts/cloud-setup.sh
 #
-# (The repo is already cloned when the setup script runs.)
+# Use a plain relative path — NOT a $(...) command substitution. The platform
+# re-wraps the setup-script field in its own shell, where command substitution
+# + quotes break ("syntax error near unexpected token )"). The repo is already
+# cloned and the working directory is the repo root when this runs; the script
+# also self-locates its repo root internally, so the relative path is enough.
 #
 # What it does, mirroring our local toolchain:
 #   1. Ensures the Docker daemon is running (wp-env needs it).


### PR DESCRIPTION
## Summary

The setup-script one-liner shipped in #181 used `$(git rev-parse --show-toplevel)` command substitution. The Claude Code cloud platform re-wraps the setup-script field in its own shell, where that substitution + the surrounding quotes fail at parse time:

```
/tmp/init-script-*.sh: line 3: syntax error near unexpected token ')'
```

Fix: use a plain relative path. The setup script already runs from the repo root and self-locates its repo root internally, so `bash scripts/cloud-setup.sh` is sufficient.

- Updated the UI one-liner in `docs/cloud-environment.md` and the header comment in `scripts/cloud-setup.sh`, each with a note explaining why command substitution must not be used here.

## Action required after merge

Update the **Setup script** field in the cloud environment UI to:

```bash
bash scripts/cloud-setup.sh
```

then start a new session.

## Verification

- `bash -n scripts/cloud-setup.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)