### PR TITLE
ci: run wp-env PHP integration suites on push/PR

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -1,0 +1,76 @@
+name: PHP tests (wp-env)
+
+# Runs the WordPress-integration suites: the tests/php/run-*.php scripts that
+# need a live WordPress (+ Gutenberg) install, executed via `wp eval-file`
+# inside the wp-env container. The pure-Node suites (test:schema / test:parity
+# / test:runtime / test:engines) don't need WordPress and are not covered here.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: php-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  php-tests:
+    name: WordPress integration (wp-env)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install wp-env
+        # Pin a version (e.g. @wordpress/env@10) for fully reproducible runs.
+        run: npm install -g @wordpress/env
+
+      # wp-env reads .wp-env.json: mounts this repo as a plugin and pulls the
+      # Gutenberg plugin (a hard runtime dependency of the shell). The shell's
+      # build/ assets aren't needed — the plugin bootstrap bails gracefully
+      # when build/index.asset.php is absent, and the PHP suites load the
+      # cascade/REST classes directly.
+      - name: Start WordPress
+        run: wp-env start
+
+      - name: Run PHP test suites
+        run: |
+          set -uo pipefail
+          # wp-env mounts "." as a plugin named after the checkout directory
+          # (the repo name), so the in-container path is:
+          #   wp-content/plugins/<repo>/tests/php/run-*.php
+          plugin_dir="wp-content/plugins/${GITHUB_REPOSITORY##*/}"
+          shopt -s nullglob
+          failed=()
+          for f in tests/php/run-*.php; do
+            name="$(basename "$f")"
+            echo "::group::$name"
+            if wp-env run cli wp eval-file "$plugin_dir/$f"; then
+              echo "PASS  $name"
+            else
+              echo "FAIL  $name"
+              failed+=("$name")
+            fi
+            echo "::endgroup::"
+          done
+          echo
+          if [ ${#failed[@]} -gt 0 ]; then
+            echo "::error::${#failed[@]} PHP suite(s) failed: ${failed[*]}"
+            exit 1
+          fi
+          echo "All PHP suites passed."
+
+      - name: Dump WordPress debug.log on failure
+        if: failure()
+        run: wp-env run cli cat wp-content/debug.log || true

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,6 @@
 {
 	"core": null,
-	"plugins": [ ".", "https://downloads.wordpress.org/plugin/gutenberg.zip" ],
+	"plugins": [ "https://downloads.wordpress.org/plugin/gutenberg.zip", "." ],
 	"config": {
 		"WP_DEBUG": true,
 		"WP_DEBUG_LOG": true,

--- a/tests/php/run-alpha-routing-tests.php
+++ b/tests/php/run-alpha-routing-tests.php
@@ -260,3 +260,5 @@ $T::ok( 'baseline does NOT map allowlisted plugin-install', ! isset( $lm['/plugi
 echo "\n────────────────────────────\n";
 echo 'PASS: ' . WPAS_Alpha_Routing_Runner::$pass . '  FAIL: ' . WPAS_Alpha_Routing_Runner::$fail . "\n";
 echo ( WPAS_Alpha_Routing_Runner::$fail > 0 ? "RESULT: FAIL\n" : "RESULT: PASS\n" );
+
+exit( WPAS_Alpha_Routing_Runner::$fail > 0 ? 1 : 0 );

--- a/tests/php/run-alpha-trigger-tests.php
+++ b/tests/php/run-alpha-trigger-tests.php
@@ -228,3 +228,5 @@ if ( WPAS_Alpha_Trigger_Runner::$fail > 0 ) {
 } else {
 	echo "RESULT: PASS\n";
 }
+
+exit( WPAS_Alpha_Trigger_Runner::$fail > 0 ? 1 : 0 );

--- a/tests/php/run-mode-resolution-tests.php
+++ b/tests/php/run-mode-resolution-tests.php
@@ -300,3 +300,5 @@ WPAS_Mode_Resolution_Test_Runner::assert_not_has_key(
 echo "\nTOTAL: " . WPAS_Mode_Resolution_Test_Runner::$pass . " passed, " .
 	WPAS_Mode_Resolution_Test_Runner::$fail . " failed of " .
 	( WPAS_Mode_Resolution_Test_Runner::$pass + WPAS_Mode_Resolution_Test_Runner::$fail ) . "\n";
+
+exit( WPAS_Mode_Resolution_Test_Runner::$fail > 0 ? 1 : 0 );


### PR DESCRIPTION
Adds CI for the WordPress-integration tests — the `tests/php/run-*.php` suites that need a live WordPress (+ Gutenberg) install and so couldn't run as plain Node tests.

### Workflow (`.github/workflows/php-tests.yml`)
- Triggers on `pull_request`, `push` to `main`, and manual `workflow_dispatch`.
- `npm i -g @wordpress/env` → `wp-env start` (reads the existing `.wp-env.json`: mounts the repo as a plugin + pulls the Gutenberg hard-dep).
- Runs **every** `tests/php/run-*.php` via `wp-env run cli wp eval-file`, grouped per-suite, **aggregating** failures (one broken suite doesn't mask the rest) and failing the job if any fail.
- Dumps `wp-content/debug.log` on failure. No build step — the plugin bootstrap bails gracefully without `build/`, and the suites load the cascade/REST classes directly.

### Test-runner exit-code fix (prerequisite)
Three runners only **printed** a FAIL count and exited 0, so CI would have gone green on real failures. Added `exit( $fail > 0 ? 1 : 0 )` to:
- `tests/php/run-mode-resolution-tests.php`
- `tests/php/run-alpha-routing-tests.php`
- `tests/php/run-alpha-trigger-tests.php`

The other 14 suites already signal correctly (12 via `exit(1)`; `engine-defaults` + `tokens` via an uncaught exception → non-zero). PHP `php -l` clean on all three.

### Note
`@wordpress/env` is installed unpinned (latest) — pin a major (e.g. `@wordpress/env@10`) if you want fully reproducible runs. The pure-Node suites (`test:schema` / `test:parity` / `test:runtime` / `test:engines`) still have no CI; happy to add a companion workflow.

This PR run is itself the first execution of the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)