### PR TITLE
ci: run Node test suites + lint on push/PR

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,63 @@
+name: Node tests
+
+# Runs the pure-Node suites + lint — everything that does NOT need a running
+# WordPress. The WordPress-integration suites live in php-tests.yml (wp-env).
+# All steps after `npm ci` run even if an earlier one fails (so one red suite
+# doesn't mask the others); any failure still fails the job.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: node-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  node-tests:
+    name: Node suites + lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Node 22+ is required: test:engines runs the core-desktop *.ts tests via
+      # `node --experimental-strip-types` (added in 22.6).
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint JS
+        if: ${{ !cancelled() }}
+        run: npm run lint:js
+
+      - name: Type-check (core-desktop)
+        if: ${{ !cancelled() }}
+        run: npm run lint:ts
+
+      - name: Schema validation
+        if: ${{ !cancelled() }}
+        run: npm run test:schema
+
+      - name: WPDS parity snapshot
+        if: ${{ !cancelled() }}
+        run: npm run test:parity
+
+      - name: Runtime suites
+        if: ${{ !cancelled() }}
+        run: npm run test:runtime
+
+      - name: Engine suites (core-desktop)
+        if: ${{ !cancelled() }}
+        run: npm run test:engines


### PR DESCRIPTION
Companion to #183 (wp-env PHP tests). Adds `.github/workflows/node-tests.yml` — the pure-Node gate that needs no WordPress.

Runs on `pull_request`, `push` to `main`, and manual dispatch:
- `lint:js` + `lint:ts` (core-desktop type-check)
- `test:schema` · `test:parity` (WPDS snapshot drift) · `test:runtime` · `test:engines`

**Node 22** — `test:engines` runs the core-desktop `*.ts` tests via `node --experimental-strip-types` (needs ≥22.6). `npm ci` with npm cache (lockfile present). Steps after `npm ci` use `if: ${{ !cancelled() }}` so all suites run even if one fails — any failure still fails the job (no masking).

All six commands were run green on the current tree before wiring this up, so this should land green. This PR run is the first execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)