### PR TITLE
fix(ci): remove dangling symlink that crashed Claude Code Review

### DIFF
--- a/.claude/skills/gutenberg-contributor
+++ b/.claude/skills/gutenberg-contributor
@@ -1,1 +1,0 @@
-/Users/davidbowman/.claude/skills/gutenberg-contributor


### PR DESCRIPTION
## What was failing
The **Claude Code Review** workflow has failed on every PR. The OAuth token is fine — OIDC succeeds, the app token is obtained, `Trigger result: true`. The crash is:

```
Action failed with error: ENOENT: no such file or directory, statx '.claude/skills/gutenberg-contributor'
```

## Root cause
`.claude/skills/gutenberg-contributor` is a committed **symlink** (git mode `120000`) pointing at an **absolute local path**:
```
.claude/skills/gutenberg-contributor -> /Users/davidbowman/.claude/skills/gutenberg-contributor
```
That target doesn't exist on the GitHub runner, so when `anthropics/claude-code-action` walks `.claude/skills/` it hits the dangling link and dies. It's the **only** dangling/absolute symlink tracked in the repo, and nothing references the path.

## Fix
`git rm` the symlink. The other 163 `.claude/skills/` files are real committed content and are untouched; the gutenberg-contributor skill stays available to local Claude via the user-global `~/.claude/skills` install.

The Claude review run **on this PR** is the live test of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)