### PR TITLE
Self-locate cloud setup script via find (cwd is not repo root)

### DIFF
--- a/docs/cloud-environment.md
+++ b/docs/cloud-environment.md
@@ -16,15 +16,23 @@ aborts the session).
 2. **Setup script** field — paste this single line:
 
    ```bash
-   bash scripts/cloud-setup.sh
+   find / -path /proc -prune -o -path /sys -prune -o -path /dev -prune -o -name cloud-setup.sh -path '*scripts*' -exec bash {} ';' || true
    ```
 
    Keeping the logic in the committed script means changes ship with the repo;
-   only this one-liner lives in the UI. Use a **plain relative path** — do NOT
-   wrap it in `$(...)` command substitution. The platform re-wraps the setup
-   field in its own shell, where command substitution + quotes fail with
-   `syntax error near unexpected token ')'`. The repo is cloned and the working
-   directory is the repo root when the setup script runs.
+   only this self-locating one-liner lives in the UI. It looks odd for two
+   reasons, both learned the hard way:
+
+   - **The working directory is _not_ the repo root**, and the clone path isn't
+     known ahead of time, so `bash scripts/cloud-setup.sh` fails with exit 127
+     (`No such file or directory`). `find` resolves the script wherever the repo
+     was cloned.
+   - **No `$(...)`, no double quotes, no backslashes.** The platform re-wraps the
+     setup field in its own shell, where command substitution + quotes fail with
+     `syntax error near unexpected token ')'`. The `find` form avoids all three.
+
+   `|| true` guarantees a clean exit so the session always launches; the script
+   then `cd`s to its own repo root internally.
 
 3. **Network access** — the default *Trusted* allowlist already covers Docker
    Hub, npm, and GitHub, but **not** WordPress.org or the Playwright browser

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -5,13 +5,18 @@
 # This file is committed to the repo so it stays version-controlled. Paste this
 # ONE LINE into the Setup script box at claude.ai/code ▸ environment:
 #
-#     bash scripts/cloud-setup.sh
+#     find / -path /proc -prune -o -path /sys -prune -o -path /dev -prune -o -name cloud-setup.sh -path '*scripts*' -exec bash {} ';' || true
 #
-# Use a plain relative path — NOT a $(...) command substitution. The platform
-# re-wraps the setup-script field in its own shell, where command substitution
-# + quotes break ("syntax error near unexpected token )"). The repo is already
-# cloned and the working directory is the repo root when this runs; the script
-# also self-locates its repo root internally, so the relative path is enough.
+# Why this shape and not just `bash scripts/cloud-setup.sh`:
+#   - The setup field's working directory is NOT the repo root, so a relative
+#     path fails with exit 127 (No such file or directory), and the clone path
+#     isn't known ahead of time.
+#   - The platform re-wraps the field in its own shell, where $(...) command
+#     substitution + quotes break ("syntax error near unexpected token )").
+# So we self-locate: `find` resolves this script wherever the repo was cloned,
+# using no command substitution, no double quotes, and no backslashes. `|| true`
+# guarantees a clean exit so the session always launches; this script then
+# self-locates its own repo root (below) and cd's there.
 #
 # What it does, mirroring our local toolchain:
 #   1. Ensures the Docker daemon is running (wp-env needs it).


### PR DESCRIPTION
## Summary

Follow-up to #181 / #182. The setup-script field's **working directory is not the repo root**, so `bash scripts/cloud-setup.sh` fails with:

```
bash: scripts/cloud-setup.sh: No such file or directory  (exit 127)
```

The clone path isn't known ahead of time, and we can't discover it with `$(...)` because the platform mangles command substitution + quotes into `syntax error near unexpected token ')'`.

Fix: a self-locating UI one-liner that uses **no command substitution, no double quotes, and no backslashes** —

```bash
find / -path /proc -prune -o -path /sys -prune -o -path /dev -prune -o -name cloud-setup.sh -path '*scripts*' -exec bash {} ';' || true
```

It prunes the noisy virtual filesystems, finds the committed script wherever the repo was cloned, runs it, and `|| true` guarantees a clean exit. The script's existing `BASH_SOURCE`-based repo-root resolution already works when invoked by absolute path, so no script-body logic changed — only the header comment and `docs/cloud-environment.md`.

## Action required after merge

Set the cloud environment's **Setup script** field to the one-liner above, then start a new session.

## Verification

- `bash -n scripts/cloud-setup.sh` ✅
- Confirmed the `find` form resolves the script and the `BASH_SOURCE`-derived repo root resolves correctly when invoked by absolute path ✅
- Not yet run end-to-end in a live cloud sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)