### PR TITLE
fix(site-health): probe Authorization header + soften failed-test scoring

### DIFF
--- a/src/apps/site-health/app.json
+++ b/src/apps/site-health/app.json
@@ -27,7 +27,7 @@
 		"icon": "wordpress"
 	},
 	"documentation": {
-		"purpose": "Runs WordPress's async site-health checks (`/wp-site-health/v1/tests/{id}`) in parallel on mount and on user re-run. Surfaces a per-test card with status (Good / Recommended / Critical) and a HTML description; the toolbar summarizes counts per category and offers a re-run button. Five tests today: WordPress.org communication, background updates, loopback requests, HTTPS status, authorization header.",
+		"purpose": "Runs WordPress's async site-health checks (`/wp-site-health/v1/tests/{id}`) in parallel on mount and on user re-run. Surfaces a per-test card with status (Good / Recommended / Critical) and a HTML description; the toolbar summarizes counts per category and offers a re-run button. Five tests today: WordPress.org communication, background updates, loopback requests, HTTPS status, authorization header. The authorization-header test is probed with an `Authorization: Basic` header (mirroring classic) so the server can observe whether it strips the header.",
 		"rebuilds": "site-health",
 		"data": {
 			"reads": [
@@ -62,7 +62,7 @@
 			{
 				"id": "per-test-error",
 				"when": "A test request rejected",
-				"renders": "That test's card shows status=critical with `err.message` as description."
+				"renders": "That test's card shows status=recommended with an \"A test is unavailable\" label and a friendly description naming the test — matching classic's soft \"unavailable\" notice rather than a critical failure that would skew the score."
 			}
 		],
 		"interactions": [
@@ -86,7 +86,7 @@
 			},
 			{
 				"concern": "promise-all-with-per-error-catch",
-				"note": "Each test's request is wrapped in try/catch so one failing test doesn't reject the `Promise.all`. Failed tests show as critical with the error message — preserves partial results."
+				"note": "Each test's request is wrapped in try/catch so one failing test doesn't reject the `Promise.all`. Failed tests show as recommended (\"A test is unavailable\") rather than critical — matching classic, so a transient network blip doesn't read as a critical failure. Preserves partial results."
 			},
 			{
 				"concern": "spinner-fallback",

--- a/src/apps/site-health/app.md
+++ b/src/apps/site-health/app.md
@@ -6,7 +6,9 @@ Prose accompanying `app.json#documentation` for the site-health runner.
 
 SiteHealthApp runs WordPress's async site-health checks and reports results in a card list. Each card shows the test label + status pill (Good / Recommended / Critical) + a description sourced from the REST response (which is HTML, written by WordPress core, and trusted accordingly). The toolbar summarizes results into three category counts; clicking Re-run resets results and fires the checks again in parallel.
 
-The interesting pattern is the **per-test error fallback**: each test's `apiFetch` is wrapped in its own try/catch inside the `Promise.all`. A failing test doesn't reject the whole batch — it just renders as critical with `err.message` as the description. This is the right call because site-health is a diagnostic surface; users want partial results when some checks fail.
+The interesting pattern is the **per-test error fallback**: each test's `apiFetch` is wrapped in its own try/catch inside the `Promise.all`. A failing test doesn't reject the whole batch — it renders as a `recommended` "A test is unavailable" card with a friendly description naming the test. This mirrors classic (`site-health.js:333-349`), which treats an unreachable test as a soft notice rather than a critical failure; scoring it `critical` would let a transient network blip skew the score. This is the right call because site-health is a diagnostic surface; users want partial results when some checks fail.
+
+The `authorization-header` test is sent with an `Authorization: Basic dXNlcjpwd2Q=` probe header (mirroring `class-wp-site-health.php:2975`). The entire point of that test is to detect whether the server strips the header in transit, so the request must carry one — without it the result is meaningless.
 
 ## Architecture
 
@@ -15,7 +17,7 @@ Tests live in a module-scope `ASYNC_TESTS` array — five entries today (dotorg-
 `runTests`:
 
 1. Set `isRunning=true`, clear results, clear error.
-2. `Promise.all(ASYNC_TESTS.map(async t => { try { const res = await apiFetch(...); setResults(prev => ({ ...prev, [t.id]: res })) } catch (err) { setResults(prev => ({ ...prev, [t.id]: { status: 'critical', label: t.label, description: err.message } })) } }))`.
+2. `Promise.all(ASYNC_TESTS.map(async t => { try { const res = await apiFetch({ path, ...(t.id === 'authorization-header' && { headers: { Authorization: 'Basic dXNlcjpwd2Q=' } }) }); setResults(prev => ({ ...prev, [t.id]: res })) } catch (err) { setResults(prev => ({ ...prev, [t.id]: { status: 'recommended', label: __('A test is unavailable'), description: '<p>…could not be run.</p>' } })) } }))`.
 3. Set `isRunning=false`.
 
 The per-test `setResults` calls are intentional — results stream in as each request completes rather than waiting for all five.
@@ -26,7 +28,8 @@ Category counts: `Object.values(results).reduce((acc, r) => { if (r?.status && a
 
 Two patterns worth preserving:
 
-- **Partial-result reporting.** Most async-batch UIs reject the whole batch when one request fails. Site-health is the rare case where partial results are useful — wrap each request in try/catch and treat errors as data, not exceptions.
+- **Partial-result reporting.** Most async-batch UIs reject the whole batch when one request fails. Site-health is the rare case where partial results are useful — wrap each request in try/catch and treat errors as data, not exceptions. Score the failure as `recommended` ("unavailable"), not `critical` — classic does the same so a flaky test doesn't tank the health score.
+- **Probe headers belong with the test.** The authorization-header test only means something if the request carries the `Authorization: Basic` header it's probing for. Keep the header alongside the test definition when rebuilding.
 - **Stream results as they arrive.** `setResults(prev => ({ ...prev, [id]: res }))` mounted per request beats `await Promise.all().then(setResults)` — the user sees progress.
 
 A non-WPDS rebuild needs Card, Badge (status pill with intent), Button, Spinner, and dangerously-set-HTML (or equivalent) for trusted descriptions.

--- a/src/apps/site-health/index.js
+++ b/src/apps/site-health/index.js
@@ -3,7 +3,7 @@ import { useEffect, useState, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { Badge, Button, Card, Icon, Stack, Text } from '@wordpress/ui';
 import { Spinner } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { update } from '@wordpress/icons';
 
 const ASYNC_TESTS = [
@@ -58,18 +58,41 @@ export default function SiteHealthApp() {
 					try {
 						const res = await apiFetch( {
 							path: `/wp-site-health/v1/tests/${ t.id }`,
+							// The authorization-header test probes whether the
+							// server strips the Authorization header; classic
+							// sends this Basic header so the endpoint can observe
+							// it (class-wp-site-health.php:2975). Without it the
+							// result is meaningless.
+							...( t.id === 'authorization-header' && {
+								headers: {
+									Authorization: 'Basic dXNlcjpwd2Q=',
+								},
+							} ),
 						} );
 						setResults( ( prev ) => ( {
 							...prev,
 							[ t.id ]: res,
 						} ) );
 					} catch ( err ) {
+						// Match classic: an unreachable test is a soft
+						// "recommended" notice, not a critical failure that
+						// tanks the score (site-health.js:333-349).
 						setResults( ( prev ) => ( {
 							...prev,
 							[ t.id ]: {
-								status: 'critical',
-								label: t.label,
-								description: err.message,
+								status: 'recommended',
+								label: __(
+									'A test is unavailable',
+									'wp-admin-shell'
+								),
+								description: `<p>${ sprintf(
+									// translators: %s: the name of the Site Health test.
+									__(
+										'The “%s” test could not be run.',
+										'wp-admin-shell'
+									),
+									t.label
+								) }</p>`,
 							},
 						} ) );
 					}

--- a/src/apps/site-health/index.js
+++ b/src/apps/site-health/index.js
@@ -73,7 +73,7 @@ export default function SiteHealthApp() {
 							...prev,
 							[ t.id ]: res,
 						} ) );
-					} catch ( err ) {
+					} catch {
 						// Match classic: an unreachable test is a soft
 						// "recommended" notice, not a critical failure that
 						// tanks the score (site-health.js:333-349).


### PR DESCRIPTION
Fixes the two Site Health correctness bugs called out in #105 (parity roadmap group A, P1, item 9; detail in `docs/parity/site-health.md`).

## Bugs

1. **Authorization-header test ran without its probe header.** The whole point of that test is to detect whether the server strips the `Authorization` header in transit. Classic sends `Authorization: Basic dXNlcjpwd2Q=` (`class-wp-site-health.php:2975`); the shell sent no headers, so the endpoint couldn't observe the header it's supposed to be probing — the result was unreliable / likely wrong.

2. **Failed/unavailable tests were scored `critical`.** A transient network blip on, say, the loopback test rendered as a `critical` card with the raw JS error string, which would tank the score and read as a security/perf failure. Classic downgrades an unreachable test to a soft `recommended` "A test is unavailable" notice (`site-health.js:333-349`).

## Changes

- `src/apps/site-health/index.js`
  - Send the `Authorization: Basic` probe header for the `authorization-header` test only.
  - Catch path now sets `status: 'recommended'`, label `"A test is unavailable"`, and a friendly translated description naming the test (no raw error string).
- `app.json#documentation` + `app.md` updated to match the new behavior (per-test-error state, constraint note, purpose line, rebuild guide).

## Testing

- `npx eslint src/apps/site-health/index.js` — clean.

Closes #105.

https://claude.ai/code/session_01Tuaq7MJUGNLQSBuQ96JXmQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuaq7MJUGNLQSBuQ96JXmQ)_