### PR TITLE
docs(parity): close stale editor-classic.md gap (#174)

### DIFF
--- a/docs/parity/block-editor.md
+++ b/docs/parity/block-editor.md
@@ -23,7 +23,7 @@ Both are explicitly positioned as interim (`app.md` "v2-beta concession" / "MVP 
   - `core:editor` (iframe): writes only — `POST /wp/v2/posts | /wp/v2/pages` (auto-draft creation, `src/apps/editor/index.js:81-95`). All editing data flows through the *iframed* `post.php`, which uses core's full preload + REST stack. Reads `window.wpAdminShell.adminUrl` for the iframe `src`.
   - `core:simple-editor` (native): `useEntityRecord('postType', postType, postId)` (`src/apps/simple-editor/index.js:228-236`) — `GET`/`PUT /wp/v2/{posts|pages}/{id}` with `context: 'edit'` (declared in `app.json:45`). Auto-draft create: `POST /wp/v2/{posts|pages}` (`index.js:143-151`). **Does not touch** `/autosaves`, `/revisions`, block-types, block-patterns, blocks, global-styles, or `/batch/v1`.
 
-- **Project screen spec:** `docs/screens/editor-block.md` (overview/header/canvas/save) + `docs/screens/editor-block-inspector.md` + `docs/screens/editor-block-modes.md` + `docs/screens/editor-block-data.md` (REST/preload/autosave/revisions). This is the most complete tier-2 spec in the repo; the §15 gap tables there already enumerate most of what follows. **No `editor-classic.md` exists** despite §16 referencing it — minor doc gap.
+- **Project screen spec:** `docs/screens/editor-block.md` (overview/header/canvas/save) + `docs/screens/editor-block-inspector.md` + `docs/screens/editor-block-modes.md` + `docs/screens/editor-block-data.md` (REST/preload/autosave/revisions). This is the most complete tier-2 spec in the repo; the §15 gap tables there already enumerate most of what follows. The classic TinyMCE editor that §16 cross-references is specced separately in `docs/screens/editor-classic.md` (a full tier-2 spec, landed in PR #36) — the earlier "no `editor-classic.md` exists" note was a stale-snapshot artifact of this 2026-05-29 audit.
 
 ## Feature parity matrix
 
@@ -191,4 +191,4 @@ Not blockers (REST-reachable, just unbuilt in simple-editor): featured image (`f
 
 12. **Upstream: expose `preview_nonce` (or a draft-preview URL) in the posts REST schema** (blocker #5) so a native editor can offer draft preview without a server round-trip. *Upstream.*
 
-13. **Author `docs/screens/editor-classic.md`** — referenced by `editor-block.md` §16 but absent. *Doc gap.*
+13. ✅ **Done — `docs/screens/editor-classic.md` exists.** A full tier-2 classic-editor spec landed in PR #36; this audit's 2026-05-29 snapshot predated it. Correctly cross-referenced by `editor-block.md` §16. *No action.*

--- a/docs/parity/roadmap.md
+++ b/docs/parity/roadmap.md
@@ -201,7 +201,7 @@ All against `@wordpress/dataviews@14.0.0`. The harness is idiomatic; these are c
 
 ### P2 — missing screen specs
 
-4. **Author `docs/screens/editor-classic.md`** — the block/classic post editor (`core:editor` + `core:simple-editor`) has no dedicated screen spec. ([block-editor.md](block-editor.md))
+4. ✅ **Done — `docs/screens/editor-classic.md` exists.** A full tier-2 classic-editor spec landed in PR #36; this audit's 2026-05-29 snapshot predated it. The block editor (`core:editor` + `core:simple-editor`) is separately specced by `docs/screens/editor-block.md` + `editor-block-{data,inspector,modes}.md`. ([block-editor.md](block-editor.md))
 
 5. **Author a dedicated `docs/screens/profile.md`** — Profile is currently only a sub-section of `users.md`; own-vs-other-user branching and the email-confirm flow get light coverage. ([profile.md](profile.md))
 

--- a/docs/parity/roadmap.md
+++ b/docs/parity/roadmap.md
@@ -199,7 +199,7 @@ All against `@wordpress/dataviews@14.0.0`. The harness is idiomatic; these are c
 
 3. **Fix app.md claims of non-existent window globals.** themes `app.md` references a `window.wpAdminShell.activeTheme` read never emitted by `wp-admin-shell.php`; verify and remove. ([themes.md](themes.md))
 
-### P2 — missing screen specs
+### P2 — screen spec coverage
 
 4. ✅ **Done — `docs/screens/editor-classic.md` exists.** A full tier-2 classic-editor spec landed in PR #36; this audit's 2026-05-29 snapshot predated it. The block editor (`core:editor` + `core:simple-editor`) is separately specced by `docs/screens/editor-block.md` + `editor-block-{data,inspector,modes}.md`. ([block-editor.md](block-editor.md))
 


### PR DESCRIPTION
## Summary

Issue #174 asks to author `docs/screens/editor-classic.md`. On investigation, **that file already exists** — it's a complete 480-line tier-2 spec for the classic TinyMCE editor that landed in PR #36 (2026-05-14) and correctly satisfies the `editor-block.md` §16 cross-reference. The block editor (`core:editor` + `core:simple-editor`) is itself already specced by `editor-block.md` + `editor-block-{data,inspector,modes}.md`.

The gap was filed by the 2026-05-29 parity audit (PR #96), which was taken from a stale snapshot that predated PR #36. So there is no spec to author — the remaining work is to correct the three now-inaccurate tracking statements that still claim the file is absent.

## Changes

- `docs/parity/block-editor.md` — drop the false "**No `editor-classic.md` exists**" note in the overview; point at the existing sibling spec and flag the note as a stale-snapshot artifact.
- `docs/parity/block-editor.md` (gap-list item 13) — mark ✅ Done, noting the audit snapshot predated PR #36.
- `docs/parity/roadmap.md` (group D, P2, item 4) — mark ✅ Done; clarify the block editor is separately specced.

Docs-only; no code or behavior changes.

Closes #174

https://claude.ai/code/session_01JZ5hHFGrjFv9j5pookPaVR

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZ5hHFGrjFv9j5pookPaVR)_