### PR TITLE
fix(posts): wire trash Restore + Delete Permanently actions + a Trash view

### DIFF
--- a/shells/wp-admin-default.json
+++ b/shells/wp-admin-default.json
@@ -881,6 +881,28 @@
 				"taxonomy": "post_tag"
 			}
 		},
+		"posts-trash": {
+			"label": "Trash",
+			"icon": "trash",
+			"description": "Trashed posts — restore or permanently delete.",
+			"path": "/posts/trash",
+			"app": "core:posts",
+			"config": {
+				"postType": "post",
+				"status": "trash"
+			},
+			"dataViewRef": "postType/post/trash",
+			"permissions": {
+				"capabilities": [
+					"edit_posts"
+				]
+			},
+			"legacy_path": "edit.php",
+			"legacy_query": {
+				"post_type": "post",
+				"post_status": "trash"
+			}
+		},
 		"pages": {
 			"label": "Pages",
 			"icon": "page",
@@ -1371,6 +1393,9 @@
 				},
 				"tags": {
 					"position": 40
+				},
+				"posts-trash": {
+					"position": 50
 				}
 			}
 		},

--- a/shells/wp-admin-default.json
+++ b/shells/wp-admin-default.json
@@ -165,10 +165,50 @@
 						},
 						"actions": [
 							{
+								"id": "edit",
+								"label": "Edit",
+								"eligibleWhen": {
+									"status": [
+										"publish",
+										"future",
+										"draft",
+										"pending",
+										"private"
+									]
+								}
+							},
+							{
+								"id": "view",
+								"label": "View",
+								"eligibleWhen": {
+									"status": [
+										"publish",
+										"future",
+										"draft",
+										"pending",
+										"private"
+									]
+								}
+							},
+							{
+								"id": "trash",
+								"label": "Move to Trash",
+								"eligibleWhen": {
+									"status": [
+										"publish",
+										"future",
+										"draft",
+										"pending",
+										"private"
+									]
+								}
+							},
+							{
 								"id": "restore",
 								"label": "Restore",
 								"isPrimary": true,
 								"supportsBulk": true,
+								"icon": "update",
 								"eligibleWhen": {
 									"status": "trash"
 								}
@@ -178,6 +218,7 @@
 								"label": "Delete Permanently",
 								"isDestructive": true,
 								"supportsBulk": true,
+								"icon": "trash",
 								"eligibleWhen": {
 									"status": "trash"
 								}

--- a/src/apps/posts/app.json
+++ b/src/apps/posts/app.json
@@ -57,7 +57,7 @@
 					{ "id": "date", "type": "datetime", "label": "Date" }
 				],
 				"actions": [
-					{ "id": "edit", "label": "Edit", "isPrimary": true, "icon": "pencil" },
+					{ "id": "edit", "label": "Edit", "isPrimary": true, "icon": "pencil", "eligibleWhen": { "status": [ "publish", "future", "draft", "pending", "private" ] } },
 					{ "id": "view", "label": "View", "icon": "external", "eligibleWhen": { "status": "publish" } },
 					{ "id": "trash", "label": "Move to Trash", "isDestructive": true, "supportsBulk": true, "icon": "trash", "eligibleWhen": { "status": [ "publish", "future", "draft", "pending", "private" ] } }
 				]
@@ -83,7 +83,10 @@
 					"filters": [ { "field": "status", "operator": "is", "value": "trash" } ]
 				},
 				"actions": [
-					{ "id": "restore", "label": "Restore", "isPrimary": true, "supportsBulk": true, "eligibleWhen": { "status": "trash" } },
+					{ "id": "edit", "label": "Edit", "__tombstone": true },
+					{ "id": "view", "label": "View", "__tombstone": true },
+					{ "id": "trash", "label": "Move to Trash", "__tombstone": true },
+					{ "id": "restore", "label": "Restore", "isPrimary": true, "supportsBulk": true, "icon": "update", "eligibleWhen": { "status": "trash" } },
 					{ "id": "delete-permanent", "label": "Delete Permanently", "isDestructive": true, "supportsBulk": true, "icon": "trash", "eligibleWhen": { "status": "trash" } }
 				]
 			}

--- a/src/apps/posts/app.json
+++ b/src/apps/posts/app.json
@@ -167,6 +167,24 @@
 					"invalidates": [
 						"postType/{config.postType}"
 					]
+				},
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"operation": "update",
+					"purpose": "Restore trashed posts (trash-variant `restore` action). `saveEntityRecord` with `status: 'draft'` — REST exposes no pre-trash status meta, so restore lands on draft (an accepted divergence from classic wp-admin; see docs/parity/posts.md blocker #4).",
+					"invalidates": [
+						"postType/{config.postType}"
+					]
+				},
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"operation": "delete",
+					"purpose": "Permanently delete trashed posts (trash-variant `delete-permanent` action). `deleteEntityRecord(..., { force: true })` after a confirm modal — skips trash, irreversible.",
+					"invalidates": [
+						"postType/{config.postType}"
+					]
 				}
 			]
 		},
@@ -221,6 +239,20 @@
 			{
 				"trigger": "Trash bulk action",
 				"effect": "Open the confirm modal with a pluralized message; on confirm `Promise.allSettled(items.map(deleteEntityRecord(...)))` is awaited."
+			},
+			{
+				"trigger": "Restore row/bulk action (trash variant)",
+				"effect": "`saveEntityRecord('postType', postType, { id, status: 'draft' })` over the selected rows; success/partial-failure snackbar; list + status counts refresh. Restores to draft, not the pre-trash status (REST limitation).",
+				"guards": [
+					"item.status === 'trash'"
+				]
+			},
+			{
+				"trigger": "Delete Permanently row/bulk action (trash variant)",
+				"effect": "Open the confirm modal; on confirm `deleteEntityRecord('postType', postType, item.id, { force: true })` over the selected rows — irreversible.",
+				"guards": [
+					"item.status === 'trash'"
+				]
 			},
 			{
 				"trigger": "Change DataViews view (search / filter / sort / layout / page / perPage)",

--- a/src/apps/posts/app.md
+++ b/src/apps/posts/app.md
@@ -88,13 +88,13 @@ Two patterns to preserve:
 - No inline edit (DataViews supports it; not wired up here).
 - Status filter is a single-select today. The `filterBy.operators: ['isAny']` declaration exists but the queryArgs mapper only handles the `isAny`/`is` operators against the `status` field.
 - Site-editor post types (`wp_template`, `wp_block`, `wp_navigation`) navigate through `editHref()` but `editHref()` only special-cases `page`. Their URL-encoded slug-shaped IDs would need a new edit pattern + decode step; deferred until those screens land.
-- The trash action is hard-coded. A future iteration may surface restore / delete-permanently as separate eligible actions once the post is in trash status.
+- The `trash` variant adds `restore` and `delete-permanent` actions (status-gated to trashed rows). `restore` calls `saveEntityRecord(..., { status: 'draft' })` — REST exposes no pre-trash status meta, so a restored post lands on draft rather than its previous status (accepted divergence; see `docs/parity/posts.md` blocker #4). `delete-permanent` confirms, then calls `deleteEntityRecord(..., { force: true })`. Surface the variant via a screen with `dataViewRef: "postType/post/trash"` (the `wp-admin-default` shell ships a Posts → Trash screen for this).
 
 Parity gaps versus `docs/screens/posts.md` not surfaced in the v2 app:
 
 - Status **counts** now surface on the status filter elements (`Published (12)`, `Draft (3)`) via the shared `useEntityElementCounts` hook — one lightweight `per_page=1&_fields=id` request per status value, read back off the `X-WP-Total` header, global (search/page-independent) to mirror wp-admin's status links. Still rendered as filter-dropdown options, **not** the classic standalone subsubsub tab strip (`All (N) | Mine (N) | …`), and there is no `Mine` count.
 - No author / date / taxonomy column filters. wp-admin offers a separate dropdown per axis; the v2 app exposes only the status filter.
-- No trash view + Restore + Delete Permanently actions. Trashed posts are filtered out by `status: any` and the app never surfaces them.
+- Trash view + Restore + Delete Permanently are now wired (trash variant + the `wp-admin-default` Posts → Trash screen). Remaining gap: no **Empty Trash** bulk button, and restore lands on draft rather than the pre-trash status (REST limitation).
 - No undo snackbar after trash. We emit a plain success notice; wp-admin offers "Move to trash · Undo".
 - No keyboard shortcuts (J/K navigation, X to select, T to trash). DataViews has no built-in shortcut layer.
 - No hierarchical pages tree. The Pages screen in wp-admin indents child pages under parents; DataViews renders a flat list ordered by `menu_order` and date.

--- a/src/apps/posts/index.js
+++ b/src/apps/posts/index.js
@@ -1,6 +1,6 @@
 import '../_shared/app.css';
 import { Spinner } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useRef } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -163,6 +163,11 @@ export default function PostsApp( { config } ) {
 		useDispatch( coreStore );
 	const { createNotice } = useDispatch( noticesStore );
 
+	// Re-entry guard for the non-modal `restore` callback — mirrors the
+	// `isBusy` guard the confirm-modal flows get from `createBulkConfirmModal`,
+	// so a fast double-click can't fire two restore batches.
+	const restoreBusy = useRef( false );
+
 	const data = useMemo( () => {
 		if ( ! records ) {
 			return [];
@@ -229,7 +234,7 @@ export default function PostsApp( { config } ) {
 			confirmLabel: __( 'Move to Trash', 'wp-admin-shell' ),
 			mutate: ( item ) =>
 				deleteEntityRecord( 'postType', postType, item.id ),
-			onSettled: ( { items, failed } ) => {
+			onSettled: ( { targets, failed } ) => {
 				refreshAfterMutation();
 				if ( failed > 0 ) {
 					createNotice(
@@ -243,7 +248,22 @@ export default function PostsApp( { config } ) {
 								'wp-admin-shell'
 							),
 							failed,
-							items.length
+							targets.length
+						),
+						{ type: 'snackbar' }
+					);
+				} else {
+					createNotice(
+						'success',
+						sprintf(
+							/* translators: %d: trashed item count */
+							_n(
+								'%d item moved to trash.',
+								'%d items moved to trash.',
+								targets.length,
+								'wp-admin-shell'
+							),
+							targets.length
 						),
 						{ type: 'snackbar' }
 					);
@@ -269,7 +289,7 @@ export default function PostsApp( { config } ) {
 				deleteEntityRecord( 'postType', postType, item.id, {
 					force: true,
 				} ),
-			onSettled: ( { items, failed } ) => {
+			onSettled: ( { targets, failed } ) => {
 				refreshAfterMutation();
 				if ( failed > 0 ) {
 					createNotice(
@@ -283,7 +303,22 @@ export default function PostsApp( { config } ) {
 								'wp-admin-shell'
 							),
 							failed,
-							items.length
+							targets.length
+						),
+						{ type: 'snackbar' }
+					);
+				} else {
+					createNotice(
+						'success',
+						sprintf(
+							/* translators: %d: permanently deleted item count */
+							_n(
+								'%d item permanently deleted.',
+								'%d items permanently deleted.',
+								targets.length,
+								'wp-admin-shell'
+							),
+							targets.length
 						),
 						{ type: 'snackbar' }
 					);
@@ -295,50 +330,64 @@ export default function PostsApp( { config } ) {
 		// pre-trash status (`_wp_trash_meta_status`); REST doesn't expose that
 		// meta, so we restore to `draft` — an accepted divergence documented in
 		// docs/parity/posts.md (blocker #4).
-		const restore = async ( items ) => {
-			const results = await Promise.allSettled(
-				items.map( ( item ) =>
-					saveEntityRecord( 'postType', postType, {
-						id: item.id,
-						status: 'draft',
-					} )
-				)
-			);
-			refreshAfterMutation();
-			const failed = results.filter(
-				( r ) => r.status === 'rejected'
-			).length;
-			if ( failed > 0 ) {
-				createNotice(
-					'error',
-					sprintf(
-						/* translators: 1: failed item count, 2: total item count */
-						_n(
-							'%1$d of %2$d item failed to restore.',
-							'%1$d of %2$d items failed to restore.',
+		const restore = async ( items, { onActionPerformed } = {} ) => {
+			if ( restoreBusy.current ) {
+				return;
+			}
+			restoreBusy.current = true;
+			try {
+				const results = await Promise.allSettled(
+					items.map( ( item ) =>
+						saveEntityRecord( 'postType', postType, {
+							id: item.id,
+							status: 'draft',
+						} )
+					)
+				);
+				refreshAfterMutation();
+				const failed = results.filter(
+					( r ) => r.status === 'rejected'
+				).length;
+				if ( failed > 0 ) {
+					createNotice(
+						'error',
+						sprintf(
+							/* translators: 1: failed item count, 2: total item count */
+							_n(
+								'%1$d of %2$d item failed to restore.',
+								'%1$d of %2$d items failed to restore.',
+								failed,
+								'wp-admin-shell'
+							),
 							failed,
-							'wp-admin-shell'
+							items.length
 						),
-						failed,
-						items.length
-					),
-					{ type: 'snackbar' }
-				);
-			} else {
-				createNotice(
-					'success',
-					sprintf(
-						/* translators: %d: restored item count */
-						_n(
-							'%d item restored to draft.',
-							'%d items restored to draft.',
-							items.length,
-							'wp-admin-shell'
+						{ type: 'snackbar' }
+					);
+				} else {
+					createNotice(
+						'success',
+						sprintf(
+							/* translators: %d: restored item count */
+							_n(
+								'%d item restored to draft.',
+								'%d items restored to draft.',
+								items.length,
+								'wp-admin-shell'
+							),
+							items.length
 						),
-						items.length
-					),
-					{ type: 'snackbar' }
+						{ type: 'snackbar' }
+					);
+				}
+				// Clear the selection for the rows that actually restored —
+				// mirrors the modal flows' onActionPerformed(succeeded).
+				const succeeded = items.filter(
+					( _item, i ) => results[ i ]?.status === 'fulfilled'
 				);
+				onActionPerformed?.( succeeded );
+			} finally {
+				restoreBusy.current = false;
 			}
 		};
 

--- a/src/apps/posts/index.js
+++ b/src/apps/posts/index.js
@@ -61,6 +61,8 @@ const ACTION_LABELS = {
 	edit: __( 'Edit', 'wp-admin-shell' ),
 	view: __( 'View', 'wp-admin-shell' ),
 	trash: __( 'Move to Trash', 'wp-admin-shell' ),
+	restore: __( 'Restore', 'wp-admin-shell' ),
+	'delete-permanent': __( 'Delete Permanently', 'wp-admin-shell' ),
 };
 
 const VIEW_DEFAULTS = {
@@ -157,7 +159,7 @@ export default function PostsApp( { config } ) {
 		STATUS_VALUES
 	);
 
-	const { deleteEntityRecord, invalidateResolution } =
+	const { deleteEntityRecord, saveEntityRecord, invalidateResolution } =
 		useDispatch( coreStore );
 	const { createNotice } = useDispatch( noticesStore );
 
@@ -196,6 +198,23 @@ export default function PostsApp( { config } ) {
 	);
 
 	const actions = useMemo( () => {
+		// Status mutations move rows between filters, so the list query and the
+		// per-status count queries the filter labels read from both refresh.
+		const refreshAfterMutation = () => {
+			invalidateResolution( 'getEntityRecords', [
+				'postType',
+				postType,
+				queryArgs,
+			] );
+			invalidateEntityElementCounts(
+				invalidateResolution,
+				'postType',
+				postType,
+				'status',
+				STATUS_VALUES
+			);
+		};
+
 		const trashModal = createBulkConfirmModal( {
 			getMessage: ( items ) =>
 				items.length === 1
@@ -211,20 +230,7 @@ export default function PostsApp( { config } ) {
 			mutate: ( item ) =>
 				deleteEntityRecord( 'postType', postType, item.id ),
 			onSettled: ( { items, failed } ) => {
-				invalidateResolution( 'getEntityRecords', [
-					'postType',
-					postType,
-					queryArgs,
-				] );
-				// Trash moves rows between statuses, so the count queries
-				// the filter labels read from need to refresh too.
-				invalidateEntityElementCounts(
-					invalidateResolution,
-					'postType',
-					postType,
-					'status',
-					STATUS_VALUES
-				);
+				refreshAfterMutation();
 				if ( failed > 0 ) {
 					createNotice(
 						'error',
@@ -245,6 +251,97 @@ export default function PostsApp( { config } ) {
 			},
 		} );
 
+		// Delete Permanently is irreversible (force: true skips trash), so it
+		// confirms before mutating like the trash flow does.
+		const deletePermanentModal = createBulkConfirmModal( {
+			getMessage: ( items ) =>
+				items.length === 1
+					? __(
+							'Are you sure you want to permanently delete this item? This cannot be undone.',
+							'wp-admin-shell'
+					  )
+					: __(
+							'Are you sure you want to permanently delete these items? This cannot be undone.',
+							'wp-admin-shell'
+					  ),
+			confirmLabel: __( 'Delete Permanently', 'wp-admin-shell' ),
+			mutate: ( item ) =>
+				deleteEntityRecord( 'postType', postType, item.id, {
+					force: true,
+				} ),
+			onSettled: ( { items, failed } ) => {
+				refreshAfterMutation();
+				if ( failed > 0 ) {
+					createNotice(
+						'error',
+						sprintf(
+							/* translators: 1: failed item count, 2: total item count */
+							_n(
+								'%1$d of %2$d item failed to delete.',
+								'%1$d of %2$d items failed to delete.',
+								failed,
+								'wp-admin-shell'
+							),
+							failed,
+							items.length
+						),
+						{ type: 'snackbar' }
+					);
+				}
+			},
+		} );
+
+		// Restore untrashes the selected rows. Classic wp-admin restores to the
+		// pre-trash status (`_wp_trash_meta_status`); REST doesn't expose that
+		// meta, so we restore to `draft` — an accepted divergence documented in
+		// docs/parity/posts.md (blocker #4).
+		const restore = async ( items ) => {
+			const results = await Promise.allSettled(
+				items.map( ( item ) =>
+					saveEntityRecord( 'postType', postType, {
+						id: item.id,
+						status: 'draft',
+					} )
+				)
+			);
+			refreshAfterMutation();
+			const failed = results.filter(
+				( r ) => r.status === 'rejected'
+			).length;
+			if ( failed > 0 ) {
+				createNotice(
+					'error',
+					sprintf(
+						/* translators: 1: failed item count, 2: total item count */
+						_n(
+							'%1$d of %2$d item failed to restore.',
+							'%1$d of %2$d items failed to restore.',
+							failed,
+							'wp-admin-shell'
+						),
+						failed,
+						items.length
+					),
+					{ type: 'snackbar' }
+				);
+			} else {
+				createNotice(
+					'success',
+					sprintf(
+						/* translators: %d: restored item count */
+						_n(
+							'%d item restored to draft.',
+							'%d items restored to draft.',
+							items.length,
+							'wp-admin-shell'
+						),
+						items.length
+					),
+					{ type: 'snackbar' }
+				);
+			}
+		};
+
 		return buildActions( dataViewConfig.actions, {
 			labels: ACTION_LABELS,
 			callbacks: {
@@ -257,13 +354,18 @@ export default function PostsApp( { config } ) {
 						'noopener,noreferrer'
 					);
 				},
+				restore,
 			},
-			modals: { trash: trashModal },
+			modals: {
+				trash: trashModal,
+				'delete-permanent': deletePermanentModal,
+			},
 		} );
 	}, [
 		dataViewConfig,
 		postType,
 		deleteEntityRecord,
+		saveEntityRecord,
 		invalidateResolution,
 		queryArgs,
 		createNotice,


### PR DESCRIPTION
## Summary

Fixes #104. The `core:posts` `trash` dataView variant declared `restore` and `delete-permanent` actions in `app.json`, but `src/apps/posts/index.js` wired **no callbacks** for them — so both were inert — and no bundled screen surfaced the trash variant, so they never even rendered.

This PR wires the callbacks and adds a reachable Trash view.

## Changes

- **`src/apps/posts/index.js`**
  - `restore` callback — `saveEntityRecord('postType', postType, { id, status: 'draft' })` over the selected rows via `Promise.allSettled`, with success / partial-failure snackbars and a list + status-count refresh.
  - `delete-permanent` — a `createBulkConfirmModal` (matching the trash flow) that runs `deleteEntityRecord(..., { force: true })` after confirmation.
  - Extracted the shared post-mutation `refreshAfterMutation()` (list query + per-status counts invalidation) so trash / delete / restore all reuse it.
  - Added `restore` + `delete-permanent` to `ACTION_LABELS` so they're translated.
- **`shells/wp-admin-default.json`** — a `posts-trash` screen (`dataViewRef: postType/post/trash`, status-scoped) + a Posts → Trash menu item, so the variant (and its actions) are reachable.
- **Docs** — updated `app.json#documentation` (writes + interactions) and `app.md` known-limitations to reflect the now-wired flow.

## Restore-to-draft caveat

Classic wp-admin restores a trashed post to its pre-trash status (`_wp_trash_meta_status`). REST exposes no such meta, so restore lands on **draft** — an accepted divergence documented in `docs/parity/posts.md` (blocker #4) and noted inline + in `app.md`.

## Testing

- `npm run lint:js` (posts app) — clean
- `npm run test:schema` — PASS 56 / FAIL 0 (validates the updated shell + app.json)
- `npm run test:runtime` — PASS 25 / FAIL 0

PHP shape tests (unique paths, valid primary app) require wp-env, unavailable in this environment; the new `/posts/trash` path is unique and `core:posts` is a valid primary app.

https://claude.ai/code/session_01A2x21zWi595eAeECEvqp2p

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2x21zWi595eAeECEvqp2p)_