### PR TITLE
fix(tools): route landing cards through navigate() to in-shell screens

### DIFF
--- a/src/apps/tools/app.json
+++ b/src/apps/tools/app.json
@@ -24,20 +24,18 @@
 		"icon": "tool"
 	},
 	"documentation": {
-		"purpose": "Landing screen for the Tools navigation entry. Renders a 2-column grid of cards, one per available tool. Each card opens either a sibling shell app (Site Health → `#/site-health`) or a wp-admin page (Import, Export, Export Personal Data, Erase Personal Data — all four still link out to `import.php`, `export.php`, etc. because the wp-admin equivalents have no REST surface and no v2 native equivalent yet).",
+		"purpose": "Landing screen for the Tools navigation entry. Renders a 2-column grid of cards, one per available tool. Each card navigates in-shell (via the router) to the tool's screen: Site Health is a native v2 app, while Import, Export, Export Personal Data, and Erase Personal Data resolve to `iframe:` screens in the default shell (those wp-admin equivalents have no REST surface and no native v2 app yet, so they render the classic screen inside the workspace chrome).",
 		"rebuilds": "tools",
 		"data": {
-			"reads": [
-				{
-					"source": "window.wpAdminShell.adminUrl",
-					"via": "window-global",
-					"purpose": "Base URL for legacy wp-admin links."
-				}
-			]
+			"reads": []
 		},
 		"url": {
 			"navigates": [
-				"#/site-health"
+				"#/tools/site-health",
+				"#/tools/import",
+				"#/tools/export",
+				"#/tools/export-personal-data",
+				"#/tools/erase-personal-data"
 			]
 		},
 		"states": [
@@ -49,12 +47,8 @@
 		],
 		"interactions": [
 			{
-				"trigger": "Click Open on a tool card with `appId`",
-				"effect": "`navigate('site-health')` (or whichever tool's app id)."
-			},
-			{
-				"trigger": "Click Open on a tool card with `legacy`",
-				"effect": "`window.location.href = adminUrl + tool.legacy` — leaves the shell into wp-admin."
+				"trigger": "Click Open on a tool card",
+				"effect": "`navigate(tool.path)` — in-shell router navigation to the tool's screen path (e.g. `/tools/import`). Never leaves the workspace."
 			}
 		],
 		"a11y": {
@@ -62,8 +56,12 @@
 		},
 		"constraints": [
 			{
-				"concern": "legacy-link-fallback",
-				"note": "Import / Export / Personal Data Export / Personal Data Erase have no REST coverage and no native v2 app yet. Their cards navigate out to wp-admin and lose the user's place in the shell."
+				"concern": "iframe-screen-fallback",
+				"note": "Import / Export / Personal Data Export / Personal Data Erase have no REST coverage and no native v2 app yet. Their cards navigate in-shell to `iframe:` screens that render the classic wp-admin page inside the workspace chrome."
+			},
+			{
+				"concern": "default-shell-coupling",
+				"note": "Card `path` values assume the default shell's `/tools/*` screen layout. A shell that remounts `core:tools` without those screens would navigate to dead routes."
 			},
 			{
 				"concern": "static-tool-list",

--- a/src/apps/tools/app.md
+++ b/src/apps/tools/app.md
@@ -4,21 +4,21 @@ Prose accompanying `app.json#documentation` for the tools landing.
 
 ## Overview
 
-ToolsApp is a card grid of links. Five tools today: Site Health (native v2 app), Import, Export, Export Personal Data, Erase Personal Data (four legacy wp-admin links). Each card has a title, a sentence-long description, and an Open button that either navigates to a sibling shell app or hard-navigates to wp-admin's classic page.
+ToolsApp is a card grid of links. Five tools today: Site Health (native v2 app), Import, Export, Export Personal Data, Erase Personal Data (four classic wp-admin screens). Each card has a title, a sentence-long description, and an Open button that navigates — in-shell, via the router — to the tool's screen. Site Health is a native sibling app; the four classic tools are wrapped as `iframe:` screens in the default shell, so they open inside the workspace chrome rather than reloading out to raw wp-admin.
 
 This is the simplest fully-static app in the shell — no data fetching, no state machine, no async. It exists to give the Tools navigation entry a landing screen instead of a 404.
 
 ## Architecture
 
-The `TOOLS` array is module-scope. Each entry has `{ id, title, description, appId | legacy }`. The card click handler branches: `appId` → `navigate(tool.appId)`, `legacy` → `window.location.href = adminUrl(tool.legacy)`.
+The `TOOLS` array is module-scope. Each entry has `{ id, title, description, path }`, where `path` is the destination screen's admin.json `path` (e.g. `/tools/import`). The card click handler is uniform: `navigate(tool.path)`. Navigation is always in-shell — the kernel resolves the path to the matching route (a native app or an `iframe:` screen), so no card ever leaves the workspace via `window.location`. `path` must match the resolved route exactly: it is the screen `path`, not the bare screen id, because `navigate()` operates on URL paths.
 
 ## Rebuild guide
 
-Trivial port. Card + grid + button primitives are universal; the only project-specific bit is the URL resolution helper for legacy links. Reuse your host's link primitive (React Router `Link`, Next `Link`) instead of `window.location.href` where the navigation is internal — `legacy` links cross out of the shell so plain `<a>` or `window.location.href` is correct.
+Trivial port. Card + grid + button primitives are universal. Keep every Open action on the host's in-app navigation primitive (React Router `Link`, Next `Link`, or a `navigate()` equivalent) — there are no cross-shell links here, so plain `window.location.href` is never appropriate.
 
 ## Known limitations
 
 - **Plugins can't inject tools.** WordPress core has hooks like `update_management_pages` for plugins to add tool entries; the shell doesn't honor any.
-- **Legacy links lose place.** Clicking Import / Export navigates fully out of the shell. The user has to find their way back via browser back or the toolbar.
+- **Tool paths are coupled to the default shell.** Each card's `path` assumes the default shell's `/tools/*` screen layout. A shell that remounts `core:tools` without those screens would navigate to dead routes (falling back to the default route).
 - **No description-action distinction.** Cards have title + description + Open button; no row-action menu or secondary action.
 - **Hard-coded tool list.** Adding a new tool requires editing this file. A `wp_admin_shell_register_tool` filter would be the natural extension.

--- a/src/apps/tools/index.js
+++ b/src/apps/tools/index.js
@@ -5,6 +5,13 @@ import { __experimentalGrid as Grid } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { navigate } from '../../runtime/routing/router';
 
+// Each card routes to its in-shell screen via the router (`navigate`),
+// keeping the user inside the workspace chrome. `path` is the screen's
+// `path` in admin.json (the route key the kernel synthesizes), NOT a bare
+// screen id — `navigate()` operates on URL paths, so it must match the
+// resolved route exactly. The default shell wraps the legacy
+// import/export/personal-data tools in `iframe:` screens at these paths;
+// Site Health is a native sibling app on the same `/tools/*` prefix.
 const TOOLS = [
 	{
 		id: 'site-health',
@@ -13,7 +20,7 @@ const TOOLS = [
 			'Check that your site is running on the latest WordPress and that key services are reachable.',
 			'wp-admin-shell'
 		),
-		appId: 'site-health',
+		path: '/tools/site-health',
 	},
 	{
 		id: 'import',
@@ -22,7 +29,7 @@ const TOOLS = [
 			'Pull content into this site from another WordPress install or a third-party platform.',
 			'wp-admin-shell'
 		),
-		legacy: 'import.php',
+		path: '/tools/import',
 	},
 	{
 		id: 'export',
@@ -31,7 +38,7 @@ const TOOLS = [
 			'Download an XML archive of posts, pages, comments, custom fields, terms, and authors.',
 			'wp-admin-shell'
 		),
-		legacy: 'export.php',
+		path: '/tools/export',
 	},
 	{
 		id: 'export-personal-data',
@@ -40,7 +47,7 @@ const TOOLS = [
 			'Generate a privacy-compliant export of a user’s personal data on request.',
 			'wp-admin-shell'
 		),
-		legacy: 'export-personal-data.php',
+		path: '/tools/export-personal-data',
 	},
 	{
 		id: 'erase-personal-data',
@@ -49,14 +56,9 @@ const TOOLS = [
 			'Delete a user’s personal data on request.',
 			'wp-admin-shell'
 		),
-		legacy: 'erase-personal-data.php',
+		path: '/tools/erase-personal-data',
 	},
 ];
-
-function adminUrl( legacy ) {
-	const base = window.wpAdminShell?.adminUrl || '/wp-admin/';
-	return base + legacy;
-}
 
 export default function ToolsApp() {
 	return (
@@ -68,7 +70,7 @@ export default function ToolsApp() {
 					</Text>
 					<Text variant="body-md">
 						{ __(
-							'Routine maintenance tasks. Some still link out to the legacy WordPress screens.',
+							'Routine maintenance tasks. Each opens inside the workspace; some are presented as the classic WordPress screen.',
 							'wp-admin-shell'
 						) }
 					</Text>
@@ -92,28 +94,13 @@ export default function ToolsApp() {
 									<Text variant="body-sm">
 										{ tool.description }
 									</Text>
-									{ tool.appId ? (
-										<Button
-											tone="neutral"
-											variant="outline"
-											onClick={ () =>
-												navigate( tool.appId )
-											}
-										>
-											{ __( 'Open', 'wp-admin-shell' ) }
-										</Button>
-									) : (
-										<Button
-											tone="neutral"
-											variant="outline"
-											onClick={ () =>
-												( window.location.href =
-													adminUrl( tool.legacy ) )
-											}
-										>
-											{ __( 'Open', 'wp-admin-shell' ) }
-										</Button>
-									) }
+									<Button
+										tone="neutral"
+										variant="outline"
+										onClick={ () => navigate( tool.path ) }
+									>
+										{ __( 'Open', 'wp-admin-shell' ) }
+									</Button>
 								</Stack>
 							</Card.Content>
 						</Card.Root>


### PR DESCRIPTION
## Summary

Fixes #138. The `core:tools` landing cards hard-navigated **out of the workspace** via `window.location.href`, even though `wp-admin-default.json` already defines in-shell iframe screens at `/tools/import`, `/tools/export`, etc. The same destination behaved two different ways depending on entry point:

- **Left-nav menu item** → in-shell iframe (kept the workspace chrome)
- **Landing card** → full browser reload out to raw `/wp-admin/import.php`

Every card now routes through `navigate(tool.path)` to its in-shell screen path.

## What changed

- **`src/apps/tools/index.js`** — `TOOLS` entries now carry a `path` (the screen's admin.json `path`, e.g. `/tools/import`) instead of `appId` / `legacy`. The card handler is uniform: `navigate(tool.path)`. Dropped the now-unused `adminUrl()` helper and the `window.wpAdminShell.adminUrl` read. Intro copy updated.
- **`src/apps/tools/app.md` / `app.json`** — documentation block updated to match (in-shell navigation, `iframe:`-screen fallback, default-shell path coupling).

## Why `path`, not a bare screen id

`navigate()` operates on **URL paths**, not screen ids — it just sets `location.hash`, which the kernel matches against routes synthesized from each screen's `path`. So a card must navigate to `/tools/import`, not `import`.

This also surfaced a pre-existing bug: the **Site Health** card called `navigate('site-health')` → `#/site-health`, but that screen lives at `/tools/site-health`, so it never matched a route (it fell through to the default route). Now fixed alongside the legacy cards.

## Rule compliance

Removes a CLAUDE-rule violation — *"Workspace links never bypass the admin-link interceptor"* / *"never `window.location.assign('/wp-admin/...')`"*. All Open actions are now in-shell router navigation.

## Testing

- `npx eslint src/apps/tools/index.js` — clean
- `npm run test:schema` — PASS: 56, FAIL: 0 (covers the edited `app.json`)

Source: `docs/parity/tools.md` (functional divergence #1, recommendation P1); roadmap group A / P3 / item 42; parity audit PR #96.

https://claude.ai/code/session_01MCPMPNDFjLpAHEoZLR2qk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCPMPNDFjLpAHEoZLR2qk4)_