### PR TITLE
ci(claude-review): post findings as a formal review, never a silent pass

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,16 +32,40 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          # Run the code-review skill at MAX effort and post findings inline.
-          # This is a WordPress plugin: the repo ships WordPress skills under
-          # .claude/skills/ — load whichever are relevant to the changed files
-          # so the review reflects WordPress + project conventions.
+          # Run the code-review skill at MAX effort and post findings as a
+          # single FORMAL pull request review with inline comments — never a
+          # silent pass. This is a WordPress plugin: the repo ships WordPress
+          # skills under .claude/skills/ — load whichever are relevant to the
+          # changed files so the review reflects WordPress + project conventions.
           prompt: |
             Review this pull request: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
-            Run the `/code-review:code-review` skill at **max** effort, and post
-            the findings as inline PR comments (use the skill's `--comment`
-            behavior) plus a summary comment.
+            Run the `/code-review:code-review` skill at **max** effort. Then
+            publish ALL findings as a SINGLE formal GitHub pull request review
+            (a real review object with inline threads), NOT as one aggregated
+            issue comment:
+
+            - Anchor each finding to its exact file and line as an **inline
+              review comment**. Surface everything — include low-severity nits
+              and style/cleanup notes as inline comments too; do not silently
+              drop the small stuff.
+            - Put a **ranked summary + overall verdict** in the review body
+              (findings ordered by severity, plus a one-line bottom line).
+            - **Always submit the review, even when the code is clean.** A
+              passing review must be explicit: if there are no findings, submit
+              a review whose body is an explicit `LGTM ✅` so an approval is
+              never silent.
+            - Submit the review with the **`COMMENT` event** (NOT `APPROVE` /
+              `REQUEST_CHANGES`). The action authenticates as the repo owner and
+              these PRs are owner-authored — GitHub rejects approving or
+              requesting changes on your own PR, so `COMMENT` is the only event
+              that reliably lands. Carry the accept/reject verdict in the body
+              text instead.
+
+            Use the GitHub pull request **review** API (e.g. `gh pr review` /
+            the reviews endpoint: create the review, attach inline comments,
+            submit once) so this lands as a formal review with inline threads
+            rather than a standalone issue comment.
 
             This repository is a WordPress plugin. Before and during the review,
             load whichever WordPress skills shipped in this repo's


### PR DESCRIPTION
## Why

The label-gated Claude review was coming back **green with no output** on several PRs (#190, #195, #200 all ran `success` but posted zero comments/reviews), and even when it did post (#180), findings landed as a **single aggregated issue comment** authored by the OAuth-token identity — `get_reviews` / `get_review_comments` stayed empty across every PR checked. So a passing check didn't guarantee a review happened, and inline/formal review threads never landed.

## What changed

Rewrites the `prompt:` in `.github/workflows/claude-code-review.yml` so the review:

- **Lands as one formal PR review with inline threads** (reviews API / `gh pr review`), anchored to exact file + line — not a standalone issue comment.
- **Surfaces low-level issues too** — nits / style / cleanup notes are required as inline comments, not dropped.
- **Is never silent** — always submits a review; a clean pass posts an explicit `LGTM ✅` in the body so an approval is visible rather than a green check with no output.
- **Submits with the `COMMENT` event** (not `APPROVE` / `REQUEST_CHANGES`). The action authenticates as the repo owner and these PRs are owner-authored; GitHub rejects self-approval / self-request-changes, so `COMMENT` is the only event that reliably lands. The accept/reject verdict rides in the body text.

## Verifying

This PR carries the `claude-review` label so it exercises the new behavior on itself — expect a formal review with inline comments (or an explicit `LGTM ✅` if clean), not a silent green.

## Not verified here

Couldn't pull the raw Actions logs for the prior silent runs (no workflow-logs tool / `gh` CLI in the session), so if those were failing in a posting step rather than posting to the wrong surface, a second issue may remain (e.g. the `claude[bot]` GitHub App that errored on #180). This PR's own run is the live test.

https://claude.ai/code/session_01EsueRx6QjyYipPVZgnCz7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsueRx6QjyYipPVZgnCz7A)_