### PR TITLE
ci(claude-review): pin Opus, remove the 60-turn cap

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,6 +30,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Pin Opus for this label-gated, max-effort review — the heavy
+          # multi-finder/verifier pass wants the strongest model.
+          model: 'claude-opus-4-8'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           # Run the code-review skill at MAX effort and post findings as a
@@ -77,5 +80,6 @@ jobs:
             authoring skills — so the review applies WordPress core, REST,
             DataViews/DataForm, and this project's conventions (see CLAUDE.md
             and docs/). Skip skills unrelated to the diff.
-          # Allow the skill's finder/verifier sub-agents and the gh CLI it uses.
-          claude_args: '--max-turns 60'
+          # No --max-turns cap: a max-effort review with finder/verifier
+          # sub-agents was hitting the 60-turn limit and getting cut off
+          # mid-review on larger PRs. Let it run to completion.


### PR DESCRIPTION
## What

Follow-up to #203. Two tuning changes to the label-gated Claude review:

- **Pin Opus** (`model: claude-opus-4-8`). The workflow previously ran on the action's default Sonnet; this max-effort, multi-finder/verifier review wants the strongest model. ("Max effort" tunes the *skill's* thoroughness, not the model — these are independent knobs.)
- **Remove `--max-turns 60`.** The multi-agent review was hitting the 60-turn cap and getting cut off mid-review on larger PRs — a likely contributor to incomplete/silent runs. Removing the cap lets it run to completion.

## Note

Dropping the flag lets the action fall back to its default turn budget rather than an explicit ceiling. If you'd rather keep a (higher) safety cap than no cap, say so and I'll set e.g. `--max-turns 200` instead.

https://claude.ai/code/session_01EsueRx6QjyYipPVZgnCz7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsueRx6QjyYipPVZgnCz7A)_