### PR TITLE
docs: add DataViews interaction patterns guide

### DIFF
--- a/docs/dataviews-interaction-patterns.md
+++ b/docs/dataviews-interaction-patterns.md
@@ -1,0 +1,181 @@
+# DataViews Interaction Patterns
+
+How the shell re-expresses classic wp-admin's **inline list-table flows** (Quick Edit, inline Reply, Bulk Edit, row pickers, status links) as a small set of **shared, reusable patterns** that every DataViews-backed app builds against — instead of each app rolling its own.
+
+> **Read this before building or reviewing any `area:dataviews` app.** The goal is one set of components and two contracts, not twelve bespoke modals. Tracking + the net-new shared work: see the umbrella issue referenced at the bottom.
+
+WordPress DataViews has **no in-list editing or row-expansion primitive** — `Field.Edit`-in-cell (#162) and the expandable detail-row API (#169) are both `blocked:upstream`. So the inline affordances classic wp-admin renders *in the row* are, in the shell, **substituted** by modals / screens. When the upstream primitives land we swap the **host**, not the logic — which is exactly what the two contracts below buy us.
+
+---
+
+## The two contracts
+
+Every host pattern here obeys these. They are what make a flow portable across a modal, a side-pane/inspector, and a full screen without a rewrite.
+
+### 1. Presentation-agnostic units
+
+A flow (Edit / Create / Detail / Bulk) is a **unit** that owns:
+
+- its **entity binding** — `useEntityRecord` / `useEntityRecords` with a **buffered `edit()`** exposing `save()` / `hasEdits` (never a hand-rolled `useState` mirror of server fields);
+- its **fields** (via `@wordpress/dataviews` `DataForm`) and any **sub-slots** (e.g. a media preview / image-editor slot);
+- **injectable actions** (Save, Cancel, Delete) — supplied or styled by the host.
+
+The unit **does not own its chrome.** The host decides whether it lives in a modal, a region, or a screen.
+
+### 2. The host chooses the commit strategy
+
+| Host | Commit |
+|---|---|
+| Modal | **Explicit Save** (Save/Cancel footer) |
+| Side-pane / inspector | **Autosave** on change (debounce / blur) |
+| Full screen (editor-backed) | the editor's own save model |
+
+Same field set, same validation — only the commit wiring differs. A unit exposes `save()` + `hasEdits` so a modal host renders a Save button; a pane host autosaves and ignores it. (Comments-edit is explicit-save in a modal; Media metadata autosaves — both correct, same unit shape.)
+
+### Action → Host routing rule
+
+Every app's `edit`/`create` action must choose a host. The rule:
+
+| Situation | Host pattern |
+|---|---|
+| Small entity (comment, term, user, media item) — edit | **Modal Edit** (quick edit == full edit) |
+| Small entity — create | **Modal Create** |
+| Editor-backed entity (post, page) — quick edit | **Modal Edit** (metadata subset) |
+| Editor-backed entity — full edit | **Navigate to the editor screen** |
+| Apply fields to many selected rows | **Bulk Edit** |
+| Destructive / irreversible | **Bulk Confirm** |
+
+**Quick Edit and full Edit collapse into one surface for small entities** — once it's a modal, "quick" has no speed advantage, so expose the whole field set in one Modal Edit. Only editor-backed entities keep the quick-vs-full split (modal vs screen).
+
+---
+
+## Pattern catalog
+
+### Host patterns — where a flow renders
+
+#### Modal Edit
+- **Intent:** edit one small entity's full field set. Substitutes classic Quick Edit **and** the single-record Edit screen.
+- **Host / commit:** modal, explicit Save.
+- **Shared:** `EntityFormModal` (a `RenderModal` action hosting `DataForm` + `useEntitySave`) — *net-new; promote from the taxonomy term modal.*
+- **Consumers:** #114 (comments), taxonomy terms, users edit, #109 (media metadata, but autosaving — same unit, pane-style commit).
+- **Substitutes:** #162.
+
+#### Modal Create
+- **Intent:** create a related entity inline. Classic inline Reply / "Add New".
+- **Host / commit:** modal, explicit submit (blocking when the new id is needed).
+- **Shared:** `EntityFormModal` in create mode (no id → POST).
+- **Consumers:** #114 (comment Reply — content-only, parent/post implicit), #122 (Add New User), add-term. Content-minimal by default, **expandable** to richer create-with-meta (see Upload / Ingest).
+
+#### Navigate-to-edit
+- **Intent:** editor-backed entities open their editor screen rather than a modal.
+- **Host / commit:** route navigation; the editor owns save.
+- **Shared:** an `editHref(item)` / route-resolution helper + the Action→Host rule above.
+- **Consumers:** posts/pages (`#107` defines the quick-vs-full boundary).
+
+#### Bulk Edit
+- **Intent:** apply a chosen subset of fields to M selected rows, with a per-field **"— No change —"** sentinel.
+- **Host / commit:** modal, explicit Apply; `Promise.allSettled` over the selection with partial-failure reporting.
+- **Shared:** `BulkEditModal` — *net-new.* `#110` (Users "Change role") is the degenerate single-field case and should consume the same component.
+- **Consumers:** #107 (posts), #110 (users).
+- **Substitutes:** #165 (upstream bulk-edit-form), #162.
+
+#### Bulk Confirm (± embedded sub-form)
+- **Intent:** destructive / irreversible bulk action; sometimes carries a small form (e.g. **reassign target** on user delete).
+- **Host / commit:** modal, confirm; `Promise.allSettled`; self-safe filtering (users skip the acting user).
+- **Shared:** `createBulkConfirmModal` — **exists.** Extend to host an optional sub-form for the reassign case.
+- **Consumers:** trash / delete-permanent / empty-spam-trash (comments, posts), bulk user delete (#22 reassign).
+
+#### Detail / read-only inspect
+- **Intent:** read-only inspection of one row.
+- **Host / commit:** modal (or future pane), no commit.
+- **Shared:** the same presentation-agnostic unit as Modal Edit, in read-only mode.
+- **Consumers:** themes `details` (precedent), comment full content, media detail.
+- **Substitutes:** #169.
+
+#### Upload / Ingest (Create whose *source is a file*)
+- **Intent:** create entities from a file selection, optionally collecting meta in the same flow.
+- **Host / commit:** header/toolbar trigger → optional meta modal; multipart `apiFetch` + per-file `try/catch` error notices; cache-invalidate only when ≥1 succeeds.
+- **Shared:** an upload trigger + a Modal-Create variant whose initial data comes from the file(s); future drag-and-drop zone.
+- **Consumers:** #109 (media — today a bare system dialog; the natural place to grow into create-with-meta), plugin/theme ZIP upload, import.
+
+### Field / control patterns — reused *inside* forms and cells
+
+#### Relational / hierarchical / async picker
+- **Intent:** pick a related entity: parent term (tree), reassign user, featured media, post parent, "in response to".
+- **Shared:** an async/hierarchical select control usable as a `DataForm` field type; a media-library picker control.
+- **Consumers:** #115 (category parent tree), #170 (media picker), users reassign.
+
+#### Cell-renderer library
+- **Intent:** common column renderers shared across apps.
+- **Shared:** `buildFields` renderers map (**exists**) extended with: avatar + name, status badge, relative date, media thumbnail, mime-type tile.
+- **Consumers:** #112 (Comments Author column, Users username cell), #109 (media field tile).
+
+### List-surface patterns
+
+#### Declarative view → REST `queryArgs` mapper
+- **Intent:** translate the DataViews `view` (search / filters / sort / paging) into REST query args, declaratively, instead of a hand-rolled mapper per app.
+- **Shared:** `buildQueryArgs(view, mapping)` — *net-new* (today each app hand-rolls it).
+- **Consumers:** #132 (date / category / format / author filters on Posts + Media), every list app.
+
+#### Pinned view tabs / segment strip with counts
+- **Intent:** the classic `All | Mine | Pending | …` subsubsub strip with live counts and an active state.
+- **Shared:** a `ViewTabs` component fed by `useEntityElementCounts`. Pinned segments may **lock** the underlying status filter (see #209).
+- **Consumers:** #111 (posts/comments status + Mine + Sticky), #163 (count slot).
+- **Substitutes:** #163.
+
+#### Action mutation (status flip, no form)
+- **Intent:** one-click row/bulk status changes — approve / unapprove / spam / trash / restore / (de)activate.
+- **Shared:** `buildActions` callbacks + partial-PATCH via `saveEntityRecord` — **exists.**
+- **Consumers:** #113 (comments status verbs) extends the set; posts trash; themes/plugins activation.
+
+---
+
+## Shared-module map
+
+| Module | Status | Patterns |
+|---|---|---|
+| `_shared/forms/EntityDataForm.js` | exists (explicit-save wrapper) | Modal Edit/Create (modal flavor) |
+| `_shared/forms/useEntitySave.js` | exists | commit core |
+| `_shared/forms/useEntityAutosave` | **net-new** (promote when #109 / #119 need it) | pane/inspector commit |
+| `_shared/dataviews/createBulkConfirmModal.js` | exists | Bulk Confirm |
+| `_shared/dataviews/buildActions.js` | exists | Action mutation, action→host wiring |
+| `_shared/dataviews/buildFields.mjs` (+ renderers) | exists (extend) | Cell-renderer library |
+| `_shared/dataviews/useEntityDataView.js` | exists | view state |
+| `_shared/dataviews/useEntityElementCounts` | exists | counts for ViewTabs / filter labels |
+| `_shared/dataviews/EntityFormModal` | **net-new** | Modal Edit, Modal Create |
+| `_shared/dataviews/BulkEditModal` | **net-new** | Bulk Edit |
+| `_shared/dataviews/ViewTabs` | **net-new** | Pinned view tabs |
+| `_shared/dataviews/buildQueryArgs` | **net-new** | view→REST mapper |
+| `_shared/dataviews/pickers/*` | **net-new** | Relational/hierarchical/async pickers |
+| `editHref` / Action→Host helper | partly exists (PostsApp) → codify | Navigate-to-edit |
+
+**Kernel boundary:** all of the above live in **app space** (`src/apps/_shared/*`), never `src/runtime/*` — they import `@wordpress/dataviews` / `@wordpress/components` / WPDS, which the kernel must stay free of (see `CLAUDE.md` → "Kernel is DS-neutral").
+
+**Cascade caution:** any app shipping a new dataView family (e.g. `root/media/_default`) must declare its `defaultView` (incl. `mediaField` / `titleField`) **completely** — a shell that redeclares the triple wins outright and a partial copy silently drops baseline keys (`CLAUDE.md` → "A shell that redeclares a `settings.dataViews` triple wins OUTRIGHT").
+
+---
+
+## Upstream substitution table
+
+When these land in `@wordpress/dataviews`, swap the **host**, keep the unit:
+
+| Upstream issue | Shell substitute today |
+|---|---|
+| #162 editable-cell / inline-edit | Modal Edit + Bulk Edit |
+| #169 expandable detail-row | Detail / inspect modal |
+| #163 native count slot / tab-strip | `ViewTabs` |
+| #165 bulk-edit-form primitive | `BulkEditModal` |
+| #170 media-library-picker control | picker control |
+
+---
+
+## Build order
+
+Build (or stub) the **net-new shared components before the per-app lanes consume them**, so apps share one implementation instead of forking:
+
+1. `EntityFormModal` (Modal Edit + Create) — unblocks #114, #122, taxonomy, #109.
+2. `BulkEditModal` — unblocks #107, #110.
+3. `buildQueryArgs` + `ViewTabs` — unblock #132, #111.
+4. Pickers + renderer-library extensions — unblock #115, #112, #170.
+
+Per-app issues should **consume** these and contribute entity-specific bits only (field defs, REST mapping, renderers). Scheduling lives in the umbrella tracking issue.

--- a/docs/no-api-fallback-pattern.md
+++ b/docs/no-api-fallback-pattern.md
@@ -1,0 +1,75 @@
+# No-API Fallback Pattern
+
+When a wp-admin capability has **no REST surface**, the shell must not dead-end or silently drop the control. It offers a **consistent, tiered fallback** so the user — or their agent — can still complete the action. This is the companion to the `iframe:` escape hatch: a deliberate feature, not a compromise.
+
+> Use this anywhere the workspace can't write something through `/wp/v2/*` or `/wp-admin-shell/v1/*`. A large share of the parity backlog is `[upstream]`/no-REST (session destroy, admin password reset, confirmation flows, page-attribute templates, legacy options); they should all be handled **identically** via this pattern.
+
+---
+
+## Shim, or fall back?
+
+Decide per capability:
+
+| | Treatment |
+|---|---|
+| Common + safe + belongs in the workspace UX | **Shim it first-class** (e.g. `register_setting( show_in_rest )` for standard settings — see #202/#118). Inline editing is the point. |
+| Legacy, rare, risky, or genuinely not REST-able | **No-API fallback** (this pattern). |
+
+Don't make a user drop to the CLI to toggle a common setting; don't build a fragile shim for a legacy or sensitive one (e.g. we deliberately keep `mailserver_pass` out of REST). The fallback is the consistent treatment for the **long tail**, not a replacement for first-class surfaces.
+
+---
+
+## Why REST-absent ≠ unreachable
+
+Every option lives in `wp_options`; most no-REST actions have a CLI / PHP path. Reachability tiers, by how many users can use them:
+
+1. **Classic screen (universal).** The legacy wp-admin screen, reached through the shell's existing `legacy_path` / classic-mode routing. Needs **no** agent or CLI — works for every admin. Always the base tier.
+2. **WP-CLI (scriptable).** `wp option update <name> '<value>'` — calls `update_option()` under the hood, so it runs `sanitize_option`, fires `update_option_{$name}` hooks, and handles autoload + object cache. Works for **any** option regardless of `show_in_rest`. (This product's dev/wp-env contexts ship WP-CLI.)
+3. **Agent (agentic).** A ready-to-paste instruction the user hands to their coding agent (the context this product targets), e.g. *"Set the WordPress option `comment_moderation` to `1` using `wp option update`."*
+
+### Guardrails (non-negotiable)
+
+- **Always `wp option update` / `update_option`, never raw SQL.** `UPDATE wp_options …` bypasses `sanitize_option`, the update hooks, and cache invalidation (it can desync the `alloptions` cache and store an unsanitized value). The pattern must never emit SQL.
+- **The agent tier is advisory.** It generates an instruction the user *chooses* to run — it never auto-executes.
+- **Tier 1 is the floor.** WP-CLI availability varies (dev/wp-env: yes; some production: no), so the classic-screen link is always offered as the universally-available path.
+
+---
+
+## The component
+
+A single shared component renders all three tiers and degrades gracefully.
+
+**Home:** `src/apps/_shared/fallback/UnavailableViaApi.js` — deliberately **global** app-space (not under `_shared/forms` or `_shared/dataviews`), because it serves settings *and* non-settings gaps. It renders WPDS, so it lives in **app space, never `src/runtime/*`** (the kernel stays DS-neutral — see `CLAUDE.md`). The classic link rides the existing capture-phase admin-link interceptor / `legacy_path` routing, so no new navigation surface is needed.
+
+Two shapes:
+
+```jsx
+// Option flavor — pre-fills the value the user just entered, so they don't retype.
+<UnavailableViaApi
+    kind="option"
+    name="comment_moderation"
+    value={ enteredValue }
+    classicPath="options-discussion.php"
+/>
+
+// Action flavor — non-option capabilities (session destroy, password reset, …).
+<UnavailableViaApi
+    kind="action"
+    command="wp user session destroy 42"
+    agentPrompt="Destroy all login sessions for user 42 using wp-cli."
+    classicPath="users.php"
+/>
+```
+
+Renders: a short "this isn't writable through the workspace API" explanation → the **entered value** (option flavor) → **classic-screen link** (tier 1) → **copy-paste `wp option update` / command** (tier 2) → **agent prompt** (tier 3). WPDS throughout (`@wordpress/ui` / `@wordpress/components`).
+
+---
+
+## Consumers
+
+- **#118** — the legacy Writing options (`mailserver_*`, `ping_sites`, `default_link_category`, `use_balanceTags`) get the fallback affordance instead of silently vanishing. First consumer.
+- **`[upstream]` no-REST gaps** — session destroy (#144), admin-initiated password reset, confirmation flows (#160), page-attribute templates, and the rest of the `[upstream]` backlog.
+
+## Boundary
+
+App-space shared, DS-specific. The kernel never learns about this. The classic link uses the existing `legacy_path` / admin-link-interceptor path; the CLI/agent tiers are static, copy-only affordances with no privileged execution from the shell itself.

--- a/docs/runtime-harvest-pattern.md
+++ b/docs/runtime-harvest-pattern.md
@@ -1,0 +1,47 @@
+# Runtime-Harvest Pattern
+
+Several WordPress extension surfaces have **no clean REST representation** — they're PHP runtime structures that core + plugins populate at request time:
+
+- the **admin menu** (`$GLOBALS['menu']` / `$GLOBALS['submenu']`),
+- the **admin bar** (`WP_Admin_Bar` nodes),
+- **admin notices** (`do_action('admin_notices')` output).
+
+The shell **harvests** these server-side and folds them into the resolved admin.json doc, so un-ported third-party plugins still surface in the workspace (menu entries, toolbar nodes, notices) without anyone writing shell config. This is the server-side sibling of the [no-API fallback](./no-api-fallback-pattern.md): when there's no REST surface to *read* a runtime registry, harvest it in PHP.
+
+---
+
+## The convention
+
+A harvest is a **`wp_admin_shell_data_plugin` pass at priority ~6** (after the merge, alongside the existing menu bridge + dataView baselines). Each pass:
+
+1. **Skip-lists the core entries the shell already ships first-class** — so we never double-render Posts/Settings (menu), site-name/my-account/+New (admin bar), etc.
+2. **Ingests the remainder** and synthesizes shell data under a named, extensible container.
+3. **Exposes a filter on its skip-list** (e.g. `wp_admin_shell_classic_menu_core_slugs`) so a shell that mirrors more surfaces natively can extend what's skipped.
+
+Harvest passes are **PHP** (`includes/cascade/`); they emit *data*. The kernel never learns about them — rendering happens app/engine-side.
+
+---
+
+## Instances
+
+1. **Menu bridge** — *exists* (`WP_Admin_Shell_Classic_Menu_Bridge`). Walks `$GLOBALS['menu']`/`$GLOBALS['submenu']`, skips core parent slugs, synthesizes `screens[ingested-<slug>]` + `menu.ingested.items[]`. **#127** extends it: carry the numeric `position`, nest core-parented plugin submenus under the real shell parent (Settings/Tools) instead of the generic `ingested` bucket, and harvest menu icons.
+2. **Admin-bar bridge** — *new (#128)*. Instantiate `WP_Admin_Bar`, run `do_action('admin_bar_menu', $bar)`, read `$bar->get_nodes()`; skip the core nodes already owned by `site-hub` / `user-menu` / `toolbar-actions` (incl. `+new` — built natively by **#129**); render plugin nodes in the toolbar (submenus → dropdown). Shell-side answer to upstream **#155**.
+3. **Admin-notices buffer** — *new (#128)*. `ob_start` around `do_action('admin_notices')` on the shell's own render pass; feed the captured HTML to `core:notices-banner`.
+
+   **Documented limitation:** the shell is a SPA, but `admin_notices` is a *per-page-render* hook. Only notices that fire on the shell's own page load (global ones) are captured; per-screen notices keyed on `$pagenow` / the current screen **do not fire** and are not surfaced. **Global-only is the accepted interim**; the proper fix is a notices REST surface (upstream **#155**).
+
+---
+
+## Arbitrary-icon escape hatch
+
+Harvested entries carry icons the kernel's **name-based** icon registry (`resolveIcon`) can't resolve — dashicon classes, data-URIs, image URLs (menu icons), and inline HTML (admin-bar node titles). The **engine** nav/toolbar renderers need a pass-through render path (`<img src>` / dashicon class / trusted SVG) that bypasses the name registry. Engine-side (DS-specific) — **never** the kernel registry. One decision, two consumers (#127 menu icons, #128 admin-bar node titles).
+
+---
+
+## Trust
+
+Harvested HTML (notice markup, admin-bar node titles) is **admin-context**, the same trust level at which classic wp-admin renders it. No new exposure; not sanitized beyond what the emitting plugin already does — identical to classic. (The shell only renders it inside the already-`manage_options`/admin-gated workspace.)
+
+## Boundary
+
+Harvest = PHP data emission. Rendering (icons, notice HTML, toolbar nodes) = engine/app space. The kernel stays DS-neutral throughout.


### PR DESCRIPTION
## Summary

Add comprehensive documentation for DataViews interaction patterns — a shared set of reusable UI patterns and components that replace classic wp-admin's inline list-table flows (Quick Edit, inline Reply, Bulk Edit, row pickers, status links) with modal/pane/screen alternatives.

## Key changes

- **Two foundational contracts** that make flows portable across hosts (modal, side-pane, full screen) without rewrites:
  - Presentation-agnostic units that own entity binding and fields but not chrome
  - Host-chosen commit strategies (explicit Save for modals, autosave for panes, editor-owned for full screens)

- **Action → Host routing rule** that collapses Quick Edit and full Edit into one Modal Edit surface for small entities, keeping the split only for editor-backed entities (post/page)

- **Pattern catalog** covering:
  - Host patterns: Modal Edit, Modal Create, Navigate-to-edit, Bulk Edit, Bulk Confirm, Detail/inspect, Upload/Ingest
  - Field/control patterns: relational pickers, cell-renderer library
  - List-surface patterns: declarative view→REST mapper, pinned view tabs, action mutations

- **Shared-module map** documenting which components are net-new (`EntityFormModal`, `BulkEditModal`, `ViewTabs`, `buildQueryArgs`, pickers) vs. existing, with status and consumer apps

- **Upstream substitution table** showing how to swap hosts when `@wordpress/dataviews` primitives (#162, #169, #163, #165, #170) land

- **Build order** prioritizing net-new shared components before per-app consumption to prevent forking

## Implementation notes

- Kernel boundary enforced: all shared patterns live in `src/apps/_shared/*`, never `src/runtime/*`, to keep the kernel design-system-neutral
- Cascade caution documented for apps declaring new dataView families
- Emphasizes that the same presentation-agnostic unit can be hosted in different ways — the contract is what enables portability

https://claude.ai/code/session_011C1dy9mVmw7NhLDZbVgimA