### PR TITLE
fix(settings): read value from correct rest_pre_update_setting arg

### DIFF
--- a/wp-admin-shell.php
+++ b/wp-admin-shell.php
@@ -1156,16 +1156,14 @@ add_action( 'init', function () {
  *
  * @param bool   $updated Whether the setting was already handled by a prior filter.
  * @param string $name    REST setting name being written.
- * @param object $request The REST request.
+ * @param mixed  $value   The incoming setting value (core passes `$request[ $name ]` here).
  * @param array  $args    Registered option args (includes `option_name`).
  * @return bool Whether the setting write was handled here.
  */
-add_filter( 'rest_pre_update_setting', function ( $updated, $name, $request, $args ) {
+add_filter( 'rest_pre_update_setting', function ( $updated, $name, $value, $args ) {
 	if ( $updated || empty( $args['option_name'] ) || 'timezone_string' !== $args['option_name'] ) {
 		return $updated;
 	}
-
-	$value = isset( $request[ $name ] ) ? $request[ $name ] : '';
 
 	if ( is_string( $value ) && preg_match( '/^UTC[+-]/', $value ) ) {
 		// Manual offset: store gmt_offset, clear the zone. With timezone_string


### PR DESCRIPTION
The timezone-offset routing callback named its third parameter $request
and indexed $request[$name] into it, but WordPress core passes the
setting *value* ($request[$name]) as the third argument to the
rest_pre_update_setting filter, not the request object. For a string
value like 'UTC+5', isset($value['timezone']) was false, so the offset
was never written: gmt_offset stayed 0.0 and timezone_string stayed
empty. Use the value argument directly.

Fixes the 5 failing assertions in run-settings-shims-tests.php.