### PR TITLE
feat(plugins): install-by-slug + Add New Plugin header action

### DIFF
--- a/src/apps/plugins/app.json
+++ b/src/apps/plugins/app.json
@@ -110,6 +110,15 @@
 			],
 			"writes": [
 				{
+					"source": "root/plugin",
+					"via": "core-data",
+					"operation": "create",
+					"purpose": "Install-by-slug — `saveEntityRecord( 'root', 'plugin', { slug, status } )` POSTs `/wp/v2/plugins { slug, status }` (status `active` when 'Activate after install' is checked, else `inactive`). Wired via the shared `createEntityFormModal` create mode behind the 'Add New Plugin' header action.",
+					"invalidates": [
+						"root/plugin"
+					]
+				},
+				{
 					"source": "/wp/v2/plugins/{plugin}",
 					"via": "api-fetch",
 					"operation": "partial-update",
@@ -149,6 +158,16 @@
 				"id": "delete-confirm",
 				"when": "User triggered Delete action",
 				"renders": "Confirm modal with destructive primary."
+			},
+			{
+				"id": "install",
+				"when": "User clicked the 'Add New Plugin' header action",
+				"renders": "`@wordpress/components` `Modal` hosting the shared `createEntityFormModal` create-mode body: a `DataForm` with a `slug` text field + an 'Activate after install' boolean, and an Install / Cancel footer."
+			},
+			{
+				"id": "upload-fallback",
+				"when": "User clicked the 'Upload plugin (.zip)' header action",
+				"renders": "`Modal` hosting the shared `UnavailableViaApi` (`kind=\"action\"`) — the documented no-API fallback. Links to classic `plugin-install.php?tab=upload`, a `wp plugin install` WP-CLI command, and an advisory agent prompt."
 			}
 		],
 		"interactions": [
@@ -183,6 +202,17 @@
 			{
 				"trigger": "Change view (search / filter / sort / page)",
 				"effect": "Local `view` updates; client-side filter recomputes (single REST request returns the full list)."
+			},
+			{
+				"trigger": "Click 'Add New Plugin' header action, enter a slug, submit",
+				"effect": "`saveEntityRecord( 'root', 'plugin', { slug, status } )` → `POST /wp/v2/plugins`; success snackbar + invalidate `root/plugin`; modal closes. On failure the modal stays open with an error notice.",
+				"guards": [
+					"slug is required (DataForm `isValid.required`)"
+				]
+			},
+			{
+				"trigger": "Click 'Upload plugin (.zip)' header action",
+				"effect": "Open a modal hosting the `UnavailableViaApi` no-API fallback (classic-screen link + WP-CLI command + agent prompt). No REST surface exists for zip upload."
 			}
 		],
 		"a11y": {
@@ -199,7 +229,11 @@
 			},
 			{
 				"concern": "api-fetch-not-coredata",
-				"note": "Status changes + delete go through `apiFetch` because `core-data`'s `saveEntityRecord` / `deleteEntityRecord` don't have a clean payload shape for the plugin endpoint's `{ status }` PATCH. After mutating, manually `invalidateResolution` on the entity records query."
+				"note": "Status changes + delete go through `apiFetch` because `core-data`'s `saveEntityRecord` / `deleteEntityRecord` don't have a clean payload shape for the plugin endpoint's `{ status }` PATCH. Install-by-slug is the exception — it's a create against the collection, which `saveEntityRecord( 'root', 'plugin', { slug, status } )` maps cleanly (the shared `createEntityFormModal` create mode uses it). After mutating, manually `invalidateResolution` on the entity records query."
+			},
+			{
+				"concern": "zip-upload-no-rest",
+				"note": "`POST /wp/v2/plugins` `create_item` accepts a wordpress.org `slug` only — there is no multipart/file path for a `.zip`. The 'Upload plugin (.zip)' header action renders the shared `UnavailableViaApi` (`kind=\"action\"`) pointing at classic `plugin-install.php?tab=upload`, the documented no-API fallback treatment."
 			},
 			{
 				"concern": "plugin-file-encoding",
@@ -216,16 +250,24 @@
 				"purpose": "DataViews + DataForm components, field descriptor shape. Table view with actions."
 			},
 			{
-				"import": "@wordpress/ui#Button, Notice, Stack, Text",
-				"purpose": "Modal layout + error banner + cells."
+				"import": "@wordpress/ui#Button, Icon, Notice, Stack, Text",
+				"purpose": "Toolbar (heading + Add New / Upload actions) + error banner + cells."
 			},
 			{
-				"import": "@wordpress/components#Button (as DestructiveButton)",
-				"purpose": "Destructive primary in delete-confirm modal."
+				"import": "@wordpress/components#Modal, Spinner",
+				"purpose": "Header-action modal host (install-by-slug + zip-upload fallback) + loading spinner. `Button as DestructiveButton` for the delete-confirm modal."
 			},
 			{
-				"import": "@wordpress/icons#trash, external, check, closeSmall",
-				"purpose": "Action icons."
+				"import": "@wordpress/icons#plus, trash, external, check, closeSmall",
+				"purpose": "Toolbar Add-New + action icons."
+			},
+			{
+				"import": "_shared/dataviews/EntityFormModal#createEntityFormModal",
+				"purpose": "Install-by-slug create form (create mode) hosted in the Add-New modal."
+			},
+			{
+				"import": "_shared/fallback/UnavailableViaApi#UnavailableViaApi",
+				"purpose": "No-API fallback for the zip-upload path (no REST surface)."
 			}
 		]
 	}

--- a/src/apps/plugins/app.json
+++ b/src/apps/plugins/app.json
@@ -207,7 +207,7 @@
 				"trigger": "Click 'Add New Plugin' header action, enter a slug, submit",
 				"effect": "`saveEntityRecord( 'root', 'plugin', { slug, status } )` → `POST /wp/v2/plugins`; success snackbar + invalidate `root/plugin`; modal closes. On failure the modal stays open with an error notice.",
 				"guards": [
-					"slug is required (DataForm `isValid.required`)"
+					"slug is required and rejects whitespace-only input (DataForm `isValid.required` + `isValid.custom`), so the Install button stays disabled until a real slug is entered"
 				]
 			},
 			{
@@ -255,11 +255,11 @@
 			},
 			{
 				"import": "@wordpress/components#Modal, Spinner",
-				"purpose": "Header-action modal host (install-by-slug + zip-upload fallback) + loading spinner. `Button as DestructiveButton` for the delete-confirm modal."
+				"purpose": "Header-action modal host (install-by-slug + zip-upload fallback) + loading spinner."
 			},
 			{
-				"import": "@wordpress/icons#plus, trash, external, check, closeSmall",
-				"purpose": "Toolbar Add-New + action icons."
+				"import": "@wordpress/icons#plus",
+				"purpose": "Toolbar Add-New icon. The delete/visit action icons (trash/external) come via the dataView action specs, resolved by name through the kernel icon registry (resolveIcon)."
 			},
 			{
 				"import": "_shared/dataviews/EntityFormModal#createEntityFormModal",

--- a/src/apps/plugins/app.md
+++ b/src/apps/plugins/app.md
@@ -10,6 +10,14 @@ Mutations split between two layers:
 
 - **Reads** go through `core-data`'s `useEntityRecords('root', 'plugin')` so the entity layer caches the full list.
 - **Writes** go through `apiFetch` directly because the plugin endpoint accepts a `{ status }` PATCH shape that doesn't map cleanly to `saveEntityRecord`. After each mutation, `invalidateResolution('getEntityRecords', ['root', 'plugin', query])` is fired manually so the entity layer refetches.
+- **Install** is the one write that DOES go through `core-data` — it's a create against the collection, which `saveEntityRecord('root', 'plugin', { slug, status })` maps cleanly (the shared `createEntityFormModal` create mode owns that call). It still invalidates the same query so the new plugin appears.
+
+## Add New Plugin
+
+A toolbar above the DataViews list carries two header actions:
+
+- **Add New Plugin** opens a small install-by-slug form built with the shared `createEntityFormModal` create mode (`src/apps/_shared/dataviews/EntityFormModal.js`), hosted in a `@wordpress/components` `Modal`. The `DataForm` collects a wordpress.org directory `slug` (required) and an "Activate after install" boolean. `toRecord` maps the form data to the REST payload `{ slug, status }` — `status: 'active'` when activate is checked, else `'inactive'`. The create body POSTs `/wp/v2/plugins` via `saveEntityRecord`, shows a success snackbar / error notice, and `onSaved` invalidates `root/plugin` so the list refreshes. The factory returns a bare body (no `<Modal>`), so the app wraps it in its own `Modal`; `closeModal` flips the app's `isInstalling` state. Create mode ignores `items`, so it's passed `items={[]}`.
+- **Upload plugin (.zip)** opens a `Modal` hosting the shared `UnavailableViaApi` (`kind="action"`). The REST `create_item` controller accepts a wordpress.org `slug` only — there is no multipart/file path — so the zip-upload flow has no clean REST surface. The fallback links to classic `plugin-install.php?tab=upload` (via the capture-phase admin-link interceptor), a copy-paste `wp plugin install <path-to-zip>` WP-CLI command, and an advisory agent prompt. This is the documented no-API fallback treatment.
 
 ## Architecture
 
@@ -42,7 +50,8 @@ A non-WPDS rebuild needs the standard DataViews equivalents plus an error banner
 
 ## Known limitations
 
-- No install / upload flow — only manage what's installed. wp-admin's "Add new" + zip-upload paths aren't ported. (Parity gap vs `docs/screens/plugins.md`.)
+- Install-by-slug is supported (the "Add New Plugin" header action), but the full **Add New** directory browse — search wordpress.org, Featured/Popular/Recommended/Favorites tabs, plugin cards with ratings/active-installs/compatibility — is not ported. That's blocked on a missing REST surface: `plugins_api()` is not exposed through `/wp/v2`. (Parity gap vs `docs/screens/plugins.md`.)
+- **Zip upload has no clean REST surface** — `POST /wp/v2/plugins` `create_item` accepts a wordpress.org `slug` only. The "Upload plugin (.zip)" header action falls back to the shared `UnavailableViaApi` affordance (classic `plugin-install.php?tab=upload` + WP-CLI + agent prompt) rather than uploading in-app. (Parity gap vs `docs/screens/plugins.md`.)
 - No update flow. WordPress shows an "Update available" indicator + bulk update; the app reads `version` but doesn't compare against the .org repository version. (Parity gap vs `docs/screens/plugins.md`.)
 - Network-active deactivation falls through the multisite delegation chain; we don't verify the multisite path actually completes.
 - The activate path doesn't surface a fatal-error rollback. If activation triggers a PHP error, WordPress traps it and returns `update`/`network_active` state; we don't currently parse that response to show a contextual error.

--- a/src/apps/plugins/index.css
+++ b/src/apps/plugins/index.css
@@ -1,0 +1,22 @@
+/*
+ * PluginsApp layout. A flex column: a fixed toolbar (heading + Add New /
+ * Upload actions) above a flexed list region that hosts the DataViews table.
+ * App-space, WPDS-flavored — the kernel stays DS-neutral.
+ */
+.wp-admin-shell-app-plugins {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.wp-admin-shell-app-plugins__toolbar {
+	margin-bottom: var( --wpds-dimension-gap-lg );
+	flex-shrink: 0;
+}
+
+/* The list region carries `--fill` so the DataViews wrapper stretches to fill
+ * the remaining column height below the toolbar. */
+.wp-admin-shell-app-plugins__list {
+	flex: 1;
+	min-height: 0;
+}

--- a/src/apps/plugins/index.js
+++ b/src/apps/plugins/index.js
@@ -1,12 +1,14 @@
 import '../_shared/app.css';
-import { Spinner } from '@wordpress/components';
+import './index.css';
+import { Modal, Spinner } from '@wordpress/components';
 import { useMemo, useState, useCallback } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { Notice, Stack, Text } from '@wordpress/ui';
+import { Button, Icon, Notice, Stack, Text } from '@wordpress/ui';
 import { __ } from '@wordpress/i18n';
+import { plus } from '@wordpress/icons';
 import { useDataView } from '../../runtime/dataView/useDataView';
 import {
 	buildFields,
@@ -15,6 +17,8 @@ import {
 import { buildActions } from '../_shared/dataviews/buildActions';
 import { useEntityDataView } from '../_shared/dataviews/useEntityDataView';
 import { createBulkConfirmModal } from '../_shared/dataviews/createBulkConfirmModal';
+import { createEntityFormModal } from '../_shared/dataviews/EntityFormModal';
+import { UnavailableViaApi } from '../_shared/fallback/UnavailableViaApi';
 
 const STATUS_LABELS = {
 	active: __( 'Active', 'wp-admin-shell' ),
@@ -45,6 +49,33 @@ const VIEW_DEFAULTS = {
 	sort: { field: 'name', direction: 'asc' },
 	fields: [],
 	layout: {},
+};
+
+// Install-by-slug DataForm. `slug` is the wordpress.org directory slug the REST
+// `POST /wp/v2/plugins` create endpoint accepts; `activate` maps to the
+// endpoint's `status` (`active` when checked, `inactive` otherwise) in
+// `toRecord` below.
+const INSTALL_FIELDS = [
+	{
+		id: 'slug',
+		type: 'text',
+		label: __( 'Plugin slug', 'wp-admin-shell' ),
+		description: __(
+			'The wordpress.org directory slug, e.g. "hello-dolly" or "akismet".',
+			'wp-admin-shell'
+		),
+		isValid: { required: true },
+	},
+	{
+		id: 'activate',
+		type: 'boolean',
+		label: __( 'Activate after install', 'wp-admin-shell' ),
+	},
+];
+
+const INSTALL_FORM = {
+	layout: { type: 'regular', labelPosition: 'top' },
+	fields: [ 'slug', 'activate' ],
 };
 
 function buildFieldRenderers() {
@@ -94,6 +125,8 @@ export default function PluginsApp( { config = {} } = {} ) {
 	const { invalidateResolution } = useDispatch( coreStore );
 
 	const [ error, setError ] = useState( null );
+	const [ isInstalling, setIsInstalling ] = useState( false );
+	const [ isUploading, setIsUploading ] = useState( false );
 
 	const refresh = useCallback( () => {
 		invalidateResolution( 'getEntityRecords', [
@@ -304,6 +337,38 @@ export default function PluginsApp( { config = {} } = {} ) {
 		[ data.length, view.perPage ]
 	);
 
+	// Install-by-slug modal body. `createEntityFormModal` create mode seeds a
+	// local draft from `toData(undefined)`, then `POST`s `toRecord(data)` via
+	// `saveEntityRecord( 'root', 'plugin', … )` — which targets the same
+	// `POST /wp/v2/plugins { slug, status }` create endpoint the list reads
+	// from. It returns a BARE body (no `<Modal>`), so we host it in our own
+	// `<Modal>` below (DataViews' `ActionModal` isn't in play for a header
+	// action). `onSaved` invalidates the list so the new plugin appears.
+	const InstallBody = useMemo(
+		() =>
+			createEntityFormModal( {
+				entity: [ 'root', 'plugin' ],
+				mode: 'create',
+				fields: INSTALL_FIELDS,
+				form: INSTALL_FORM,
+				toData: () => ( { slug: '', activate: false } ),
+				toRecord: ( { slug, activate } ) => ( {
+					slug: ( slug || '' ).trim(),
+					status: activate ? 'active' : 'inactive',
+				} ),
+				messages: {
+					saved: __( 'Plugin installed.', 'wp-admin-shell' ),
+					error: __( 'Failed to install plugin.', 'wp-admin-shell' ),
+					createLabel: __( 'Install', 'wp-admin-shell' ),
+				},
+				onSaved: () => {
+					refresh();
+					setIsInstalling( false );
+				},
+			} ),
+		[ refresh ]
+	);
+
 	if ( error ) {
 		return (
 			<div className="wp-admin-shell-app-plugins__error">
@@ -315,27 +380,98 @@ export default function PluginsApp( { config = {} } = {} ) {
 	}
 
 	return (
-		<div className="wp-admin-shell-app-plugins wp-admin-shell-app--fill">
-			{ ! records ? (
-				<div className="wp-admin-shell-app__center">
-					<Spinner />
-				</div>
-			) : (
-				<DataViews
-					data={ paginatedData }
-					fields={ fields }
-					view={ view }
-					onChangeView={ setView }
-					actions={ actions }
-					paginationInfo={ paginationInfo }
-					isLoading={ isResolving }
-					defaultLayouts={
-						dataViewConfig.defaultLayouts ?? { table: {} }
-					}
-					selection={ selection }
-					onChangeSelection={ setSelection }
-					getItemId={ ( item ) => item.id }
-				/>
+		<div className="wp-admin-shell-app-plugins">
+			<Stack
+				direction="row"
+				align="center"
+				justify="space-between"
+				className="wp-admin-shell-app-plugins__toolbar"
+			>
+				<Text variant="heading-md" render={ <h2 /> }>
+					{ __( 'Plugins', 'wp-admin-shell' ) }
+				</Text>
+				<Stack direction="row" align="center" gap="sm">
+					<Button
+						tone="neutral"
+						variant="outline"
+						size="compact"
+						onClick={ () => setIsUploading( true ) }
+					>
+						{ __( 'Upload plugin (.zip)', 'wp-admin-shell' ) }
+					</Button>
+					<Button
+						tone="brand"
+						variant="solid"
+						size="compact"
+						onClick={ () => setIsInstalling( true ) }
+					>
+						<Icon icon={ plus } size={ 16 } />
+						{ __( 'Add New Plugin', 'wp-admin-shell' ) }
+					</Button>
+				</Stack>
+			</Stack>
+
+			<div className="wp-admin-shell-app-plugins__list wp-admin-shell-app--fill">
+				{ ! records ? (
+					<div className="wp-admin-shell-app__center">
+						<Spinner />
+					</div>
+				) : (
+					<DataViews
+						data={ paginatedData }
+						fields={ fields }
+						view={ view }
+						onChangeView={ setView }
+						actions={ actions }
+						paginationInfo={ paginationInfo }
+						isLoading={ isResolving }
+						defaultLayouts={
+							dataViewConfig.defaultLayouts ?? { table: {} }
+						}
+						selection={ selection }
+						onChangeSelection={ setSelection }
+						getItemId={ ( item ) => item.id }
+					/>
+				) }
+			</div>
+
+			{ isInstalling && (
+				<Modal
+					title={ __( 'Add New Plugin', 'wp-admin-shell' ) }
+					onRequestClose={ () => setIsInstalling( false ) }
+				>
+					{ /* `createEntityFormModal` create mode ignores `items`; it
+					     renders its own DataForm + Install / Cancel footer and
+					     POSTs `{ slug, status }`. `closeModal` flips our state. */ }
+					<InstallBody
+						items={ [] }
+						closeModal={ () => setIsInstalling( false ) }
+					/>
+				</Modal>
+			) }
+
+			{ isUploading && (
+				<Modal
+					title={ __( 'Upload plugin (.zip)', 'wp-admin-shell' ) }
+					onRequestClose={ () => setIsUploading( false ) }
+				>
+					{ /* No REST surface for zip upload — `create_item` accepts a
+					     wordpress.org slug only. Fall back to the classic upload
+					     screen via the shared no-API affordance. */ }
+					<UnavailableViaApi
+						kind="action"
+						classicPath="plugin-install.php?tab=upload"
+						label={ __(
+							'Open the classic Upload Plugin screen',
+							'wp-admin-shell'
+						) }
+						command="wp plugin install /path/to/plugin.zip --activate"
+						agentPrompt={ __(
+							'Install a WordPress plugin from a local .zip archive using `wp plugin install <path-to-zip>`.',
+							'wp-admin-shell'
+						) }
+					/>
+				</Modal>
 			) }
 		</div>
 	);

--- a/src/apps/plugins/index.js
+++ b/src/apps/plugins/index.js
@@ -64,7 +64,17 @@ const INSTALL_FIELDS = [
 			'The wordpress.org directory slug, e.g. "hello-dolly" or "akismet".',
 			'wp-admin-shell'
 		),
-		isValid: { required: true },
+		// `required: true` passes any non-empty string, including whitespace-only
+		// input like "   " — `toRecord` then trims it to "" and the POST fires
+		// empty. Reject whitespace-only here so the disabled-button guard catches
+		// it client-side instead of surfacing the generic install-failed notice.
+		isValid: {
+			required: true,
+			custom: ( item, field ) =>
+				( field.getValue( { item } ) || '' ).trim()
+					? null
+					: __( 'Plugin slug is required.', 'wp-admin-shell' ),
+		},
 	},
 	{
 		id: 'activate',
@@ -361,10 +371,10 @@ export default function PluginsApp( { config = {} } = {} ) {
 					error: __( 'Failed to install plugin.', 'wp-admin-shell' ),
 					createLabel: __( 'Install', 'wp-admin-shell' ),
 				},
-				onSaved: () => {
-					refresh();
-					setIsInstalling( false );
-				},
+				// `CreateBody.onSubmit` already calls `closeModal()` on success,
+				// which our host wires to `setIsInstalling( false )` — so the
+				// close is the modal host's job. Just invalidate the list here.
+				onSaved: () => refresh(),
 			} ),
 		[ refresh ]
 	);


### PR DESCRIPTION
## Summary

Implements the Plugins install-by-slug + "Add New Plugin" header action lane of Phase 2 (issue #126).

A toolbar above the plugins DataViews list now carries two header actions:

- **Add New Plugin** — opens an install-by-slug form built with the shared `createEntityFormModal` create mode (`src/apps/_shared/dataviews/EntityFormModal.js`), hosted in a `@wordpress/components` `Modal`. The `DataForm` collects a required wordpress.org directory `slug` plus an "Activate after install" boolean. `toRecord` maps `{ slug, activate }` → the REST payload `{ slug, status }` (`active` when checked, else `inactive`). The create body POSTs `/wp/v2/plugins` via `saveEntityRecord('root','plugin', …)`, shows a success snackbar / error notice, and `onSaved` invalidates `root/plugin` so the new plugin appears.
- **Upload plugin (.zip)** — falls back to the shared `UnavailableViaApi` (`kind="action"`) in a `Modal`, pointing at classic `plugin-install.php?tab=upload` plus a `wp plugin install` WP-CLI command and an advisory agent prompt. The REST `create_item` controller accepts a wordpress.org `slug` only (no multipart/zip path), so this is the documented no-API fallback treatment.

The app root is restructured into a flex column (fixed toolbar + filled list region) backed by a small `src/apps/plugins/index.css`. `app.json#documentation` and `app.md` are updated to cover the new install write (core-data create), states, interactions, constraints, and design-system leakage.

## Validation

- `npm run lint:js src/apps/plugins/` — clean
- `npm run test:runtime` — 52 passed, 0 failed
- `npm run test:schema` — 56 passed, 0 failed
- `npm run build` — source modules compile (the two pre-existing CSS glob copy errors for `@wordpress/dataviews` / `@wordpress/theme` are environment-only, node_modules not vendored in the worktree)

## Notes

- Install-by-slug uses `core-data` `saveEntityRecord` (a clean create against the collection); status changes + delete still go through `apiFetch` as before.
- Full Add-New directory browse (cards, ratings, tabs) remains a parity gap — blocked on the missing `plugins_api()` REST surface. Documented in `app.md` known limitations.

Part of #126

https://claude.ai/code/session_011C1dy9mVmw7NhLDZbVgimA

---
_Generated by [Claude Code](https://claude.ai/code/session_011C1dy9mVmw7NhLDZbVgimA)_