### PR TITLE
feat(comments): status verbs + author column + reply/edit modals + status tabs

### DIFF
--- a/shells/wp-admin-default.json
+++ b/shells/wp-admin-default.json
@@ -459,6 +459,28 @@
 						},
 						"actions": [
 							{
+								"id": "edit",
+								"label": "Edit",
+								"isPrimary": true,
+								"eligibleWhen": {
+									"status": [
+										"hold",
+										"approved",
+										"spam"
+									]
+								}
+							},
+							{
+								"id": "reply",
+								"label": "Reply",
+								"eligibleWhen": {
+									"status": [
+										"hold",
+										"approved"
+									]
+								}
+							},
+							{
 								"id": "approve",
 								"label": "Approve",
 								"supportsBulk": true,
@@ -492,6 +514,22 @@
 								}
 							},
 							{
+								"id": "unspam",
+								"label": "Not spam",
+								"supportsBulk": true,
+								"eligibleWhen": {
+									"status": "spam"
+								}
+							},
+							{
+								"id": "untrash",
+								"label": "Restore",
+								"supportsBulk": true,
+								"eligibleWhen": {
+									"status": "trash"
+								}
+							},
+							{
 								"id": "trash",
 								"label": "Move to trash",
 								"supportsBulk": true,
@@ -502,6 +540,18 @@
 										"hold",
 										"approved",
 										"spam"
+									]
+								}
+							},
+							{
+								"id": "delete-permanently",
+								"label": "Delete permanently",
+								"supportsBulk": true,
+								"isDestructive": true,
+								"eligibleWhen": {
+									"status": [
+										"spam",
+										"trash"
 									]
 								}
 							}

--- a/src/apps/_shared/dataviews/EntityFormModal.js
+++ b/src/apps/_shared/dataviews/EntityFormModal.js
@@ -38,14 +38,15 @@ import { buildSubmitPayload, firstItem } from './entityFormPayload.mjs';
  * navigate to its id.
  *
  * @param {Object}          config
- * @param {Array}           config.entity     Entity coords `[ kind, name ]` spread into `useEntityRecord` / `saveEntityRecord` (e.g. `[ 'root', 'comment' ]`).
- * @param {'edit'|'create'} [config.mode]     Commit mode. Defaults to `'edit'`.
- * @param {Array}           config.fields     `DataForm` field definitions.
- * @param {Object}          config.form       `DataForm` layout config (`regular` / `panel` / `sections`).
- * @param {Function}        [config.toData]   `(record|undefined) => DataForm data`. Edit: maps `editedRecord` → form data (keep it near-identity — edit commits the buffered record, not a re-mapped payload). Create: `toData(undefined)` seeds the draft. Defaults to identity (`record ?? {}`).
- * @param {Function}        [config.toRecord] **Create-only.** `(data) => REST payload` for the `POST`. Defaults to identity. Edit does NOT apply `toRecord` — it commits the buffered `editedRecord` through `useEntityRecord().save()` (matching `EntityDataForm`), so an edit modal can omit it.
- * @param {Object}          [config.messages] `{ saved, error }` copy for the save notices plus `{ saveLabel, createLabel }` button text. The modal *header* is NOT set here — DataViews' internal `ActionModal` already wraps this `RenderModal` in its own `<Modal>` and titles it from the action's `label` / `modalHeader`. Returning our own `<Modal>` (or passing an `editTitle` / `createTitle`) would double the overlay, header, and focus trap, so the consumer sets the action label instead (matching `createBulkConfirmModal`).
- * @param {Function}        [config.onSaved]  `(record) => void` after a successful commit. CREATE receives the freshly-saved record (with its new id). EDIT receives the record refetched after `save()` resolves (the up-to-date server record, not the pre-save buffer).
+ * @param {Array}           config.entity          Entity coords `[ kind, name ]` spread into `useEntityRecord` / `saveEntityRecord` (e.g. `[ 'root', 'comment' ]`).
+ * @param {'edit'|'create'} [config.mode]          Commit mode. Defaults to `'edit'`.
+ * @param {Array}           config.fields          `DataForm` field definitions.
+ * @param {Object}          config.form            `DataForm` layout config (`regular` / `panel` / `sections`).
+ * @param {Function}        [config.toData]        `(record|undefined, item?) => DataForm data`. Edit: maps `editedRecord` → form data (keep it near-identity — edit commits the buffered record, not a re-mapped payload). Create: `toData(undefined, item)` seeds the draft, receiving the action's subject row as the second arg (so an inline-creation modal — e.g. comment Reply — can seed `parent`/`post` from the row).
+ * @param {Function}        [config.toRecord]      **Create-only.** `(data, item?) => REST payload` for the `POST`. Defaults to identity. Receives the subject row second so the payload can carry row-derived implicit fields (`parent`/`post`). Edit does NOT apply `toRecord` — it commits the buffered `editedRecord` through `useEntityRecord().save()` (matching `EntityDataForm`), so an edit modal can omit it.
+ * @param {Function}        [config.renderContext] **Create-only, optional.** `(item) => JSX | null` rendered above the form as read-only context (e.g. the parent comment in a Reply). Returns `null` when there's no subject row.
+ * @param {Object}          [config.messages]      `{ saved, error }` copy for the save notices plus `{ saveLabel, createLabel }` button text. The modal *header* is NOT set here — DataViews' internal `ActionModal` already wraps this `RenderModal` in its own `<Modal>` and titles it from the action's `label` / `modalHeader`. Returning our own `<Modal>` (or passing an `editTitle` / `createTitle`) would double the overlay, header, and focus trap, so the consumer sets the action label instead (matching `createBulkConfirmModal`).
+ * @param {Function}        [config.onSaved]       `(record) => void` after a successful commit. CREATE receives the freshly-saved record (with its new id). EDIT receives the record refetched after `save()` resolves (the up-to-date server record, not the pre-save buffer).
  * @return {Function} A DataViews `RenderModal` component.
  */
 export function createEntityFormModal( {
@@ -55,6 +56,7 @@ export function createEntityFormModal( {
 	form,
 	toData,
 	toRecord,
+	renderContext,
 	messages = {},
 	onSaved,
 } ) {
@@ -158,12 +160,17 @@ export function createEntityFormModal( {
 	 * new record (and its id) is available to `onSaved`.
 	 *
 	 * @param {Object}   root0
+	 * @param {Object}   [root0.item]            The action's subject row (used by
+	 *                                           inline-creation modals to seed
+	 *                                           row-derived implicit fields).
 	 * @param {Function} root0.closeModal        DataViews modal-close callback.
 	 * @param {Function} root0.onActionPerformed DataViews post-action callback.
 	 * @return {JSX.Element} The create body.
 	 */
-	function CreateBody( { closeModal, onActionPerformed } ) {
-		const [ data, setData ] = useState( () => mapToData( undefined ) );
+	function CreateBody( { item, closeModal, onActionPerformed } ) {
+		const [ data, setData ] = useState( () =>
+			mapToData( undefined, item )
+		);
 		const [ isSaving, setIsSaving ] = useState( false );
 		const { saveEntityRecord } = useDispatch( coreStore );
 		const { createSuccessNotice, createErrorNotice } =
@@ -182,7 +189,11 @@ export function createEntityFormModal( {
 			}
 			setIsSaving( true );
 			try {
-				const payload = buildSubmitPayload( { data, toRecord } );
+				const payload = buildSubmitPayload( {
+					data,
+					toRecord,
+					item,
+				} );
 				// Blocking: the new record (with its id) is returned so
 				// `onSaved` can navigate to / invalidate the new id.
 				const record = await saveEntityRecord( kind, name, payload );
@@ -219,8 +230,14 @@ export function createEntityFormModal( {
 			}
 		};
 
+		const context =
+			item && typeof renderContext === 'function'
+				? renderContext( item )
+				: null;
+
 		return (
 			<Stack direction="column" gap="md">
+				{ context }
 				<DataForm
 					data={ data }
 					fields={ fields }
@@ -276,6 +293,7 @@ export function createEntityFormModal( {
 		if ( mode === 'create' ) {
 			return (
 				<CreateBody
+					item={ item }
 					closeModal={ closeModal }
 					onActionPerformed={ onActionPerformed }
 				/>

--- a/src/apps/_shared/dataviews/entityFormPayload.mjs
+++ b/src/apps/_shared/dataviews/entityFormPayload.mjs
@@ -17,12 +17,16 @@
  *
  * @param {Object}   params
  * @param {Object}   params.data       The create draft `DataForm` data.
- * @param {Function} [params.toRecord] `(data) => payload` REST mapper.
+ * @param {Function} [params.toRecord] `(data, item?) => payload` REST mapper.
+ * @param {Object}   [params.item]     The action's subject row, threaded to
+ *                                     `toRecord` so an inline-creation modal can
+ *                                     derive implicit fields (e.g. a Reply's
+ *                                     `parent`/`post`) from the clicked row.
  * @return {Object} The REST payload.
  */
-export function buildSubmitPayload( { data, toRecord } ) {
+export function buildSubmitPayload( { data, toRecord, item } ) {
 	const map = typeof toRecord === 'function' ? toRecord : ( d ) => d;
-	return { ...( map( data ?? {} ) ?? {} ) };
+	return { ...( map( data ?? {}, item ) ?? {} ) };
 }
 
 /**

--- a/src/apps/comments/app.json
+++ b/src/apps/comments/app.json
@@ -43,10 +43,15 @@
 					{ "id": "date",    "type": "datetime", "label": "Date" }
 				],
 				"actions": [
-					{ "id": "approve",   "label": "Approve",       "supportsBulk": true, "eligibleWhen": { "status": [ "hold", "spam", "trash" ] } },
-					{ "id": "unapprove", "label": "Unapprove",     "supportsBulk": true, "eligibleWhen": { "status": "approved" } },
-					{ "id": "spam",      "label": "Mark as spam",  "isDestructive": true, "supportsBulk": true, "eligibleWhen": { "status": [ "hold", "approved", "trash" ] } },
-					{ "id": "trash",     "label": "Move to trash", "isDestructive": true, "supportsBulk": true, "icon": "trash", "eligibleWhen": { "status": [ "hold", "approved", "spam" ] } }
+					{ "id": "edit",                "label": "Edit",               "isPrimary": true, "eligibleWhen": { "status": [ "hold", "approved", "spam" ] } },
+					{ "id": "reply",               "label": "Reply",              "eligibleWhen": { "status": [ "hold", "approved" ] } },
+					{ "id": "approve",             "label": "Approve",            "supportsBulk": true, "eligibleWhen": { "status": [ "hold", "spam", "trash" ] } },
+					{ "id": "unapprove",           "label": "Unapprove",          "supportsBulk": true, "eligibleWhen": { "status": "approved" } },
+					{ "id": "spam",                "label": "Mark as spam",       "isDestructive": true, "supportsBulk": true, "eligibleWhen": { "status": [ "hold", "approved", "trash" ] } },
+					{ "id": "unspam",              "label": "Not spam",           "supportsBulk": true, "eligibleWhen": { "status": "spam" } },
+					{ "id": "untrash",             "label": "Restore",            "supportsBulk": true, "eligibleWhen": { "status": "trash" } },
+					{ "id": "trash",               "label": "Move to trash",      "isDestructive": true, "supportsBulk": true, "icon": "trash", "eligibleWhen": { "status": [ "hold", "approved", "spam" ] } },
+					{ "id": "delete-permanently",  "label": "Delete permanently", "isDestructive": true, "supportsBulk": true, "eligibleWhen": { "status": [ "spam", "trash" ] } }
 				]
 			},
 			"pending": {
@@ -85,7 +90,7 @@
 		"icon": "comments"
 	},
 	"documentation": {
-		"purpose": "DataViews-driven comment moderation list. Lists author (name + email), comment content (rendered HTML), status, and date. Bulk + per-row actions: approve, unapprove, mark as spam, trash. Status changes round-trip via partial `saveEntityRecord` PATCH so optimistic edits behave; trash routes through `deleteEntityRecord`.",
+		"purpose": "DataViews-driven comment moderation list. The author cell stacks avatar + name + email (`mailto:`) + author URL link + author IP (moderators only); content renders as HTML; status + date follow. A `ViewTabs` strip above the list mirrors the classic All / Pending / Approved / Spam / Trash status views with live per-status counts. Bulk + per-row status actions: approve, unapprove, mark as spam, not spam (unspam), restore (untrash), move to trash, delete permanently. Status changes round-trip via partial `saveEntityRecord` PATCH; trash routes through `deleteEntityRecord` (no `force`), permanent delete through `deleteEntityRecord(..., { force: true })`. Per-row Edit (Quick Edit ≡ full Edit collapsed into one `createEntityFormModal` edit-mode modal) and Reply (`createEntityFormModal` create-mode, content-only POST with row-derived `parent`/`post`) substitute for the upstream-blocked inline-cell / detail-row primitives.",
 		"rebuilds": "comments",
 		"data": {
 			"reads": [
@@ -110,9 +115,15 @@
 						"id",
 						"author_name",
 						"author_email",
+						"author_url",
+						"author_ip",
+						"author_avatar_urls",
 						"content.rendered",
+						"content.raw",
 						"status",
-						"date"
+						"date",
+						"post",
+						"parent"
 					],
 					"query": {
 						"per_page": "view.perPage",
@@ -143,7 +154,25 @@
 					"source": "root/comment",
 					"via": "core-data",
 					"operation": "partial-update",
-					"purpose": "Approve / unapprove / spam — PATCH `{ id, status }`.",
+					"purpose": "Approve / unapprove / spam / unspam / untrash — PATCH `{ id, status }`. `unspam` and `untrash` both target `approved`.",
+					"invalidates": [
+						"root/comment"
+					]
+				},
+				{
+					"source": "root/comment",
+					"via": "core-data",
+					"operation": "update",
+					"purpose": "Modal Edit — PATCH `author_name` / `author_email` (moderators only) / `author_url` / `content` / `status` / `date` via `useEntityRecord().save()` on the buffered record.",
+					"invalidates": [
+						"root/comment"
+					]
+				},
+				{
+					"source": "root/comment",
+					"via": "core-data",
+					"operation": "create",
+					"purpose": "Reply — POST `{ content, parent, post }` where `parent`/`post` come from the subject row; author defaults to the current moderator server-side and the reply auto-approves.",
 					"invalidates": [
 						"root/comment"
 					]
@@ -153,6 +182,15 @@
 					"via": "core-data",
 					"operation": "trash",
 					"purpose": "Move comment to trash (no `force`).",
+					"invalidates": [
+						"root/comment"
+					]
+				},
+				{
+					"source": "root/comment",
+					"via": "core-data",
+					"operation": "delete",
+					"purpose": "Delete permanently — `deleteEntityRecord('root','comment', id, { force: true })`. Confirmed via destructive `createBulkConfirmModal`.",
 					"invalidates": [
 						"root/comment"
 					]
@@ -177,11 +215,39 @@
 			},
 			{
 				"id": "trash-confirm",
-				"when": "User triggered Trash action",
+				"when": "User triggered Trash or Delete permanently action",
 				"renders": "Confirm modal with destructive primary."
+			},
+			{
+				"id": "edit-modal",
+				"when": "User triggered Edit action",
+				"renders": "`createEntityFormModal` edit-mode form (author_name / author_email / author_url / content / status / date)."
+			},
+			{
+				"id": "reply-modal",
+				"when": "User triggered Reply action",
+				"renders": "`createEntityFormModal` create-mode form — content textarea above the read-only parent-comment context."
 			}
 		],
 		"interactions": [
+			{
+				"trigger": "Click a view tab (All / Pending / Approved / Spam / Trash)",
+				"effect": "Writes the segment's `status` filter into `view.filters` (or clears it for All) and resets to page 1; counts come from `useEntityElementCounts`."
+			},
+			{
+				"trigger": "Click Edit action",
+				"effect": "Open the edit modal; on save PATCH the buffered record (full field set); invalidate list + counts; success snackbar.",
+				"guards": [
+					"item.status !== 'trash'"
+				]
+			},
+			{
+				"trigger": "Click Reply action",
+				"effect": "Open the reply modal; on submit POST `{ content, parent: item.id, post: item.post }`; invalidate list + counts; success snackbar.",
+				"guards": [
+					"item.status === 'hold' || item.status === 'approved'"
+				]
+			},
 			{
 				"trigger": "Click Approve action",
 				"effect": "Partial-update status to `approved`; success snackbar.",
@@ -204,10 +270,31 @@
 				]
 			},
 			{
+				"trigger": "Click Not spam action",
+				"effect": "Partial-update status to `approved`; success snackbar.",
+				"guards": [
+					"item.status === 'spam'"
+				]
+			},
+			{
+				"trigger": "Click Restore action",
+				"effect": "Partial-update status to `approved`; success snackbar.",
+				"guards": [
+					"item.status === 'trash'"
+				]
+			},
+			{
 				"trigger": "Click Trash action",
 				"effect": "Open confirm modal; on confirm `deleteEntityRecord` (trash, no `force`) per item; invalidate; success snackbar.",
 				"guards": [
 					"item.status !== 'trash'"
+				]
+			},
+			{
+				"trigger": "Click Delete permanently action",
+				"effect": "Open destructive confirm modal; on confirm `deleteEntityRecord(..., { force: true })` per item; invalidate; success snackbar.",
+				"guards": [
+					"item.status === 'spam' || item.status === 'trash'"
 				]
 			},
 			{
@@ -237,17 +324,25 @@
 			},
 			{
 				"concern": "invalidate-after-mutate",
-				"note": "Every action invalidates `getEntityRecords` on `root/comment` so the list reflects the new state."
+				"note": "Every action invalidates `getEntityRecords` on `root/comment` AND the per-status `useEntityElementCounts` queries (via `invalidateEntityElementCounts`) so the list, status filter labels, and view tabs all reflect the new state."
+			},
+			{
+				"concern": "author-ip-moderate-gate",
+				"note": "The author IP is rendered only when `userCan('moderate_comments')` (resolved once at module load from the static cap map). The app cap floor is already `moderate_comments`, so the gate is belt-and-suspenders for a future relaxed floor + matches the wp-admin behavior where IP is moderator-only."
+			},
+			{
+				"concern": "reply-implicit-parent-post",
+				"note": "Reply (`createEntityFormModal` create mode) derives `parent` + `post` from the subject row inside `toRecord(draft, item)` — they are never user-editable fields. The shared factory threads the action's subject row into `toData`/`toRecord`/`renderContext` so this inline-creation pattern needs no comments-only modal."
 			}
 		],
 		"design-system-leakage": [
 			{
 				"import": "@wordpress/dataviews/wp",
-				"purpose": "DataViews + DataForm components, field descriptor shape. Table view + per-row actions."
+				"purpose": "DataViews + DataForm components, field descriptor shape. Table view + per-row actions + Edit/Reply form modals."
 			},
 			{
 				"import": "@wordpress/ui#Button, Stack, Text",
-				"purpose": "Author cell, modal layout, cancel button."
+				"purpose": "Author cell, view-tab strip, modal layout, cancel button."
 			},
 			{
 				"import": "@wordpress/components#Button (as DestructiveButton)",

--- a/src/apps/comments/app.md
+++ b/src/apps/comments/app.md
@@ -62,10 +62,15 @@ const FIELD_LABELS = {
 };
 
 const ACTION_LABELS = {
-    approve:   __( 'Approve',       'wp-admin-shell' ),
-    unapprove: __( 'Unapprove',     'wp-admin-shell' ),
-    spam:      __( 'Mark as spam',  'wp-admin-shell' ),
-    trash:     __( 'Move to trash', 'wp-admin-shell' ),
+    edit:                 __( 'Edit',               'wp-admin-shell' ),
+    reply:                __( 'Reply',              'wp-admin-shell' ),
+    approve:              __( 'Approve',            'wp-admin-shell' ),
+    unapprove:            __( 'Unapprove',          'wp-admin-shell' ),
+    spam:                 __( 'Mark as spam',       'wp-admin-shell' ),
+    unspam:               __( 'Not spam',           'wp-admin-shell' ),
+    trash:                __( 'Move to trash',      'wp-admin-shell' ),
+    untrash:              __( 'Restore',            'wp-admin-shell' ),
+    'delete-permanently': __( 'Delete permanently', 'wp-admin-shell' ),
 };
 ```
 
@@ -78,7 +83,41 @@ compiled.label = ACTION_LABELS[ spec.id ] ?? spec.label;
 
 **Precedence — LABELS wins for ids the app knows; spec wins for ids it doesn't.** `??` ensures plugin extension columns and actions (ids the app didn't author) keep whatever string the cascade supplied. That preserves the third-party authoring path: a plugin adding a new moderation action via `wp_admin_shell_data_view_config_root_comment` filter controls its own label via the spec (wrapped in `__()` PHP-side); a plugin swapping a bundled label relabels via either an `app.json` LABELS contribution (future) or the same filter.
 
-A parallel `STATUS_SUCCESS_LABELS` table holds the snackbar copy keyed by action id (`approve` → "Approved.", `unapprove` → "Set to pending.", `spam` → "Marked as spam."). Inline `__()` literals inside the trash `RenderModal` (modal copy, button labels) translate normally — only spec-supplied DataViews fields needed the recipe.
+A parallel `STATUS_SUCCESS_LABELS` table holds the snackbar copy keyed by action id (`approve` → "Approved.", `unapprove` → "Set to pending.", `spam` → "Marked as spam.", `unspam` → "No longer marked as spam.", `untrash` → "Restored."). Inline `__()` literals inside the confirm `RenderModal`s and the Edit/Reply form modals (modal copy, button labels) translate normally — only spec-supplied DataViews fields needed the recipe.
+
+## Status verbs (issue #113)
+
+The status flow is fully bidirectional. Beyond `approve` / `unapprove` / `spam` / `trash`, the app wires:
+
+- **Not spam (`unspam`)** and **Restore (`untrash`)** — both partial-PATCH `status` to `approved` through the shared `setCommentsStatus` callback (the same `Promise.allSettled` path the other status flips use). Mirroring wp-admin, neither restores the comment's *prior* state (REST does not preserve it); both land in the approved queue. `STATUS_TARGETS` maps `unspam`/`untrash` → `approved`.
+- **Delete permanently (`delete-permanently`)** — `deleteEntityRecord('root','comment', id, { force: true })`, routed through a destructive `createBulkConfirmModal` (the same factory the Trash confirm uses) with an explicit "cannot be undone" message. Eligible only on `spam`/`trash` rows, matching wp-admin where permanent delete is reachable only from those queues.
+
+Every status flip and delete refreshes both the list query and the per-status count queries via the shared `refreshList()` helper (`invalidateResolution` on `getEntityRecords` + `invalidateEntityElementCounts`), so the list, the status filter labels, and the view tabs all re-resolve.
+
+## Author column (issue #112, Comments half)
+
+`FIELD_RENDERERS.author` (the `AuthorCell` component) stacks every author field already present on the `edit`-context REST record:
+
+- **Avatar** from `author_avatar_urls` (prefers 48px, falls back through the available sizes), rendered as a 32px `<img alt="">`.
+- **Name** in bold (falls back to "Anonymous").
+- **Email** as a `mailto:` link.
+- **Author URL** as an external link (`target="_blank" rel="noopener noreferrer"`), label stripped of its protocol for a tidier display.
+- **Author IP** — rendered **only** when `userCan('moderate_comments')` (resolved once at module load from the static cap map). Matches wp-admin's moderator-only IP exposure.
+
+All five ride the same `data` projection (`useMemo` over `records`) — no extra request.
+
+## Edit + Reply modals (issue #114)
+
+Inline-in-row editing is upstream-blocked: DataViews has no editable-cell (#162) or detail-row (#169) primitive. So Quick Edit, full Edit, and Reply ship as **modal actions** built on the shared `createEntityFormModal` factory (`_shared/dataviews/EntityFormModal.js`) — no comments-only modal.
+
+- **Edit** (one modal, Quick Edit ≡ full Edit) — `mode: 'edit'`. Exposes `author_name` / `author_email` (only when `moderate_comments`, gated via the `EDIT_FORM` field list) / `author_url` / `content` (textarea) / `status` (select) / `date`. Commits by PATCHing the buffered `editedRecord` through `useEntityRecord().save()`. `toData` normalizes `content.raw ?? content.rendered` into the textarea string.
+- **Reply** — `mode: 'create'`, content-only POST. `parent` + `post` come from the subject row via `toRecord(draft, item)` and are never user-editable. The clicked comment renders as read-only context ("In reply to …") via the factory's `renderContext(item)` hook. Author defaults to the current moderator and the reply auto-approves, both server-side.
+
+To support Reply's row-derived implicit fields, `createEntityFormModal`'s **create mode** was extended to thread the action's subject row into `toData(undefined, item)`, `toRecord(draft, item)`, and the new optional `renderContext(item)`. This is backward-compatible — existing single-arg `toData`/`toRecord` callers ignore the extra argument — and is the project's first inline-creation instance (the same Modal Create pattern grows to Add New User and create-with-meta).
+
+## View tabs (issue #111, Comments half)
+
+The shared `ViewTabs` strip renders above the list: **All / Pending / Approved / Spam / Trash** segments with live counts from `useEntityElementCounts`. Clicking a segment writes the corresponding `status` filter into `view.filters` (All clears it → unfiltered `status: 'any'`) and resets to page 1. `activeSegmentId(view)` derives the pressed segment back from the current filter, so deep-links and the existing status filter dropdown stay in sync. The counts object feeds both the tabs and the status-column filter labels — one set of requests.
 
 ## Rebuild guide
 
@@ -97,12 +136,12 @@ A non-WPDS rebuild needs:
 
 ## Known limitations
 
-- No reply. wp-admin offers an inline reply form on each row; the v2 design defers this.
-- No Quick Edit. wp-admin's row inline-edit (toggleable form for author / email / URL / content) is not wired up.
-- No full single-comment Edit screen. wp-admin links to `comment.php?action=editcomment` for a full edit form with parent-comment selector + status switcher; the v2 app surfaces neither the link nor the screen.
-- No author / IP / email row-level filtering.
-- The Trash action lacks an undo path. wp-admin's edit-comments has a "Undo" snackbar after trash; we issue a plain success snackbar.
+- **Reply / Edit are modal, not inline.** wp-admin offers an inline reply form + a row Quick Edit toggle; DataViews has no editable-cell (#162) or detail-row (#169) primitive (both `blocked:upstream`), so both ship as modal actions. Swap the host to inline when those primitives land — not a missed requirement.
+- No `Mine` view tab. The strip ships **All / Pending / Approved / Spam / Trash**; `Mine` (scoped to `author=<me>`) is not wired, and there is no `Mine` count.
+- Parent-comment **selector** in Edit. wp-admin's full edit form lets a moderator re-parent a comment; the Edit modal exposes author / content / status / date but not a parent picker.
+- No author / IP / email row-level filtering (the IP is displayed for moderators but not filterable — REST has no `author_ip` collection param).
+- The Trash / spam / delete actions lack an undo path. wp-admin's edit-comments has an "Undo" snackbar; we issue a plain success snackbar.
 - Pagination caps perPage at 100 server-side; the app passes whatever DataViews sends.
-- Status **counts** surface on the status filter elements (`Approved (12)`, `Pending (3)`) via the shared `useEntityElementCounts` hook — one `per_page=1&_fields=id` request per status, read off the `X-WP-Total` header. Rendered as filter-dropdown options, not the standalone `All | Mine | Pending | Approved | Spam | Trash` tab strip wp-admin uses, and there is no `Mine` count.
+- Status **counts** drive both the `ViewTabs` strip and the status-column filter labels (`Approved (12)`, `Pending (3)`) via the shared `useEntityElementCounts` hook — one `per_page=1&_fields=id` request per status, read off the `X-WP-Total` header.
 
 Parity gaps versus `docs/screens/comments.md` not surfaced in the v2 app are tracked in that screen spec; they carry forward unchanged from the pre-C2 implementation.

--- a/src/apps/comments/index.css
+++ b/src/apps/comments/index.css
@@ -8,3 +8,20 @@
 .wp-admin-shell-app-comments__excerpt p {
 	margin: 0 0 0.5em;
 }
+
+.wp-admin-shell-app-comments__avatar {
+	flex-shrink: 0;
+	border-radius: var(--wpds-border-radius-small, 2px);
+}
+
+.wp-admin-shell-app-comments__author-email,
+.wp-admin-shell-app-comments__author-url {
+	font-size: var(--wpds-font-size-sm);
+	word-break: break-word;
+}
+
+.wp-admin-shell-app-comments__reply-context {
+	padding: var(--wpds-dimension-padding-md, 12px);
+	background: var(--wpds-color-gray-100, rgba(0, 0, 0, 0.04));
+	border-radius: var(--wpds-border-radius-small, 2px);
+}

--- a/src/apps/comments/index.js
+++ b/src/apps/comments/index.js
@@ -514,7 +514,11 @@ export default function CommentsApp( { config = {} } ) {
 			toData: ( record ) => ( {
 				...record,
 				content:
-					record?.content?.raw ?? record?.content?.rendered ?? '',
+					typeof record?.content === 'string'
+						? record.content
+						: record?.content?.raw ??
+						  record?.content?.rendered ??
+						  '',
 			} ),
 			messages: {
 				saved: __( 'Comment updated.', 'wp-admin-shell' ),

--- a/src/apps/comments/index.js
+++ b/src/apps/comments/index.js
@@ -10,6 +10,7 @@ import { Stack, Text } from '@wordpress/ui';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useDataView } from '../../runtime/dataView/useDataView';
+import { userCan } from '../../runtime/capabilities/userCan';
 import {
 	buildFields,
 	elementsFromLabels,
@@ -21,15 +22,25 @@ import {
 	invalidateEntityElementCounts,
 } from '../_shared/dataviews/useEntityElementCounts';
 import { createBulkConfirmModal } from '../_shared/dataviews/createBulkConfirmModal';
+import { createEntityFormModal } from '../_shared/dataviews/EntityFormModal';
+import ViewTabs from '../_shared/dataviews/ViewTabs';
 
 /**
  * core:comments — moderation list backed by `useEntityRecords('root','comment')`.
  *
- * Status flow: hold → approved | spam | trash. The REST endpoint accepts
- * `status` updates via PATCH; we issue them through `saveEntityRecord` with a
- * partial payload so optimistic edits round-trip cleanly. Comment content
- * arrives HTML-rendered (already sanitized server-side by
- * `wp_filter_comment_content`); we render it via `dangerouslySetInnerHTML`.
+ * Status flow: hold → approved | spam | trash, plus the inverse transitions —
+ * unspam (spam → approved), restore (trash → approved), and permanent delete
+ * (`force`). The REST endpoint accepts `status` updates via PATCH; we issue them
+ * through `saveEntityRecord` with a partial payload so optimistic edits
+ * round-trip cleanly. Comment content arrives HTML-rendered (already sanitized
+ * server-side by `wp_filter_comment_content`); we render it via
+ * `dangerouslySetInnerHTML`.
+ *
+ * Single-comment Edit (Quick Edit ≡ full Edit, collapsed into one modal) and
+ * Reply ride the shared `createEntityFormModal` factory — Edit in edit mode
+ * (PATCH the buffered record), Reply in create mode (content-only POST with the
+ * row's `parent`/`post`). Inline-in-row placement is upstream-blocked (DataViews
+ * has no editable-cell / detail-row primitive), so both ship as modal actions.
  */
 const STATUS_LABELS = {
 	approved: __( 'Approved', 'wp-admin-shell' ),
@@ -49,28 +60,71 @@ const FIELD_LABELS = {
 };
 
 const ACTION_LABELS = {
+	edit: __( 'Edit', 'wp-admin-shell' ),
+	reply: __( 'Reply', 'wp-admin-shell' ),
 	approve: __( 'Approve', 'wp-admin-shell' ),
 	unapprove: __( 'Unapprove', 'wp-admin-shell' ),
 	spam: __( 'Mark as spam', 'wp-admin-shell' ),
+	unspam: __( 'Not spam', 'wp-admin-shell' ),
 	trash: __( 'Move to trash', 'wp-admin-shell' ),
+	untrash: __( 'Restore', 'wp-admin-shell' ),
+	'delete-permanently': __( 'Delete permanently', 'wp-admin-shell' ),
 };
 
 /**
- * Snackbar copy for each non-trash status-change action. Keyed by spec id so a
- * cascade override that renames `spam` → `mark-as-spam` keeps the declared
+ * Snackbar copy for each non-destructive status-change action. Keyed by spec id
+ * so a cascade override that renames `spam` → `mark-as-spam` keeps the declared
  * label but loses the success message — the default fallback covers it.
  */
 const STATUS_SUCCESS_LABELS = {
 	approve: __( 'Approved.', 'wp-admin-shell' ),
 	unapprove: __( 'Set to pending.', 'wp-admin-shell' ),
 	spam: __( 'Marked as spam.', 'wp-admin-shell' ),
+	unspam: __( 'No longer marked as spam.', 'wp-admin-shell' ),
+	untrash: __( 'Restored.', 'wp-admin-shell' ),
 };
 
+/**
+ * Target status for each status-flip action. `unspam` and `untrash` both
+ * resolve to `approved` — mirroring wp-admin, where "Not Spam" and "Restore"
+ * return a comment to the approved queue (not its prior pending state, which
+ * REST does not preserve).
+ */
 const STATUS_TARGETS = {
 	approve: 'approved',
 	unapprove: 'hold',
 	spam: 'spam',
+	unspam: 'approved',
+	untrash: 'approved',
 };
+
+// View-tab segments — the classic All | Pending | Approved | Spam | Trash strip.
+// `filter.value` is the REST `status` arg `useEntityElementCounts` keys on; the
+// counts object is `{ approved, hold, spam, trash }`. "All" carries no count
+// (it's the unfiltered `status: 'any'` base, not a single status value).
+const VIEW_TAB_SEGMENTS = [
+	{ id: 'all', label: __( 'All', 'wp-admin-shell' ), filter: null },
+	{
+		id: 'hold',
+		label: __( 'Pending', 'wp-admin-shell' ),
+		filter: { field: 'status', value: 'hold' },
+	},
+	{
+		id: 'approved',
+		label: __( 'Approved', 'wp-admin-shell' ),
+		filter: { field: 'status', value: 'approved' },
+	},
+	{
+		id: 'spam',
+		label: __( 'Spam', 'wp-admin-shell' ),
+		filter: { field: 'status', value: 'spam' },
+	},
+	{
+		id: 'trash',
+		label: __( 'Trash', 'wp-admin-shell' ),
+		filter: { field: 'status', value: 'trash' },
+	},
+];
 
 const VIEW_DEFAULTS = {
 	type: 'table',
@@ -84,17 +138,101 @@ const VIEW_DEFAULTS = {
 };
 
 /**
+ * Derive the active view-tab segment id from the current `view.filters`. A
+ * single `status` filter (`is`/`isAny` on one value) maps to that segment; an
+ * absent or multi-value status filter falls back to "all".
+ *
+ * @param {Object} view DataViews controlled view shape.
+ * @return {string} The active segment id.
+ */
+function activeSegmentId( view ) {
+	const statusFilter = ( view.filters ?? [] ).find(
+		( f ) => f.field === 'status'
+	);
+	if ( ! statusFilter ) {
+		return 'all';
+	}
+	const { value } = statusFilter;
+	const single = Array.isArray( value ) ? value : [ value ];
+	if ( single.length !== 1 ) {
+		return 'all';
+	}
+	const match = VIEW_TAB_SEGMENTS.find(
+		( seg ) => seg.filter && seg.filter.value === single[ 0 ]
+	);
+	return match ? match.id : 'all';
+}
+
+/**
+ * Author cell renderer. Stacks avatar + name + email (`mailto:`) + author URL
+ * link, and — for users who can `moderate_comments` — the author IP. All fields
+ * already ride the `edit`-context REST record; only the moderate gate hides IP.
+ *
+ * Module-scoped — captures no props. The `canModerate` flag is resolved once at
+ * module load via `userCan` (the cap map is static for the session).
+ *
+ * @param {Object} root0
+ * @param {Object} root0.item The DataViews row.
+ * @return {JSX.Element} The author cell.
+ */
+const canModerate = userCan( 'moderate_comments' );
+
+function AuthorCell( { item } ) {
+	return (
+		<Stack
+			direction="row"
+			gap="sm"
+			align="flex-start"
+			className="wp-admin-shell-app-comments__author"
+		>
+			{ item.avatarUrl ? (
+				<img
+					className="wp-admin-shell-app-comments__avatar"
+					src={ item.avatarUrl }
+					alt=""
+					width={ 32 }
+					height={ 32 }
+				/>
+			) : null }
+			<Stack direction="column" gap="xs">
+				<Text>
+					<strong>
+						{ item.author || __( 'Anonymous', 'wp-admin-shell' ) }
+					</strong>
+				</Text>
+				{ item.authorEmail ? (
+					<a
+						className="wp-admin-shell-app-comments__author-email"
+						href={ `mailto:${ item.authorEmail }` }
+					>
+						{ item.authorEmail }
+					</a>
+				) : null }
+				{ item.authorUrl ? (
+					<a
+						className="wp-admin-shell-app-comments__author-url"
+						href={ item.authorUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ item.authorUrlDisplay }
+					</a>
+				) : null }
+				{ canModerate && item.authorIp ? (
+					<Text className="wp-admin-shell-app__muted">
+						{ item.authorIp }
+					</Text>
+				) : null }
+			</Stack>
+		</Stack>
+	);
+}
+
+/**
  * Field id → render callback. Module-scoped — renderers capture no props.
  */
 const FIELD_RENDERERS = {
-	author: ( { item } ) => (
-		<Stack direction="column" gap="xs">
-			<Text>{ item.author }</Text>
-			<Text className="wp-admin-shell-app__muted">
-				{ item.authorEmail }
-			</Text>
-		</Stack>
-	),
+	author: AuthorCell,
 	// Trust boundary: `item.content` is `record.content.rendered`, which
 	// WordPress core filters server-side via `wp_filter_comment_content`
 	// (kses + the comment-text filter chain). Author-supplied raw HTML has
@@ -108,6 +246,80 @@ const FIELD_RENDERERS = {
 	status: ( { item } ) => (
 		<Text>{ STATUS_LABELS[ item.status ] || item.status }</Text>
 	),
+};
+
+// ---- Edit / Reply DataForm field + form definitions ------------------------
+
+const STATUS_ELEMENTS = STATUS_VALUES.map( ( value ) => ( {
+	value,
+	label: STATUS_LABELS[ value ],
+} ) );
+
+// Edit-modal fields. `author_email` is gated behind `moderate_comments` via the
+// form layout (built below) — non-moderators never reach this app (the app cap
+// floor is `moderate_comments`), but the gate is kept explicit for parity with
+// the spec and any future relaxed floor.
+const EDIT_FIELDS = [
+	{
+		id: 'author_name',
+		type: 'text',
+		label: __( 'Name', 'wp-admin-shell' ),
+	},
+	{
+		id: 'author_email',
+		type: 'email',
+		label: __( 'Email', 'wp-admin-shell' ),
+	},
+	{
+		id: 'author_url',
+		type: 'text',
+		label: __( 'URL', 'wp-admin-shell' ),
+	},
+	{
+		id: 'content',
+		type: 'text',
+		label: __( 'Comment', 'wp-admin-shell' ),
+		Edit: { control: 'textarea', rows: 6 },
+	},
+	{
+		id: 'status',
+		type: 'text',
+		label: __( 'Status', 'wp-admin-shell' ),
+		elements: STATUS_ELEMENTS,
+		Edit: 'select',
+	},
+	{
+		id: 'date',
+		type: 'datetime',
+		label: __( 'Date', 'wp-admin-shell' ),
+	},
+];
+
+const EDIT_FORM = {
+	layout: { type: 'regular', labelPosition: 'top' },
+	fields: [
+		'author_name',
+		...( canModerate ? [ 'author_email' ] : [] ),
+		'author_url',
+		'content',
+		'status',
+		'date',
+	],
+};
+
+const REPLY_FIELDS = [
+	{
+		id: 'content',
+		type: 'text',
+		label: __( 'Reply', 'wp-admin-shell' ),
+		Edit: { control: 'textarea', rows: 6 },
+		isValid: { required: true },
+	},
+];
+
+const REPLY_FORM = {
+	layout: { type: 'regular', labelPosition: 'top' },
+	fields: [ 'content' ],
 };
 
 export default function CommentsApp( { config = {} } ) {
@@ -174,21 +386,55 @@ export default function CommentsApp( { config = {} } ) {
 		if ( ! records ) {
 			return [];
 		}
-		return records.map( ( record ) => ( {
-			id: record.id,
-			author: decodeEntities( record.author_name || '' ),
-			authorEmail: decodeEntities( record.author_email || '' ),
-			content: record.content?.rendered || '',
-			status: record.status,
-			date: record.date,
-			rawRecord: record,
-		} ) );
+		return records.map( ( record ) => {
+			const avatarUrls = record.author_avatar_urls || {};
+			// Prefer the 48px avatar, fall back to whatever size is present.
+			const avatarUrl =
+				avatarUrls[ '48' ] ||
+				avatarUrls[ '96' ] ||
+				avatarUrls[ '24' ] ||
+				Object.values( avatarUrls )[ 0 ] ||
+				'';
+			const authorUrl = record.author_url || '';
+			return {
+				id: record.id,
+				author: decodeEntities( record.author_name || '' ),
+				authorEmail: decodeEntities( record.author_email || '' ),
+				authorUrl,
+				// Strip the protocol for a tidier display label, like wp-admin.
+				authorUrlDisplay: authorUrl.replace( /^https?:\/\//, '' ),
+				authorIp: record.author_ip || '',
+				avatarUrl,
+				content: record.content?.rendered || '',
+				status: record.status,
+				date: record.date,
+				post: record.post,
+				rawRecord: record,
+			};
+		} );
 	}, [ records ] );
+
+	const refreshList = useCallback( () => {
+		invalidateResolution( 'getEntityRecords', [
+			'root',
+			'comment',
+			queryArgs,
+		] );
+		// Status transitions move comments between buckets, so the per-status
+		// count queries the filter labels + view tabs read from refresh too.
+		invalidateEntityElementCounts(
+			invalidateResolution,
+			'root',
+			'comment',
+			'status',
+			STATUS_VALUES
+		);
+	}, [ invalidateResolution, queryArgs ] );
 
 	const setCommentsStatus = useCallback(
 		async ( items, targetStatus, label ) => {
 			// `allSettled` so one failure in a bulk action doesn't collapse
-			// the rest — symmetric with the trash modal.
+			// the rest — symmetric with the destructive modals.
 			const results = await Promise.allSettled(
 				items.map( ( item ) =>
 					saveEntityRecord( 'root', 'comment', {
@@ -197,21 +443,7 @@ export default function CommentsApp( { config = {} } ) {
 					} )
 				)
 			);
-			invalidateResolution( 'getEntityRecords', [
-				'root',
-				'comment',
-				queryArgs,
-			] );
-			// Status transitions move comments between buckets, so the
-			// per-status count queries the filter labels read from need
-			// to refresh too — same goes for the trash modal below.
-			invalidateEntityElementCounts(
-				invalidateResolution,
-				'root',
-				'comment',
-				'status',
-				STATUS_VALUES
-			);
+			refreshList();
 			const failed = results.filter(
 				( r ) => r.status === 'rejected'
 			).length;
@@ -248,8 +480,7 @@ export default function CommentsApp( { config = {} } ) {
 		},
 		[
 			saveEntityRecord,
-			invalidateResolution,
-			queryArgs,
+			refreshList,
 			createSuccessNotice,
 			createErrorNotice,
 		]
@@ -271,6 +502,69 @@ export default function CommentsApp( { config = {} } ) {
 	);
 
 	const actions = useMemo( () => {
+		// Modal Edit (Quick Edit ≡ full Edit) — PATCH the buffered record.
+		const editModal = createEntityFormModal( {
+			entity: [ 'root', 'comment' ],
+			mode: 'edit',
+			fields: EDIT_FIELDS,
+			form: EDIT_FORM,
+			// Near-identity: edit commits the buffered `editedRecord`, not a
+			// re-mapped payload. We only normalize `content` from the rendered
+			// shape into the raw string the textarea + PATCH expect.
+			toData: ( record ) => ( {
+				...record,
+				content:
+					record?.content?.raw ?? record?.content?.rendered ?? '',
+			} ),
+			messages: {
+				saved: __( 'Comment updated.', 'wp-admin-shell' ),
+				error: __( 'Failed to update comment.', 'wp-admin-shell' ),
+				saveLabel: __( 'Update', 'wp-admin-shell' ),
+			},
+			onSaved: refreshList,
+		} );
+
+		// Reply — content-only POST; `parent`/`post` come from the subject row.
+		// `author` defaults to the current moderator server-side; the reply
+		// auto-approves (the moderator is trusted).
+		const replyModal = createEntityFormModal( {
+			entity: [ 'root', 'comment' ],
+			mode: 'create',
+			fields: REPLY_FIELDS,
+			form: REPLY_FORM,
+			toData: () => ( { content: '' } ),
+			toRecord: ( draft, item ) => ( {
+				content: draft.content,
+				parent: item?.id,
+				post: item?.post,
+			} ),
+			renderContext: ( item ) => (
+				<Stack
+					direction="column"
+					gap="xs"
+					className="wp-admin-shell-app-comments__reply-context"
+				>
+					<Text className="wp-admin-shell-app__muted">
+						{ sprintf(
+							/* translators: %s: comment author name. */
+							__( 'In reply to %s', 'wp-admin-shell' ),
+							item.author || __( 'Anonymous', 'wp-admin-shell' )
+						) }
+					</Text>
+					<div
+						className="wp-admin-shell-app-comments__excerpt"
+						dangerouslySetInnerHTML={ { __html: item.content } }
+					/>
+				</Stack>
+			),
+			messages: {
+				saved: __( 'Reply posted.', 'wp-admin-shell' ),
+				error: __( 'Failed to post reply.', 'wp-admin-shell' ),
+				createLabel: __( 'Reply', 'wp-admin-shell' ),
+			},
+			onSaved: refreshList,
+		} );
+
 		const trashModal = createBulkConfirmModal( {
 			getMessage: ( items ) =>
 				items.length === 1
@@ -280,18 +574,7 @@ export default function CommentsApp( { config = {} } ) {
 			mutate: ( item ) =>
 				deleteEntityRecord( 'root', 'comment', item.id ),
 			onSettled: ( { items, failed } ) => {
-				invalidateResolution( 'getEntityRecords', [
-					'root',
-					'comment',
-					queryArgs,
-				] );
-				invalidateEntityElementCounts(
-					invalidateResolution,
-					'root',
-					'comment',
-					'status',
-					STATUS_VALUES
-				);
+				refreshList();
 				if ( failed > 0 ) {
 					createErrorNotice(
 						sprintf(
@@ -310,6 +593,48 @@ export default function CommentsApp( { config = {} } ) {
 				} else {
 					createSuccessNotice(
 						__( 'Moved to trash.', 'wp-admin-shell' ),
+						{ type: 'snackbar' }
+					);
+				}
+			},
+		} );
+
+		const deleteModal = createBulkConfirmModal( {
+			getMessage: ( items ) =>
+				items.length === 1
+					? __(
+							'Permanently delete this comment? This cannot be undone.',
+							'wp-admin-shell'
+					  )
+					: __(
+							'Permanently delete these comments? This cannot be undone.',
+							'wp-admin-shell'
+					  ),
+			confirmLabel: __( 'Delete permanently', 'wp-admin-shell' ),
+			mutate: ( item ) =>
+				deleteEntityRecord( 'root', 'comment', item.id, {
+					force: true,
+				} ),
+			onSettled: ( { items, failed } ) => {
+				refreshList();
+				if ( failed > 0 ) {
+					createErrorNotice(
+						sprintf(
+							/* translators: 1: failed item count, 2: total item count */
+							_n(
+								'%1$d of %2$d comment failed to delete.',
+								'%1$d of %2$d comments failed to delete.',
+								failed,
+								'wp-admin-shell'
+							),
+							failed,
+							items.length
+						),
+						{ isDismissible: true }
+					);
+				} else {
+					createSuccessNotice(
+						__( 'Permanently deleted.', 'wp-admin-shell' ),
 						{ type: 'snackbar' }
 					);
 				}
@@ -337,15 +662,31 @@ export default function CommentsApp( { config = {} } ) {
 						STATUS_TARGETS.spam,
 						STATUS_SUCCESS_LABELS.spam
 					),
+				unspam: ( items ) =>
+					setCommentsStatus(
+						items,
+						STATUS_TARGETS.unspam,
+						STATUS_SUCCESS_LABELS.unspam
+					),
+				untrash: ( items ) =>
+					setCommentsStatus(
+						items,
+						STATUS_TARGETS.untrash,
+						STATUS_SUCCESS_LABELS.untrash
+					),
 			},
-			modals: { trash: trashModal },
+			modals: {
+				edit: editModal,
+				reply: replyModal,
+				trash: trashModal,
+				'delete-permanently': deleteModal,
+			},
 		} );
 	}, [
 		dataViewConfig,
 		setCommentsStatus,
 		deleteEntityRecord,
-		invalidateResolution,
-		queryArgs,
+		refreshList,
 		createSuccessNotice,
 		createErrorNotice,
 	] );
@@ -358,6 +699,30 @@ export default function CommentsApp( { config = {} } ) {
 		[ totalItems, totalPages ]
 	);
 
+	const currentSegment = activeSegmentId( view );
+
+	const onSelectSegment = useCallback(
+		( segment ) => {
+			setView( ( prev ) => {
+				// Drop any existing status filter, then add the segment's (if
+				// any). "All" carries no filter → unfiltered `status: 'any'`.
+				const filters = ( prev.filters ?? [] ).filter(
+					( f ) => f.field !== 'status'
+				);
+				if ( segment.filter ) {
+					filters.push( {
+						field: segment.filter.field,
+						operator: 'is',
+						value: segment.filter.value,
+					} );
+				}
+				// Reset to page 1 — the new filter set has its own pagination.
+				return { ...prev, filters, page: 1 };
+			} );
+		},
+		[ setView ]
+	);
+
 	return (
 		<div className="wp-admin-shell-app-comments wp-admin-shell-app--fill">
 			{ ! records ? (
@@ -365,19 +730,27 @@ export default function CommentsApp( { config = {} } ) {
 					<Spinner />
 				</div>
 			) : (
-				<DataViews
-					data={ data }
-					fields={ fields }
-					view={ view }
-					onChangeView={ setView }
-					actions={ actions }
-					paginationInfo={ paginationInfo }
-					isLoading={ isResolving }
-					defaultLayouts={ dataViewConfig.defaultLayouts ?? {} }
-					selection={ selection }
-					onChangeSelection={ setSelection }
-					getItemId={ ( item ) => item.id.toString() }
-				/>
+				<>
+					<ViewTabs
+						segments={ VIEW_TAB_SEGMENTS }
+						currentValue={ currentSegment }
+						onSelect={ onSelectSegment }
+						counts={ statusCounts }
+					/>
+					<DataViews
+						data={ data }
+						fields={ fields }
+						view={ view }
+						onChangeView={ setView }
+						actions={ actions }
+						paginationInfo={ paginationInfo }
+						isLoading={ isResolving }
+						defaultLayouts={ dataViewConfig.defaultLayouts ?? {} }
+						selection={ selection }
+						onChangeSelection={ setSelection }
+						getItemId={ ( item ) => item.id.toString() }
+					/>
+				</>
 			) }
 		</div>
 	);

--- a/tests/runtime/dataviews-shared.test.mjs
+++ b/tests/runtime/dataviews-shared.test.mjs
@@ -411,6 +411,21 @@ ok(
 	buildSubmitPayload( { data: { name: 'x' }, toRecord: ( d ) => d } ).id ===
 		undefined
 );
+ok(
+	'buildSubmitPayload threads the subject row into toRecord (inline-create: Reply parent/post)',
+	( () => {
+		const payload = buildSubmitPayload( {
+			data: { content: 'hi' },
+			item: { id: 7, post: 42 },
+			toRecord: ( d, item ) => ( {
+				content: d.content,
+				parent: item?.id,
+				post: item?.post,
+			} ),
+		} );
+		return payload.parent === 7 && payload.post === 42;
+	} )()
+);
 
 ok(
 	'firstItem returns items[0]',


### PR DESCRIPTION
Extends the `core:comments` app across four Wave 2 parity issues. Internal commit order: #113 → #112 → #114 → #111.

## #113 — Status verbs (Not Spam / Restore / Delete Permanently)
- `unspam` (Not spam) and `untrash` (Restore) partial-PATCH `status` → `approved` via the shared `setCommentsStatus` path (mirrors wp-admin: both land in the approved queue).
- `delete-permanently` → `deleteEntityRecord('root','comment', id, { force: true })`, routed through a destructive `createBulkConfirmModal`.
- Every flip/delete refreshes the list **and** per-status counts (shared `refreshList()` helper).

## #112 (Comments half) — Author column
`AuthorCell` renderer stacks avatar (`author_avatar_urls`), bold name, email as `mailto:`, author URL link, and author IP — IP gated behind `userCan('moderate_comments')`. All fields already ride the `edit`-context record; no extra request. (Users app untouched — separate lane.)

## #114 — Reply + Quick Edit + full Edit (modal)
Inline-in-row is upstream-blocked (DataViews has no editable-cell / detail-row primitive), so these ship as modal actions on the shared `createEntityFormModal`:
- **Edit** (Quick ≡ full, one modal) — edit mode: `author_name` / `author_email` (mod-only) / `author_url` / `content` / `status` / `date`, committed via PATCH on the buffered record.
- **Reply** — create mode: content-only POST with `parent`/`post` derived from the row, parent comment shown as read-only context.
- Extended the shared factory's **create mode** to thread the action's subject row into `toData`/`toRecord`/`renderContext` (backward-compatible — existing single-arg callers unaffected). First inline-creation instance.

## #111 (Comments half) — Status view tabs
Shared `ViewTabs` strip above the list — All / Pending / Approved / Spam / Trash — with live counts via `useEntityElementCounts`; clicking writes `view.filters` (status) and resets to page 1. `activeSegmentId` keeps the strip in sync with the existing status filter. (Posts app untouched — separate lane.)

## Other
- Mirrored the new action set into `shells/wp-admin-default.json` (the shell redeclares the `root/comment` triple, so its actions win outright — partial redeclaration would drop them).
- Updated `app.json#documentation` + `app.md`.
- Added a `buildSubmitPayload` subject-row threading test.

## Validation
- `npm run lint:js src/apps/comments/` clean.
- `npm run test:runtime` all pass (incl. new dataviews-shared assertion).
- `npm run test:schema` all pass.
- `npm run build` compiles (pre-existing dataviews/theme CSS glob warnings only).

Part of #113
Part of #112
Part of #114
Part of #111

https://claude.ai/code/session_011C1dy9mVmw7NhLDZbVgimA

---
_Generated by [Claude Code](https://claude.ai/code/session_011C1dy9mVmw7NhLDZbVgimA)_