### PR TITLE
feat(posts): Bulk Edit + status/Mine/Sticky tabs + date/category/format filters

### DIFF
--- a/src/apps/_shared/dataviews/buildFields.mjs
+++ b/src/apps/_shared/dataviews/buildFields.mjs
@@ -17,12 +17,21 @@
  *
  * Pure (no imports) so `tests/runtime/*` can import it directly.
  *
+ * `getElements` forwards an async/lazy element provider (DataViews calls it to
+ * resolve the option set for a categorical filter at filter-open time) for ids
+ * whose options aren't known statically — e.g. a taxonomy filter that fetches
+ * `/wp/v2/categories`. A `getElements[id]` wins over a static `elements`
+ * spec/fallback for the same id.
+ *
+ * Pure (no imports) so `tests/runtime/*` can import it directly.
+ *
  * @param {Array}  fieldSpecs                 View-config field specs.
  * @param {Object} [options]
  * @param {Object} [options.labels]           id → translated label.
  * @param {Object} [options.renderers]        id → render callback.
  * @param {Object} [options.elementFallbacks] id → elements[] used when the spec omits `elements`.
  * @param {Object} [options.elementCounts]    id → { value: count } merged into the field's elements.
+ * @param {Object} [options.getElements]      id → async element provider; sets the field's `getElements`.
  * @return {Array} Compiled DataViews fields.
  */
 export function buildFields(
@@ -32,6 +41,7 @@ export function buildFields(
 		renderers = {},
 		elementFallbacks = {},
 		elementCounts = {},
+		getElements = {},
 	} = {}
 ) {
 	return ( fieldSpecs ?? [] )
@@ -62,6 +72,9 @@ export function buildFields(
 					elements,
 					elementCounts[ spec.id ]
 				);
+			}
+			if ( typeof getElements[ spec.id ] === 'function' ) {
+				compiled.getElements = getElements[ spec.id ];
 			}
 			if ( spec.filterBy ) {
 				compiled.filterBy = spec.filterBy;

--- a/src/apps/posts/app.json
+++ b/src/apps/posts/app.json
@@ -54,11 +54,14 @@
 					{ "id": "title", "type": "text", "label": "Title", "enableGlobalSearch": true, "enableHiding": false },
 					{ "id": "status", "type": "text", "label": "Status", "filterBy": { "operators": [ "isAny" ] } },
 					{ "id": "author", "type": "text", "label": "Author" },
-					{ "id": "date", "type": "datetime", "label": "Date" }
+					{ "id": "categories", "type": "text", "label": "Categories", "enableSorting": false, "filterBy": { "operators": [ "is" ] } },
+					{ "id": "format", "type": "text", "label": "Format", "enableSorting": false, "filterBy": { "operators": [ "is" ] } },
+					{ "id": "date", "type": "datetime", "label": "Date", "filterBy": { "operators": [ "before", "after" ] } }
 				],
 				"actions": [
 					{ "id": "edit", "label": "Edit", "isPrimary": true, "icon": "pencil", "eligibleWhen": { "status": [ "publish", "future", "draft", "pending", "private" ] } },
 					{ "id": "view", "label": "View", "icon": "external", "eligibleWhen": { "status": "publish" } },
+					{ "id": "bulk-edit", "label": "Edit", "supportsBulk": true, "icon": "edit", "eligibleWhen": { "status": [ "publish", "future", "draft", "pending", "private" ] } },
 					{ "id": "trash", "label": "Move to Trash", "isDestructive": true, "supportsBulk": true, "icon": "trash", "eligibleWhen": { "status": [ "publish", "future", "draft", "pending", "private" ] } }
 				]
 			},
@@ -105,7 +108,7 @@
 		"icon": "post"
 	},
 	"documentation": {
-		"purpose": "DataViews table over any single post type. Defaults to 20 rows per page sorted by date descending, with title / status / author / date columns. Authors filter by status, search the title field, switch between table and grid layouts, paginate, and run per-row or bulk actions (edit, view in new tab, move to trash). Used in every bundled shell for the Posts and Pages screens, and rebindable to custom post types through the `postType` config key.",
+		"purpose": "DataViews table over any single post type. Defaults to 20 rows per page sorted by date descending, with title / status / author / date columns. Authors filter by status / categories / format / date-range, switch view via the All / Mine / Published / Draft / Pending / Sticky tab strip, search the title field, switch between table and grid layouts, paginate, and run per-row or bulk actions (edit, bulk-edit, view in new tab, move to trash). Used in every bundled shell for the Posts and Pages screens, and rebindable to custom post types through the `postType` config key.",
 		"rebuilds": "posts",
 		"data": {
 			"reads": [
@@ -144,17 +147,36 @@
 						"status": "config.status||any|filter.status",
 						"context": "edit",
 						"search": "view.search",
-						"author": "filter.author"
+						"author": "filter.author|tab.mine",
+						"sticky": "tab.sticky",
+						"categories": "filter.categories",
+						"format": "filter.format",
+						"before": "filter.date.before",
+						"after": "filter.date.after"
 					}
 				},
 				{
 					"source": "postType/{config.postType}",
 					"via": "core-data",
 					"context": "edit",
-					"purpose": "Per-status totals for the status filter elements (\"Published (12)\"). One lightweight request per status value via `useEntityElementCounts`; the total comes from the X-WP-Total header. Global counts — they ignore the active search/page so they mirror wp-admin's status links.",
+					"purpose": "Per-status totals for the status filter elements (\"Published (12)\") and the view-tab strip. One lightweight request per status value via `useEntityElementCounts`; the total comes from the X-WP-Total header. Global counts — they ignore the active search/page so they mirror wp-admin's status links.",
 					"fields": [ "id" ],
 					"query": {
-						"status": "publish|draft|pending|private|future|trash",
+						"status": "publish|draft|pending|private|future|trash|any",
+						"per_page": 1,
+						"_fields": "id",
+						"context": "edit"
+					}
+				},
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Mine + Sticky view-tab counts. `author={currentUserId}` and `sticky=true` count requests (same lightweight per_page=1 / _fields=id shape) feed the Mine and Sticky tabs in the view-tab strip.",
+					"fields": [ "id" ],
+					"query": {
+						"author": "{currentUserId}",
+						"sticky": true,
 						"per_page": 1,
 						"_fields": "id",
 						"context": "edit"
@@ -162,6 +184,15 @@
 				}
 			],
 			"writes": [
+				{
+					"source": "postType/{config.postType}",
+					"via": "core-data",
+					"operation": "update",
+					"purpose": "Bulk Edit (`bulk-edit` bulk action). A DataForm-driven panel (`createBulkEditModal`) over status / author / sticky / parent / format / comment_status / categories / tags; every field is seeded to a `— No change —` sentinel and only the fields the user changed are written. On Apply, `Promise.allSettled` fans `saveEntityRecord` over the selection with the changed-field payload merged with each row id; partial failures keep the failed rows selected for retry.",
+					"invalidates": [
+						"postType/{config.postType}"
+					]
+				},
 				{
 					"source": "postType/{config.postType}",
 					"via": "core-data",
@@ -217,6 +248,16 @@
 				"id": "trash-confirm",
 				"when": "User clicked Trash row/bulk action",
 				"renders": "Modal asking to confirm the destructive action with Cancel + Move to Trash buttons."
+			},
+			{
+				"id": "view-tabs",
+				"when": "records !== null",
+				"renders": "A `ViewTabs` strip above the list — All / Mine / Published / Draft / Pending / Sticky segments, each with a live count and `aria-pressed` for the active segment. The active segment is derived from the live `view.filters`."
+			},
+			{
+				"id": "bulk-edit",
+				"when": "User clicked the Edit bulk action with a multi-row selection",
+				"renders": "A `createBulkEditModal` DataForm panel with status / author / sticky / parent / format / comment_status / categories / tags fields, each seeded to a `— No change —` sentinel. The Update button is disabled until at least one field is changed."
 			}
 		],
 		"interactions": [
@@ -259,7 +300,18 @@
 			},
 			{
 				"trigger": "Change DataViews view (search / filter / sort / layout / page / perPage)",
-				"effect": "Local `view` state updates; `queryArgs` recomputes via `useMemo` and `useEntityRecords` re-fetches."
+				"effect": "Local `view` state updates; `queryArgs` recomputes via `buildQueryArgs(view, QUERY_MAPPING, staticArgs)` (status / author / categories / format → REST params) plus a supplemental date pass (`before`/`after` operators → REST `before`/`after`); `useEntityRecords` re-fetches."
+			},
+			{
+				"trigger": "Click a view tab (All / Mine / Published / Draft / Pending / Sticky)",
+				"effect": "Rewrites `view.filters`: drops any existing status / author / sticky filter and applies the segment's filter (All clears the status scope; Mine → `author={currentUserId}`; Sticky → `sticky=true`; status segments → `status=<value>`). Resets to page 1. Date / categories / format filters are preserved."
+			},
+			{
+				"trigger": "Edit bulk action (multi-row)",
+				"effect": "Opens the bulk-edit DataForm modal; on Update only the changed fields are written via `Promise.allSettled(saveEntityRecord)` across the selection. `bulkToRecord` maps the form values to REST (sticky string → boolean, author/parent → int, categories/tags CSV → id array). Partial failures keep failed rows selected.",
+				"guards": [
+					"selection.length >= 1"
+				]
 			}
 		],
 		"a11y": {
@@ -305,8 +357,16 @@
 				"purpose": "Destructive primary button in trash-confirm modal — WPDS 0.12 has no `tone=\"critical\"`."
 			},
 			{
-				"import": "@wordpress/icons#pencil, external, trash",
-				"purpose": "Row action icons."
+				"import": "@wordpress/icons#pencil, external, edit, trash",
+				"purpose": "Row + bulk action icons (edit is aliased to pencil in the engine icon table)."
+			},
+			{
+				"import": "_shared/dataviews/ViewTabs",
+				"purpose": "The All / Mine / Published / Draft / Pending / Sticky view-tab strip. WPDS `Button` segments under the hood (`@wordpress/ui`)."
+			},
+			{
+				"import": "_shared/dataviews/BulkEditModal",
+				"purpose": "The Bulk Edit DataForm panel host (`createBulkEditModal` + `fieldsWithNoChange`). Renders a `@wordpress/dataviews/wp` `DataForm` + WPDS `Button`/`Stack`/`Text` inside DataViews' own action modal."
 			}
 		]
 	}

--- a/src/apps/posts/app.json
+++ b/src/apps/posts/app.json
@@ -54,8 +54,8 @@
 					{ "id": "title", "type": "text", "label": "Title", "enableGlobalSearch": true, "enableHiding": false },
 					{ "id": "status", "type": "text", "label": "Status", "filterBy": { "operators": [ "isAny" ] } },
 					{ "id": "author", "type": "text", "label": "Author" },
-					{ "id": "categories", "type": "text", "label": "Categories", "enableSorting": false, "filterBy": { "operators": [ "is" ] } },
-					{ "id": "format", "type": "text", "label": "Format", "enableSorting": false, "filterBy": { "operators": [ "is" ] } },
+					{ "id": "categories", "type": "text", "label": "Categories", "enableSorting": false, "enableHiding": false, "filterBy": { "operators": [ "is" ] } },
+					{ "id": "format", "type": "text", "label": "Format", "enableSorting": false, "enableHiding": false, "filterBy": { "operators": [ "is" ] } },
 					{ "id": "date", "type": "datetime", "label": "Date", "filterBy": { "operators": [ "before", "after" ] } }
 				],
 				"actions": [
@@ -172,7 +172,7 @@
 					"source": "postType/{config.postType}",
 					"via": "core-data",
 					"context": "edit",
-					"purpose": "Mine + Sticky view-tab counts. `author={currentUserId}` and `sticky=true` count requests (same lightweight per_page=1 / _fields=id shape) feed the Mine and Sticky tabs in the view-tab strip.",
+					"purpose": "Mine + Sticky view-tab counts. `author={currentUserId}` and `sticky=true` count requests (same lightweight per_page=1 / _fields=id shape) feed the Mine and Sticky tabs in the view-tab strip. The Sticky count is only fetched when `config.postType === 'post'` (sticky is a `post`-only REST param; otherwise the request is skipped and the Sticky tab is omitted).",
 					"fields": [ "id" ],
 					"query": {
 						"author": "{currentUserId}",
@@ -181,6 +181,19 @@
 						"_fields": "id",
 						"context": "edit"
 					}
+				},
+				{
+					"source": "taxonomy/category",
+					"via": "core-data",
+					"context": "edit",
+					"purpose": "Category options for the `categories` filter. DataViews resolves the field's `getElements` lazily when the filter opens — one `resolveSelect(getEntityRecords)` over the `category` taxonomy (per_page=100, ordered by name, `_fields=id,name`), mapped to `{ value: id, label: name }` and cached per taxonomy. Fetched only when `config.postType === 'post'`.",
+					"fields": [ "id", "name" ],
+					"query": {
+						"per_page": 100,
+						"orderby": "name",
+						"order": "asc",
+						"_fields": "id,name"
+					}
 				}
 			],
 			"writes": [
@@ -188,7 +201,7 @@
 					"source": "postType/{config.postType}",
 					"via": "core-data",
 					"operation": "update",
-					"purpose": "Bulk Edit (`bulk-edit` bulk action). A DataForm-driven panel (`createBulkEditModal`) over status / author / sticky / parent / format / comment_status / categories / tags; every field is seeded to a `— No change —` sentinel and only the fields the user changed are written. On Apply, `Promise.allSettled` fans `saveEntityRecord` over the selection with the changed-field payload merged with each row id; partial failures keep the failed rows selected for retry.",
+					"purpose": "Bulk Edit (`bulk-edit` bulk action). A DataForm-driven panel (`createBulkEditModal`) over status / author / sticky / parent / format / comment_status / categories / tags; every field is seeded to a `— No change —` sentinel and only the fields the user changed are written. The post-only fields (sticky / format / categories / tags) are omitted when `config.postType !== 'post'` since their REST params aren't registered there. A free-text field (author / parent / categories / tags) that is focused then cleared is treated as no-change (`bulkToRecord` drops empty strings) so blanking a touched field never writes `author=undefined` or removes a post's parent. On Apply, `Promise.allSettled` fans `saveEntityRecord` over the selection with the changed-field payload merged with each row id; partial failures keep the failed rows selected for retry.",
 					"invalidates": [
 						"postType/{config.postType}"
 					]
@@ -252,7 +265,7 @@
 			{
 				"id": "view-tabs",
 				"when": "records !== null",
-				"renders": "A `ViewTabs` strip above the list — All / Mine / Published / Draft / Pending / Sticky segments, each with a live count and `aria-pressed` for the active segment. The active segment is derived from the live `view.filters`."
+				"renders": "A `ViewTabs` strip above the list — All / Mine / Published / Draft / Pending / Sticky segments, each with a live count and `aria-pressed` for the active segment. The Sticky segment is only emitted when `config.postType === 'post'` (sticky is a `post`-only REST param). The active segment is derived from the live `view.filters`."
 			},
 			{
 				"id": "bulk-edit",
@@ -300,7 +313,7 @@
 			},
 			{
 				"trigger": "Change DataViews view (search / filter / sort / layout / page / perPage)",
-				"effect": "Local `view` state updates; `queryArgs` recomputes via `buildQueryArgs(view, QUERY_MAPPING, staticArgs)` (status / author / categories / format → REST params) plus a supplemental date pass (`before`/`after` operators → REST `before`/`after`); `useEntityRecords` re-fetches."
+				"effect": "Local `view` state updates; `queryArgs` recomputes via `buildQueryArgs(view, QUERY_MAPPING, staticArgs)` (status / author / categories / format → REST params) plus a supplemental date pass (`before`/`after` operators → REST `before`/`after`); `useEntityRecords` re-fetches. The `categories` filter resolves its options lazily (`getElements` → category terms) and `format` from a static element list; both are wired only for `config.postType === 'post'`. The date filter is a one-sided date bound (apply `before X` OR `after Y`, not both at once — DataViews holds one filter per field), not a two-ended range."
 			},
 			{
 				"trigger": "Click a view tab (All / Mine / Published / Draft / Pending / Sticky)",

--- a/src/apps/posts/app.md
+++ b/src/apps/posts/app.md
@@ -87,6 +87,7 @@ A `ViewTabs` strip ([`_shared/dataviews/ViewTabs.js`](../_shared/dataviews/ViewT
 The `bulk-edit` action (`supportsBulk: true`, declared in `app.json`) attaches the shared `createBulkEditModal` ([`_shared/dataviews/BulkEditModal.js`](../_shared/dataviews/BulkEditModal.js)) via `buildActions(..., { modals: { 'bulk-edit': … } })`. The modal renders a DataForm over **status / author / sticky / parent / format / comment_status / categories / tags**.
 
 - Every field is seeded to the `NO_CHANGE` sentinel; `fieldsWithNoChange` injects the `— No change —` option for the four `elements`-backed selects (status / sticky / format / comment_status). The non-elements fields (author / parent integers, categories / tags CSV-of-ids text) supply a `getValue` that maps the sentinel to an empty input so the literal sentinel never renders.
+- **Touch-then-clear is no-change.** Because the sentinel maps to `''` for display, focusing and then blanking a free-text field stores `''` (not the sentinel) — which `computeBulkPayload` would treat as a real edit, writing `author=undefined` or, worse, `parent=0` (removing a post's parent). `bulkToRecord` defends against this: it drops empty-string `author` / `parent` / `categories` / `tags` keys *before* coercion, so only a non-empty value counts as a change.
 - On Apply, the modal's `computeBulkPayload` reduces the form to only the changed fields, and a `Promise.allSettled` fans `saveEntityRecord` over the selection with `{ id, ...toRecord(payload) }`. `bulkToRecord` coerces the form values to REST shapes — sticky `'true'`/`'false'` → boolean, author/parent → int, categories/tags CSV → positive-int array. Partial failures keep the failed rows selected and the staged values intact for a retry.
 - `onApplied` invalidates the list + status-count resolutions so the table and the tab/filter counts refresh.
 
@@ -94,7 +95,26 @@ Quick Edit (single-row inline) is still not wired — Bulk Edit is the first inl
 
 ### Column filters (#132)
 
-`categories` and `format` are declared as filterable text fields (`filterBy.operators: ['is']`) and wired through the `QUERY_MAPPING` to the REST `categories` / `format` params; `date` declares `before` / `after` operators wired through `applyDateFilters` to REST's `before` / `after` ISO params. These columns are filter-only by default (not in `defaultView.fields`), mirroring wp-admin's filter dropdowns rather than always-on columns. Author filtering rides the existing `author` mapping (also used by the Mine tab).
+`categories` and `format` are declared as filterable text fields (`filterBy.operators: ['is']`) and wired through the `QUERY_MAPPING` to the REST `categories` / `format` params; `date` declares `before` / `after` operators wired through `applyDateFilters` to REST's `before` / `after` ISO params. These columns are filter-only — they carry `enableHiding: false` so a user can't toggle them on as (blank) columns — mirroring wp-admin's filter dropdowns rather than always-on columns. Author filtering rides the existing `author` mapping (also used by the Mine tab).
+
+A categorical (`is`) filter renders its dropdown from the field's `elements` (static) or `getElements` (async). Those two fields ship neither in `app.json`, so `index.js` supplies them at compile time via the shared `buildFields` harness:
+
+- **`format`** — a finite known set. `elementFallbacks: { format: elementsFromLabels( FORMAT_LABELS ) }` feeds the dropdown a static option list.
+- **`categories`** — dynamic. `getElements: { categories: makeTaxonomyElements( 'category' ) }` hands DataViews an async provider that resolves the `category` taxonomy through core-data (`resolveSelect(coreStore).getEntityRecords('taxonomy', 'category', …)`, never a raw `fetch`) and maps the terms to `{ value: id, label: name }`, cached per taxonomy so re-opening the filter doesn't re-resolve. `buildFields` grew a `getElements` passthrough (id → async provider) for this — shared, pinned by `tests/runtime/dataviews-shared.test.mjs`.
+
+Both option sets are wired **only when `config.postType === 'post'`** — `format` / `categories` are `post`-only REST params, so on the Pages screen the dropdowns would have nothing to resolve. (See "Post-type gating" below.)
+
+The `date` filter is a **one-sided date bound**, not a two-ended range: DataViews holds one filter per field, so a user applies `before X` *or* `after Y`, not both simultaneously. `applyDateFilters` maps whichever operator is active to the matching REST param.
+
+### Post-type gating (Pages / CPTs)
+
+PostsApp is rebindable to any post type via `config.postType`, but `sticky` / `format` / `categories` / `tags` are only registered REST params for post types that support those features (the default `post`, not `page`). WP REST silently *ignores* unregistered query params rather than erroring, which would make those affordances misleading no-ops on the Pages list:
+
+- The **Sticky view-tab** segment is only pushed when `postType === 'post'`, and its count query passes an empty value set (so no `?sticky=true` request that would otherwise count *all* pages).
+- The post-only **bulk-edit fields** (`sticky` / `format` / `categories` / `tags`) are filtered out of both `buildBulkEditFields( postType )` and `buildBulkEditForm( postType )` for non-`post` post types.
+- The **`format` static / `categories` dynamic filter options** are only wired for `postType === 'post'`.
+
+This mirrors how classic wp-admin hides Sticky / Format on the Pages list. The gate is `postType === 'post'` rather than a live post-type-supports lookup because `window.wpAdminShell` doesn't expose per-post-type supports today; a richer capability check can swap in here later without touching the call sites.
 
 ## Rebuild guide
 
@@ -120,12 +140,12 @@ Two patterns to preserve:
 Parity gaps versus `docs/screens/posts.md` not surfaced in the v2 app:
 
 - Status **counts** surface both on the status filter elements (`Published (12)`, `Draft (3)`) AND on the **view-tab strip** (`All | Mine | Published | Draft | Pending | Sticky`) added in wave 2 (#111) — one lightweight `per_page=1&_fields=id` request per value, read off the `X-WP-Total` header, global (search/page-independent) to mirror wp-admin's status links. Remaining gap: no Scheduled / Trash tabs in the strip (Trash has its own variant + screen), and "Mine" is not auto-scoped for low-privilege users.
-- Author / date / category / format **filters are now wired** (#132) — `categories` / `format` as `is`-filter columns, `date` as a `before`/`after` range, `author` via the Mine tab + mapping. wp-admin's per-axis *dropdown* chrome (month picker, category select) is approximated through DataViews' generic filter UI rather than the classic bespoke dropdowns; tag filtering and the months-list affordance are not yet surfaced.
+- Author / date / category / format **filters are now wired** (#132) — `categories` (dynamic taxonomy options via `getElements`) / `format` (static option list) as `is`-filter columns, `date` as a one-sided `before`/`after` bound (one filter per field — not a two-ended range), `author` via the Mine tab + mapping. `categories` / `format` options are only wired for `postType === 'post'`. wp-admin's per-axis *dropdown* chrome (month picker, category select) is approximated through DataViews' generic filter UI rather than the classic bespoke dropdowns; tag filtering and the months-list affordance are not yet surfaced.
 - Trash view + Restore + Delete Permanently are now wired (trash variant + the `wp-admin-default` Posts → Trash screen). Remaining gap: no **Empty Trash** bulk button, and restore lands on draft rather than the pre-trash status (REST limitation).
 - No undo snackbar after trash. We emit a plain success notice; wp-admin offers "Move to trash · Undo".
 - No keyboard shortcuts (J/K navigation, X to select, T to trash). DataViews has no built-in shortcut layer.
 - No hierarchical pages tree. The Pages screen in wp-admin indents child pages under parents; DataViews renders a flat list ordered by `menu_order` and date.
 - No grid-card layout polish (cover image, excerpt). DataViews ships a grid variant but the v2 fields config doesn't emit a thumbnail / excerpt-aware card template.
 - No "Quick Edit" inline form. wp-admin's per-row toggle for status / author / sticky / template is not wired up (Bulk Edit covers the multi-row case).
-- **Bulk Edit is now wired** (#107) — a DataForm panel over status / author / sticky / parent / format / comment_status / categories / tags, writing only the changed fields. Gaps versus classic Bulk Edit: no title/slug/date/password fields, and the author/parent/categories/tags inputs take raw IDs rather than autocomplete pickers.
+- **Bulk Edit is now wired** (#107) — a DataForm panel over status / author / sticky / parent / format / comment_status / categories / tags, writing only the changed fields (post-only fields are dropped for non-`post` post types). Gaps versus classic Bulk Edit: no title/slug/date/password fields, and the author/parent/categories/tags inputs take raw IDs rather than autocomplete pickers.
 - ARIA + screen-reader polish: DataViews ships its own announcements; the v2 app doesn't layer on the wp-admin-specific live-region copy.

--- a/src/apps/posts/app.md
+++ b/src/apps/posts/app.md
@@ -12,7 +12,7 @@ Four pieces of state drive the app:
 
 1. **`dataView`** — pulled via `useDataView(screenId)`. Holds the JSON spec for fields, default view, default layouts, and actions. The baseline ships in `app.json#dataView` and reaches the resolved cascade via `inject_app_baselines`. Site authors and plugin code override via admin.json `settings.dataViews.postType.post.<variant|_default>` or the `wp_admin_shell_data_view_config_postType_post[_<variant>]` filter. **Field renderers and action callbacks live in the React layer** — the spec only carries data; `buildFieldRenderers()` and `buildActions()` in `index.js` map ids to behavior.
 2. **`view`** — a local `useState` mirroring the DataViews controlled shape, seeded from `dataView.defaultView`. Holds search string, active filters, page, perPage, sort, fields, and layout. Owned by the app; DataViews calls `onChangeView(next)` whenever the user changes anything.
-3. **`queryArgs`** — derived from `view + config.status` via `useMemo`. Maps DataViews concepts (filter operators, sort direction) to REST query arguments. The `_embed=author` arg lets one round trip cover the author column without a second request per row.
+3. **`queryArgs`** — derived from `view + config.status` via `useMemo`. The shared `buildQueryArgs(view, QUERY_MAPPING, staticArgs)` ([`_shared/dataviews/buildQueryArgs.mjs`](../_shared/dataviews/buildQueryArgs.mjs)) translates the declarative `status` / `author` / `categories` / `format` filter mapping into REST params; a small supplemental pass (`applyDateFilters`) wires the date `before` / `after` operators that `buildQueryArgs` doesn't speak, and the Sticky tab's boolean `sticky` param is applied off the raw filters. The `_embed=author` arg lets one round trip cover the author column without a second request per row.
 4. **`records / isResolving / totalItems / totalPages`** — pulled from `useEntityRecords('postType', config.postType, queryArgs)`. Reading `totalItems` + `totalPages` keeps DataViews' pagination footer accurate without a separate count call.
 
 `data` is a `useMemo` projection of `records` into the row shape DataViews wants (`{ id, title, status, date, author, link, rawRecord }`). The original record is kept on `rawRecord` so future row actions can read fields the projection doesn't surface.
@@ -69,6 +69,33 @@ Two adjacent paths remain available for richer cases:
 
 Action callback copy (modal text inside `RenderModal`, inline button labels) lives as JSX `__()` literals and translates normally — only the spec-supplied DataViews `label` field needed the recipe.
 
+## View tabs, Bulk Edit, and column filters (wave 2)
+
+Three parity affordances landed together, all driven by the shared `_shared/dataviews/*` scaffolding (no per-app re-copy):
+
+### View-tab strip (#111)
+
+A `ViewTabs` strip ([`_shared/dataviews/ViewTabs.js`](../_shared/dataviews/ViewTabs.js)) renders above the list with **All / Mine / Published / Draft / Pending / Sticky** segments. Each segment carries a `filter` (`{ field, operator, value }`) — the `view.filters` entry the tab applies — and a live count.
+
+- **Counts** come from `useEntityElementCounts`, fanned across the REST fields the tabs span: one call for the status values, one keyed `status=any` (the All total), one `author={currentUserId}` (Mine), one `sticky=true` (Sticky). They are merged into a single `{ filterValue: count }` map keyed exactly the way `mergeSegmentCounts` looks them up (the segment's `filter.value`). Counts resolve asynchronously — a segment shows its plain label until its total lands (no "0" flash).
+- **Active segment** is *derived from the live `view.filters`*, not a separate `useState` — author/sticky filters take precedence over a status filter so Mine/Sticky stay highlighted, falling back to the matching status segment, else `all`. This keeps the strip in sync with deep-linked or default filters.
+- **Clicking** a tab rewrites `view.filters`: it drops any existing status/author/sticky filter, applies the segment's filter (All clears the status scope entirely rather than pinning a `status=any` chip), and resets to page 1. Date / categories / format filters are preserved.
+- **"Mine" is gated on `window.wpAdminShell?.userId`** — absent (e.g. an unexpected anon context) and the segment is omitted. The classic "auto-scope Mine for users without `edit_others_posts`" behavior is still not replicated (a separate parity gap).
+
+### Bulk Edit (#107)
+
+The `bulk-edit` action (`supportsBulk: true`, declared in `app.json`) attaches the shared `createBulkEditModal` ([`_shared/dataviews/BulkEditModal.js`](../_shared/dataviews/BulkEditModal.js)) via `buildActions(..., { modals: { 'bulk-edit': … } })`. The modal renders a DataForm over **status / author / sticky / parent / format / comment_status / categories / tags**.
+
+- Every field is seeded to the `NO_CHANGE` sentinel; `fieldsWithNoChange` injects the `— No change —` option for the four `elements`-backed selects (status / sticky / format / comment_status). The non-elements fields (author / parent integers, categories / tags CSV-of-ids text) supply a `getValue` that maps the sentinel to an empty input so the literal sentinel never renders.
+- On Apply, the modal's `computeBulkPayload` reduces the form to only the changed fields, and a `Promise.allSettled` fans `saveEntityRecord` over the selection with `{ id, ...toRecord(payload) }`. `bulkToRecord` coerces the form values to REST shapes — sticky `'true'`/`'false'` → boolean, author/parent → int, categories/tags CSV → positive-int array. Partial failures keep the failed rows selected and the staged values intact for a retry.
+- `onApplied` invalidates the list + status-count resolutions so the table and the tab/filter counts refresh.
+
+Quick Edit (single-row inline) is still not wired — Bulk Edit is the first inline-editing affordance.
+
+### Column filters (#132)
+
+`categories` and `format` are declared as filterable text fields (`filterBy.operators: ['is']`) and wired through the `QUERY_MAPPING` to the REST `categories` / `format` params; `date` declares `before` / `after` operators wired through `applyDateFilters` to REST's `before` / `after` ISO params. These columns are filter-only by default (not in `defaultView.fields`), mirroring wp-admin's filter dropdowns rather than always-on columns. Author filtering rides the existing `author` mapping (also used by the Mine tab).
+
 ## Rebuild guide
 
 A rebuild on a non-WPDS / non-DataViews stack needs to provide:
@@ -85,20 +112,20 @@ Two patterns to preserve:
 
 ## Known limitations
 
-- No inline edit (DataViews supports it; not wired up here).
+- No inline (per-row) Quick Edit — DataViews supports it but only **Bulk Edit** (multi-row, modal) is wired today.
 - Status filter is a single-select today. The `filterBy.operators: ['isAny']` declaration exists but the queryArgs mapper only handles the `isAny`/`is` operators against the `status` field.
 - Site-editor post types (`wp_template`, `wp_block`, `wp_navigation`) navigate through `editHref()` but `editHref()` only special-cases `page`. Their URL-encoded slug-shaped IDs would need a new edit pattern + decode step; deferred until those screens land.
 - The `trash` variant adds `restore` and `delete-permanent` actions (status-gated to trashed rows). `restore` calls `saveEntityRecord(..., { status: 'draft' })` — REST exposes no pre-trash status meta, so a restored post lands on draft rather than its previous status (accepted divergence; see `docs/parity/posts.md` blocker #4). `delete-permanent` confirms, then calls `deleteEntityRecord(..., { force: true })`. Surface the variant via a screen with `dataViewRef: "postType/post/trash"` (the `wp-admin-default` shell ships a Posts → Trash screen for this).
 
 Parity gaps versus `docs/screens/posts.md` not surfaced in the v2 app:
 
-- Status **counts** now surface on the status filter elements (`Published (12)`, `Draft (3)`) via the shared `useEntityElementCounts` hook — one lightweight `per_page=1&_fields=id` request per status value, read back off the `X-WP-Total` header, global (search/page-independent) to mirror wp-admin's status links. Still rendered as filter-dropdown options, **not** the classic standalone subsubsub tab strip (`All (N) | Mine (N) | …`), and there is no `Mine` count.
-- No author / date / taxonomy column filters. wp-admin offers a separate dropdown per axis; the v2 app exposes only the status filter.
+- Status **counts** surface both on the status filter elements (`Published (12)`, `Draft (3)`) AND on the **view-tab strip** (`All | Mine | Published | Draft | Pending | Sticky`) added in wave 2 (#111) — one lightweight `per_page=1&_fields=id` request per value, read off the `X-WP-Total` header, global (search/page-independent) to mirror wp-admin's status links. Remaining gap: no Scheduled / Trash tabs in the strip (Trash has its own variant + screen), and "Mine" is not auto-scoped for low-privilege users.
+- Author / date / category / format **filters are now wired** (#132) — `categories` / `format` as `is`-filter columns, `date` as a `before`/`after` range, `author` via the Mine tab + mapping. wp-admin's per-axis *dropdown* chrome (month picker, category select) is approximated through DataViews' generic filter UI rather than the classic bespoke dropdowns; tag filtering and the months-list affordance are not yet surfaced.
 - Trash view + Restore + Delete Permanently are now wired (trash variant + the `wp-admin-default` Posts → Trash screen). Remaining gap: no **Empty Trash** bulk button, and restore lands on draft rather than the pre-trash status (REST limitation).
 - No undo snackbar after trash. We emit a plain success notice; wp-admin offers "Move to trash · Undo".
 - No keyboard shortcuts (J/K navigation, X to select, T to trash). DataViews has no built-in shortcut layer.
 - No hierarchical pages tree. The Pages screen in wp-admin indents child pages under parents; DataViews renders a flat list ordered by `menu_order` and date.
 - No grid-card layout polish (cover image, excerpt). DataViews ships a grid variant but the v2 fields config doesn't emit a thumbnail / excerpt-aware card template.
-- No "Quick Edit" inline form. wp-admin's row toggle for status / author / sticky / template is not wired up.
-- No bulk-edit row picker (status / author / sticky / category / tag).
+- No "Quick Edit" inline form. wp-admin's per-row toggle for status / author / sticky / template is not wired up (Bulk Edit covers the multi-row case).
+- **Bulk Edit is now wired** (#107) — a DataForm panel over status / author / sticky / parent / format / comment_status / categories / tags, writing only the changed fields. Gaps versus classic Bulk Edit: no title/slug/date/password fields, and the author/parent/categories/tags inputs take raw IDs rather than autocomplete pickers.
 - ARIA + screen-reader polish: DataViews ships its own announcements; the v2 app doesn't layer on the wp-admin-specific live-region copy.

--- a/src/apps/posts/index.js
+++ b/src/apps/posts/index.js
@@ -2,7 +2,7 @@ import '../_shared/app.css';
 import { Spinner } from '@wordpress/components';
 import { useMemo, useRef } from '@wordpress/element';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, resolveSelect } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 import { DataViews } from '@wordpress/dataviews/wp';
 import { Button, Text } from '@wordpress/ui';
@@ -149,6 +149,40 @@ function applyDateFilters( args, filters ) {
 	return args;
 }
 
+// Per-taxonomy element cache for the categorical filter `getElements` providers.
+// DataViews calls `getElements()` each time a filter opens; without a cache that
+// would re-fetch the taxonomy every open. `resolveSelect` already memoizes the
+// underlying core-data resolution, but caching the mapped `{ value, label }`
+// array avoids re-decoding on every call too.
+const taxonomyElementsCache = new Map();
+
+/**
+ * Build an async DataViews `getElements` provider for a taxonomy filter. Fetches
+ * the terms via core-data (`resolveSelect`, never raw `fetch`) and maps them to
+ * `{ value: termId, label: name }`. The result is cached per taxonomy so
+ * re-opening the filter doesn't re-resolve.
+ * @param {string} taxonomy Taxonomy rest base, e.g. `'category'`.
+ * @return {Function} `async () => [ { value, label } ]`.
+ */
+function makeTaxonomyElements( taxonomy ) {
+	return async () => {
+		if ( taxonomyElementsCache.has( taxonomy ) ) {
+			return taxonomyElementsCache.get( taxonomy );
+		}
+		const terms = await resolveSelect( coreStore ).getEntityRecords(
+			'taxonomy',
+			taxonomy,
+			{ per_page: 100, orderby: 'name', order: 'asc', _fields: 'id,name' }
+		);
+		const elements = ( terms ?? [] ).map( ( term ) => ( {
+			value: term.id,
+			label: decodeEntities( term.name ),
+		} ) );
+		taxonomyElementsCache.set( taxonomy, elements );
+		return elements;
+	};
+}
+
 /**
  * Field id → render callback. View-config declares the *shape*; the React
  * layer supplies the row renderer. Unknown ids fall through to DataViews'
@@ -172,6 +206,14 @@ function buildFieldRenderers( postType ) {
 	};
 }
 
+// Bulk-edit fields whose REST params are only registered for post types that
+// support those features — `sticky` / `format` need `post`-format/sticky
+// support, `categories` / `tags` need those taxonomies attached. Default
+// (non-`post`) post types like `page` don't register them, so WP REST silently
+// ignores the params: gate these fields on `post` to avoid presenting no-op
+// inputs, mirroring how wp-admin omits Sticky/Format on the Pages list.
+const POST_ONLY_BULK_FIELDS = [ 'sticky', 'format', 'categories', 'tags' ];
+
 /**
  * Bulk-edit DataForm fields. Every field is seeded to the `NO_CHANGE` sentinel
  * by `createBulkEditModal`; `fieldsWithNoChange` injects the matching
@@ -179,8 +221,14 @@ function buildFieldRenderers( postType ) {
  * fields (author / parent / categories / tags) map the sentinel to an empty
  * input via `getValue` so the literal sentinel string never renders, and
  * `computeBulkPayload` drops them unless the user types a value.
+ *
+ * The post-only fields (`sticky` / `format` / `categories` / `tags`) are
+ * omitted entirely for non-`post` post types — their REST params aren't
+ * registered there, so editing them would be a silent no-op.
+ * @param {string} postType Active post type id from app config.
  */
-function buildBulkEditFields() {
+function buildBulkEditFields( postType ) {
+	const isPost = postType === 'post';
 	const sentinelToText =
 		( id ) =>
 		( { item } ) =>
@@ -243,26 +291,36 @@ function buildBulkEditFields() {
 			label: __( 'Tags (comma-separated IDs)', 'wp-admin-shell' ),
 			getValue: sentinelToText( 'tags' ),
 		},
-	];
+	].filter(
+		( field ) => isPost || ! POST_ONLY_BULK_FIELDS.includes( field.id )
+	);
 
 	return fieldsWithNoChange( base, {
 		ids: [ 'status', 'sticky', 'format', 'comment_status' ],
 	} );
 }
 
-const BULK_EDIT_FORM = {
-	type: 'regular',
-	fields: [
-		'status',
-		'author',
-		'sticky',
-		'parent',
-		'format',
-		'comment_status',
-		'categories',
-		'tags',
-	],
-};
+/**
+ * Bulk-edit DataForm field order. Post-only fields are dropped for non-`post`
+ * post types so the form doesn't reference fields `buildBulkEditFields` omits.
+ * @param {string} postType Active post type id from app config.
+ */
+function buildBulkEditForm( postType ) {
+	const isPost = postType === 'post';
+	return {
+		type: 'regular',
+		fields: [
+			'status',
+			'author',
+			'sticky',
+			'parent',
+			'format',
+			'comment_status',
+			'categories',
+			'tags',
+		].filter( ( id ) => isPost || ! POST_ONLY_BULK_FIELDS.includes( id ) ),
+	};
+}
 
 /**
  * Parse a comma-separated id list into an array of positive integers.
@@ -286,11 +344,26 @@ function parseIdList( value ) {
  * Translate the changed bulk-edit payload into a REST body. Only fields the
  * user actually changed reach here (`computeBulkPayload` already dropped the
  * sentinel-valued ones), so each branch fires only when present.
+ *
+ * The free-text fields (author / parent / categories / tags) map the
+ * `NO_CHANGE` sentinel to an empty input for display (`getValue` in
+ * `buildBulkEditFields`). Focusing then clearing such a field stores `''`
+ * rather than the sentinel, so `computeBulkPayload` would treat the blank as a
+ * real edit — writing `author=undefined` or, worse, `parent=0` (which *removes*
+ * a post's parent). Treat an empty string for these fields as no-change here so
+ * only a non-empty value counts: drop the key before coercing.
  * @param {Object} payload Changed-field payload, keyed by field id.
  * @return {Object} REST body (without `id`, which the modal merges in).
  */
 function bulkToRecord( payload ) {
 	const body = { ...payload };
+	// Blank free-text fields mean "leave unchanged" — strip them before any
+	// coercion so a cleared-but-touched field can't write a spurious value.
+	for ( const id of [ 'author', 'parent', 'categories', 'tags' ] ) {
+		if ( id in body && ( body[ id ] === '' || body[ id ] === undefined ) ) {
+			delete body[ id ];
+		}
+	}
 	if ( 'sticky' in body ) {
 		body.sticky = body.sticky === 'true' || body.sticky === true;
 	}
@@ -362,11 +435,13 @@ export default function PostsApp( { config } ) {
 		'author',
 		currentUserId ? [ currentUserId ] : []
 	);
+	// Sticky is `post`-only — pass no values for other post types so the hook
+	// short-circuits (no `?sticky=true` request that would count all rows).
 	const stickyCount = useEntityElementCounts(
 		'postType',
 		postType,
 		'sticky',
-		[ true ]
+		postType === 'post' ? [ true ] : []
 	);
 
 	// Total across all statuses for the "All" tab — one extra count keyed by the
@@ -410,10 +485,23 @@ export default function PostsApp( { config } ) {
 				renderers: buildFieldRenderers( postType ),
 				elementFallbacks: {
 					status: elementsFromLabels( STATUS_LABELS ),
+					// `format` is a finite known set — feed a static element list
+					// so the categorical filter dropdown has options. (`post`
+					// only; `format` isn't a registered REST param elsewhere.)
+					...( postType === 'post'
+						? { format: elementsFromLabels( FORMAT_LABELS ) }
+						: {} ),
 				},
 				elementCounts: {
 					status: statusCounts,
 				},
+				// `categories` options are dynamic — DataViews resolves them
+				// lazily via `getElements` (fetching the category terms through
+				// core-data). `post` only, mirroring the registered taxonomy.
+				getElements:
+					postType === 'post'
+						? { categories: makeTaxonomyElements( 'category' ) }
+						: {},
 			} ),
 		[ dataViewConfig, postType, statusCounts ]
 	);
@@ -438,8 +526,8 @@ export default function PostsApp( { config } ) {
 
 		const bulkEditModal = createBulkEditModal( {
 			entity: [ 'postType', postType ],
-			fields: buildBulkEditFields(),
-			form: BULK_EDIT_FORM,
+			fields: buildBulkEditFields( postType ),
+			form: buildBulkEditForm( postType ),
 			toRecord: bulkToRecord,
 			messages: {
 				applyLabel: __( 'Update', 'wp-admin-shell' ),
@@ -686,15 +774,21 @@ export default function PostsApp( { config } ) {
 				id: 'pending',
 				label: STATUS_LABELS.pending,
 				filter: { field: 'status', operator: 'is', value: 'pending' },
-			},
-			{
+			}
+		);
+		// Sticky is a `post`-only REST param — `?sticky=true` is silently
+		// ignored on post types that don't register it (e.g. `page`), so the
+		// count would return ALL rows and the tab wouldn't filter. Omit it for
+		// non-`post` post types, mirroring wp-admin's Pages list.
+		if ( postType === 'post' ) {
+			segments.push( {
 				id: 'sticky',
 				label: __( 'Sticky', 'wp-admin-shell' ),
 				filter: { field: 'sticky', operator: 'is', value: true },
-			}
-		);
+			} );
+		}
 		return segments;
-	}, [ currentUserId ] );
+	}, [ currentUserId, postType ] );
 
 	// Merge the multi-source counts into one { filterValue: count } map keyed
 	// the way ViewTabs/mergeSegmentCounts looks them up.

--- a/src/apps/posts/index.js
+++ b/src/apps/posts/index.js
@@ -214,6 +214,14 @@ function buildFieldRenderers( postType ) {
 // inputs, mirroring how wp-admin omits Sticky/Format on the Pages list.
 const POST_ONLY_BULK_FIELDS = [ 'sticky', 'format', 'categories', 'tags' ];
 
+// Filter/column field specs whose categorical options only populate for `post`:
+// `categories` resolves the category taxonomy and `format` the post-format set.
+// On a non-`post` binding (the Pages screen reuses PostsApp) these field specs
+// would otherwise surface in the DataViews filter UI with empty option sets, so
+// drop the specs entirely — mirroring how POST_ONLY_BULK_FIELDS gates the
+// bulk-edit form.
+const POST_ONLY_FILTER_FIELDS = [ 'categories', 'format' ];
+
 /**
  * Bulk-edit DataForm fields. Every field is seeded to the `NO_CHANGE` sentinel
  * by `createBulkEditModal`; `fieldsWithNoChange` injects the matching
@@ -478,33 +486,40 @@ export default function PostsApp( { config } ) {
 		} ) );
 	}, [ records ] );
 
-	const fields = useMemo(
-		() =>
-			buildFields( dataViewConfig.fields, {
-				labels: FIELD_LABELS,
-				renderers: buildFieldRenderers( postType ),
-				elementFallbacks: {
-					status: elementsFromLabels( STATUS_LABELS ),
-					// `format` is a finite known set — feed a static element list
-					// so the categorical filter dropdown has options. (`post`
-					// only; `format` isn't a registered REST param elsewhere.)
-					...( postType === 'post'
-						? { format: elementsFromLabels( FORMAT_LABELS ) }
-						: {} ),
-				},
-				elementCounts: {
-					status: statusCounts,
-				},
-				// `categories` options are dynamic — DataViews resolves them
-				// lazily via `getElements` (fetching the category terms through
-				// core-data). `post` only, mirroring the registered taxonomy.
-				getElements:
-					postType === 'post'
-						? { categories: makeTaxonomyElements( 'category' ) }
-						: {},
-			} ),
-		[ dataViewConfig, postType, statusCounts ]
-	);
+	const fields = useMemo( () => {
+		// On a non-`post` binding the `categories`/`format` filters carry no
+		// resolvable options, so drop their field specs rather than surface
+		// empty filter dropdowns (mirrors the POST_ONLY_BULK_FIELDS gate).
+		const fieldSpecs =
+			postType === 'post'
+				? dataViewConfig.fields
+				: dataViewConfig.fields.filter(
+						( f ) => ! POST_ONLY_FILTER_FIELDS.includes( f.id )
+				  );
+		return buildFields( fieldSpecs, {
+			labels: FIELD_LABELS,
+			renderers: buildFieldRenderers( postType ),
+			elementFallbacks: {
+				status: elementsFromLabels( STATUS_LABELS ),
+				// `format` is a finite known set — feed a static element list
+				// so the categorical filter dropdown has options. (`post`
+				// only; `format` isn't a registered REST param elsewhere.)
+				...( postType === 'post'
+					? { format: elementsFromLabels( FORMAT_LABELS ) }
+					: {} ),
+			},
+			elementCounts: {
+				status: statusCounts,
+			},
+			// `categories` options are dynamic — DataViews resolves them
+			// lazily via `getElements` (fetching the category terms through
+			// core-data). `post` only, mirroring the registered taxonomy.
+			getElements:
+				postType === 'post'
+					? { categories: makeTaxonomyElements( 'category' ) }
+					: {},
+		} );
+	}, [ dataViewConfig, postType, statusCounts ] );
 
 	const actions = useMemo( () => {
 		// Status mutations move rows between filters, so the list query and the

--- a/src/apps/posts/index.js
+++ b/src/apps/posts/index.js
@@ -21,6 +21,13 @@ import {
 	invalidateEntityElementCounts,
 } from '../_shared/dataviews/useEntityElementCounts';
 import { createBulkConfirmModal } from '../_shared/dataviews/createBulkConfirmModal';
+import {
+	createBulkEditModal,
+	fieldsWithNoChange,
+} from '../_shared/dataviews/BulkEditModal';
+import { NO_CHANGE } from '../_shared/dataviews/bulkEditPayload.mjs';
+import { buildQueryArgs } from '../_shared/dataviews/buildQueryArgs.mjs';
+import ViewTabs from '../_shared/dataviews/ViewTabs';
 
 /**
  * Map a post type id to the URL hash that opens its editor route.
@@ -49,17 +56,45 @@ const STATUS_LABELS = {
 
 const STATUS_VALUES = Object.keys( STATUS_LABELS );
 
+// Bulk-edit status options — the writable statuses a row can be moved to. Trash
+// has its own (confirmed) action and `future` is date-driven, so neither is a
+// straight bulk-settable target.
+const BULK_STATUS_LABELS = {
+	publish: __( 'Published', 'wp-admin-shell' ),
+	draft: __( 'Draft', 'wp-admin-shell' ),
+	pending: __( 'Pending', 'wp-admin-shell' ),
+	private: __( 'Private', 'wp-admin-shell' ),
+};
+
+// Post formats wp-admin's Bulk Edit exposes. REST writes these via the `format`
+// param; `standard` clears the format.
+const FORMAT_LABELS = {
+	standard: __( 'Standard', 'wp-admin-shell' ),
+	aside: __( 'Aside', 'wp-admin-shell' ),
+	gallery: __( 'Gallery', 'wp-admin-shell' ),
+	link: __( 'Link', 'wp-admin-shell' ),
+	image: __( 'Image', 'wp-admin-shell' ),
+	quote: __( 'Quote', 'wp-admin-shell' ),
+	status: __( 'Status', 'wp-admin-shell' ),
+	video: __( 'Video', 'wp-admin-shell' ),
+	audio: __( 'Audio', 'wp-admin-shell' ),
+	chat: __( 'Chat', 'wp-admin-shell' ),
+};
+
 // Locale tables for the ids this app authors — see buildFields/buildActions.
 const FIELD_LABELS = {
 	title: __( 'Title', 'wp-admin-shell' ),
 	status: __( 'Status', 'wp-admin-shell' ),
 	author: __( 'Author', 'wp-admin-shell' ),
+	categories: __( 'Categories', 'wp-admin-shell' ),
+	format: __( 'Format', 'wp-admin-shell' ),
 	date: __( 'Date', 'wp-admin-shell' ),
 };
 
 const ACTION_LABELS = {
 	edit: __( 'Edit', 'wp-admin-shell' ),
 	view: __( 'View', 'wp-admin-shell' ),
+	'bulk-edit': __( 'Edit', 'wp-admin-shell' ),
 	trash: __( 'Move to Trash', 'wp-admin-shell' ),
 	restore: __( 'Restore', 'wp-admin-shell' ),
 	'delete-permanent': __( 'Delete Permanently', 'wp-admin-shell' ),
@@ -75,6 +110,44 @@ const VIEW_DEFAULTS = {
 	fields: [],
 	layout: {},
 };
+
+/**
+ * Declarative `view` → REST query mapping consumed by `buildQueryArgs`.
+ * Status / author / categories / format all collapse to single REST params;
+ * the date `before`/`after` operators are applied in a supplemental pass (the
+ * shared mapper only speaks `is`/`isAny`).
+ */
+const QUERY_MAPPING = {
+	sort: { defaultField: 'date', defaultDirection: 'desc' },
+	filters: {
+		status: { is: 'status', isAny: 'status' },
+		author: { is: 'author' },
+		categories: { is: 'categories' },
+		format: { is: 'format' },
+	},
+};
+
+/**
+ * Apply the DataViews date filter (`before` / `after` operators) to the REST
+ * args. `buildQueryArgs` only handles `is`/`isAny`, so the date range — which
+ * maps to REST's `before` / `after` ISO params — is wired here.
+ * @param {Object} args    REST args produced by `buildQueryArgs`.
+ * @param {Array}  filters `view.filters`.
+ * @return {Object} `args` with `before`/`after` applied where present.
+ */
+function applyDateFilters( args, filters ) {
+	for ( const filter of Array.isArray( filters ) ? filters : [] ) {
+		if ( filter.field !== 'date' || ! filter.value ) {
+			continue;
+		}
+		if ( filter.operator === 'before' ) {
+			args.before = filter.value;
+		} else if ( filter.operator === 'after' ) {
+			args.after = filter.value;
+		}
+	}
+	return args;
+}
 
 /**
  * Field id → render callback. View-config declares the *shape*; the React
@@ -99,9 +172,147 @@ function buildFieldRenderers( postType ) {
 	};
 }
 
+/**
+ * Bulk-edit DataForm fields. Every field is seeded to the `NO_CHANGE` sentinel
+ * by `createBulkEditModal`; `fieldsWithNoChange` injects the matching
+ * `— No change —` option for the `elements`-backed selects. The non-elements
+ * fields (author / parent / categories / tags) map the sentinel to an empty
+ * input via `getValue` so the literal sentinel string never renders, and
+ * `computeBulkPayload` drops them unless the user types a value.
+ */
+function buildBulkEditFields() {
+	const sentinelToText =
+		( id ) =>
+		( { item } ) =>
+			item?.[ id ] === NO_CHANGE ? '' : item?.[ id ] ?? '';
+
+	const base = [
+		{
+			id: 'status',
+			label: __( 'Status', 'wp-admin-shell' ),
+			elements: elementsFromLabels( BULK_STATUS_LABELS ),
+		},
+		{
+			id: 'sticky',
+			label: __( 'Sticky', 'wp-admin-shell' ),
+			elements: [
+				{ value: 'true', label: __( 'Sticky', 'wp-admin-shell' ) },
+				{
+					value: 'false',
+					label: __( 'Not sticky', 'wp-admin-shell' ),
+				},
+			],
+		},
+		{
+			id: 'format',
+			label: __( 'Format', 'wp-admin-shell' ),
+			elements: elementsFromLabels( FORMAT_LABELS ),
+		},
+		{
+			id: 'comment_status',
+			label: __( 'Comments', 'wp-admin-shell' ),
+			elements: [
+				{ value: 'open', label: __( 'Allow', 'wp-admin-shell' ) },
+				{
+					value: 'closed',
+					label: __( 'Do not allow', 'wp-admin-shell' ),
+				},
+			],
+		},
+		{
+			id: 'author',
+			type: 'integer',
+			label: __( 'Author (user ID)', 'wp-admin-shell' ),
+			getValue: sentinelToText( 'author' ),
+		},
+		{
+			id: 'parent',
+			type: 'integer',
+			label: __( 'Parent (post ID)', 'wp-admin-shell' ),
+			getValue: sentinelToText( 'parent' ),
+		},
+		{
+			id: 'categories',
+			type: 'text',
+			label: __( 'Categories (comma-separated IDs)', 'wp-admin-shell' ),
+			getValue: sentinelToText( 'categories' ),
+		},
+		{
+			id: 'tags',
+			type: 'text',
+			label: __( 'Tags (comma-separated IDs)', 'wp-admin-shell' ),
+			getValue: sentinelToText( 'tags' ),
+		},
+	];
+
+	return fieldsWithNoChange( base, {
+		ids: [ 'status', 'sticky', 'format', 'comment_status' ],
+	} );
+}
+
+const BULK_EDIT_FORM = {
+	type: 'regular',
+	fields: [
+		'status',
+		'author',
+		'sticky',
+		'parent',
+		'format',
+		'comment_status',
+		'categories',
+		'tags',
+	],
+};
+
+/**
+ * Parse a comma-separated id list into an array of positive integers.
+ * @param {string|Array} value Comma-separated id string (or already an array).
+ * @return {Array} Positive integer ids.
+ */
+function parseIdList( value ) {
+	if ( Array.isArray( value ) ) {
+		return value;
+	}
+	if ( typeof value !== 'string' ) {
+		return [];
+	}
+	return value
+		.split( ',' )
+		.map( ( part ) => parseInt( part.trim(), 10 ) )
+		.filter( ( n ) => Number.isInteger( n ) && n > 0 );
+}
+
+/**
+ * Translate the changed bulk-edit payload into a REST body. Only fields the
+ * user actually changed reach here (`computeBulkPayload` already dropped the
+ * sentinel-valued ones), so each branch fires only when present.
+ * @param {Object} payload Changed-field payload, keyed by field id.
+ * @return {Object} REST body (without `id`, which the modal merges in).
+ */
+function bulkToRecord( payload ) {
+	const body = { ...payload };
+	if ( 'sticky' in body ) {
+		body.sticky = body.sticky === 'true' || body.sticky === true;
+	}
+	if ( 'author' in body ) {
+		body.author = parseInt( body.author, 10 ) || undefined;
+	}
+	if ( 'parent' in body ) {
+		body.parent = parseInt( body.parent, 10 ) || 0;
+	}
+	if ( 'categories' in body ) {
+		body.categories = parseIdList( body.categories );
+	}
+	if ( 'tags' in body ) {
+		body.tags = parseIdList( body.tags );
+	}
+	return body;
+}
+
 export default function PostsApp( { config } ) {
 	const postType = config.postType || 'post';
 	const screenId = config.screenId || null;
+	const currentUserId = window.wpAdminShell?.userId;
 
 	const { config: dataViewConfig } = useDataView( screenId );
 
@@ -113,37 +324,20 @@ export default function PostsApp( { config } ) {
 	} );
 
 	const queryArgs = useMemo( () => {
-		const args = {
-			per_page: view.perPage,
-			page: view.page,
-			order: view.sort?.direction || 'desc',
-			orderby: view.sort?.field || 'date',
+		const args = buildQueryArgs( view, QUERY_MAPPING, {
 			status: config.status || 'any',
 			context: 'edit',
 			_embed: 'author',
-		};
-
-		if ( view.search ) {
-			args.search = view.search;
-		}
-
+		} );
+		// Sticky is a boolean REST param surfaced through the Sticky view tab
+		// (it has no DataViews filter field), so it's applied off the raw view
+		// filters here rather than through the declarative mapping.
 		for ( const filter of view.filters ) {
-			if ( filter.field === 'status' ) {
-				if (
-					filter.operator === 'isAny' &&
-					Array.isArray( filter.value )
-				) {
-					args.status = filter.value.join( ',' );
-				} else if ( filter.operator === 'is' ) {
-					args.status = filter.value;
-				}
-			}
-			if ( filter.field === 'author' && filter.operator === 'is' ) {
-				args.author = filter.value;
+			if ( filter.field === 'sticky' && filter.operator === 'is' ) {
+				args.sticky = filter.value === true || filter.value === 'true';
 			}
 		}
-
-		return args;
+		return applyDateFilters( args, view.filters );
 	}, [ view, config.status ] );
 
 	const { records, isResolving, totalItems, totalPages } = useEntityRecords(
@@ -158,6 +352,28 @@ export default function PostsApp( { config } ) {
 		'status',
 		STATUS_VALUES
 	);
+
+	// Counts for the "Mine" and "Sticky" view tabs ride their own count queries
+	// (different REST fields than status). Keyed by the value each tab's filter
+	// applies so `mergeSegmentCounts` can match them.
+	const mineCount = useEntityElementCounts(
+		'postType',
+		postType,
+		'author',
+		currentUserId ? [ currentUserId ] : []
+	);
+	const stickyCount = useEntityElementCounts(
+		'postType',
+		postType,
+		'sticky',
+		[ true ]
+	);
+
+	// Total across all statuses for the "All" tab — one extra count keyed by the
+	// `any` filter value the All tab applies.
+	const anyCount = useEntityElementCounts( 'postType', postType, 'status', [
+		'any',
+	] );
 
 	const { deleteEntityRecord, saveEntityRecord, invalidateResolution } =
 		useDispatch( coreStore );
@@ -219,6 +435,17 @@ export default function PostsApp( { config } ) {
 				STATUS_VALUES
 			);
 		};
+
+		const bulkEditModal = createBulkEditModal( {
+			entity: [ 'postType', postType ],
+			fields: buildBulkEditFields(),
+			form: BULK_EDIT_FORM,
+			toRecord: bulkToRecord,
+			messages: {
+				applyLabel: __( 'Update', 'wp-admin-shell' ),
+			},
+			onApplied: refreshAfterMutation,
+		} );
 
 		const trashModal = createBulkConfirmModal( {
 			getMessage: ( items ) =>
@@ -406,6 +633,7 @@ export default function PostsApp( { config } ) {
 				restore,
 			},
 			modals: {
+				'bulk-edit': bulkEditModal,
 				trash: trashModal,
 				'delete-permanent': deletePermanentModal,
 			},
@@ -419,6 +647,119 @@ export default function PostsApp( { config } ) {
 		queryArgs,
 		createNotice,
 	] );
+
+	// --- View tabs (#111) ----------------------------------------------------
+	// Status / Mine / Sticky one-click view switches above the list, mirroring
+	// wp-admin's subsubsub strip. Each segment's `filter` is the `view.filters`
+	// entry the tab applies; the count is keyed by `filter.value`.
+	const tabSegments = useMemo( () => {
+		const segments = [
+			{
+				id: 'all',
+				label: __( 'All', 'wp-admin-shell' ),
+				filter: { field: 'status', operator: 'is', value: 'any' },
+			},
+		];
+		if ( currentUserId ) {
+			segments.push( {
+				id: 'mine',
+				label: __( 'Mine', 'wp-admin-shell' ),
+				filter: {
+					field: 'author',
+					operator: 'is',
+					value: currentUserId,
+				},
+			} );
+		}
+		segments.push(
+			{
+				id: 'publish',
+				label: STATUS_LABELS.publish,
+				filter: { field: 'status', operator: 'is', value: 'publish' },
+			},
+			{
+				id: 'draft',
+				label: STATUS_LABELS.draft,
+				filter: { field: 'status', operator: 'is', value: 'draft' },
+			},
+			{
+				id: 'pending',
+				label: STATUS_LABELS.pending,
+				filter: { field: 'status', operator: 'is', value: 'pending' },
+			},
+			{
+				id: 'sticky',
+				label: __( 'Sticky', 'wp-admin-shell' ),
+				filter: { field: 'sticky', operator: 'is', value: true },
+			}
+		);
+		return segments;
+	}, [ currentUserId ] );
+
+	// Merge the multi-source counts into one { filterValue: count } map keyed
+	// the way ViewTabs/mergeSegmentCounts looks them up.
+	const tabCounts = useMemo(
+		() => ( {
+			...statusCounts,
+			...anyCount,
+			...( currentUserId !== undefined
+				? { [ currentUserId ]: mineCount[ currentUserId ] }
+				: {} ),
+			true: stickyCount.true,
+		} ),
+		[ statusCounts, anyCount, mineCount, stickyCount, currentUserId ]
+	);
+
+	// Derive the active tab from the live view filters: an author=me filter →
+	// Mine, a sticky filter → Sticky, a status filter → that status (or All for
+	// `any` / no status filter). Author/sticky filters take precedence so the
+	// Mine/Sticky tabs stay highlighted even with a status default present.
+	const activeTab = useMemo( () => {
+		const filters = view.filters || [];
+		if (
+			currentUserId &&
+			filters.some(
+				( f ) => f.field === 'author' && f.value === currentUserId
+			)
+		) {
+			return 'mine';
+		}
+		if (
+			filters.some(
+				( f ) =>
+					f.field === 'sticky' &&
+					( f.value === true || f.value === 'true' )
+			)
+		) {
+			return 'sticky';
+		}
+		const statusFilter = filters.find( ( f ) => f.field === 'status' );
+		const value = statusFilter?.value;
+		if ( ! value || value === 'any' ) {
+			return 'all';
+		}
+		const match = tabSegments.find(
+			( seg ) =>
+				seg.filter.field === 'status' && seg.filter.value === value
+		);
+		return match ? match.id : undefined;
+	}, [ view.filters, currentUserId, tabSegments ] );
+
+	const onSelectTab = ( segment ) => {
+		// Replace any status / author / sticky filter with the segment's filter;
+		// preserve other filters (date / categories / format). The "All" tab
+		// clears the status scope entirely rather than pinning `status=any` as a
+		// filter chip.
+		const preserved = ( view.filters || [] ).filter(
+			( f ) =>
+				f.field !== 'status' &&
+				f.field !== 'author' &&
+				f.field !== 'sticky'
+		);
+		const nextFilters =
+			segment.id === 'all' ? preserved : [ ...preserved, segment.filter ];
+		setView( { ...view, filters: nextFilters, page: 1 } );
+	};
 
 	const paginationInfo = useMemo(
 		() => ( {
@@ -435,19 +776,27 @@ export default function PostsApp( { config } ) {
 					<Spinner />
 				</div>
 			) : (
-				<DataViews
-					data={ data }
-					fields={ fields }
-					view={ view }
-					onChangeView={ setView }
-					actions={ actions }
-					paginationInfo={ paginationInfo }
-					isLoading={ isResolving }
-					defaultLayouts={ dataViewConfig.defaultLayouts ?? {} }
-					selection={ selection }
-					onChangeSelection={ setSelection }
-					getItemId={ ( item ) => item.id.toString() }
-				/>
+				<>
+					<ViewTabs
+						segments={ tabSegments }
+						currentValue={ activeTab }
+						onSelect={ onSelectTab }
+						counts={ tabCounts }
+					/>
+					<DataViews
+						data={ data }
+						fields={ fields }
+						view={ view }
+						onChangeView={ setView }
+						actions={ actions }
+						paginationInfo={ paginationInfo }
+						isLoading={ isResolving }
+						defaultLayouts={ dataViewConfig.defaultLayouts ?? {} }
+						selection={ selection }
+						onChangeSelection={ setSelection }
+						getItemId={ ( item ) => item.id.toString() }
+					/>
+				</>
 			) }
 		</div>
 	);

--- a/tests/runtime/dataviews-shared.test.mjs
+++ b/tests/runtime/dataviews-shared.test.mjs
@@ -171,6 +171,21 @@ ok(
 	] )[ 0 ].filterBy.operators[ 0 ] === 'isAny'
 );
 
+const withGetElements = buildFields(
+	[ { id: 'categories', type: 'text', filterBy: { operators: [ 'is' ] } } ],
+	{ getElements: { categories: async () => [ { value: 1, label: 'News' } ] } }
+)[ 0 ];
+ok(
+	'getElements provider attached to matching id',
+	typeof withGetElements.getElements === 'function'
+);
+ok(
+	'getElements only applies to matching id',
+	buildFields( [ { id: 'name', type: 'text' } ], {
+		getElements: { categories: async () => [] },
+	} )[ 0 ].getElements === undefined
+);
+
 // --- withElementCounts ----------------------------------------------------
 ok(
 	'withElementCounts returns input untouched when counts missing',


### PR DESCRIPTION
Extends the Posts app (`src/apps/posts/`) across three wave-2 parity lanes, all built on the shared `src/apps/_shared/dataviews/*` scaffolding (no per-app re-copy). PostsApp is the documented prototype entity-CRUD app, so these patterns set the template for the remaining list apps.

## #107 — Posts Bulk Edit
- New `bulk-edit` bulk action (`supportsBulk: true`) declared in `app.json`, wired to the shared `createBulkEditModal` via `buildActions(..., { modals: { 'bulk-edit': … } })`.
- DataForm over **status / author / sticky / parent / format / comment_status / categories / tags**. Every field is seeded to the `NO_CHANGE` sentinel; `fieldsWithNoChange` injects the `— No change —` option for the four `elements`-backed selects (status / sticky / format / comment_status). The integer/CSV fields (author / parent / categories / tags) supply a `getValue` that maps the sentinel to an empty input.
- On Apply only the changed fields are written via `Promise.allSettled(saveEntityRecord)`; `bulkToRecord` coerces values to REST shapes (sticky `'true'`/`'false'` → boolean, author/parent → int, categories/tags CSV → positive-int array). Partial failures keep the failed rows selected. `onApplied` invalidates the list + count resolutions.

## #111 (Posts half) — view-tab strip
- Renders the shared `ViewTabs` strip above the list: **All / Mine / Published / Draft / Pending / Sticky** with live counts.
- Counts come from `useEntityElementCounts` fanned across the REST fields the tabs span (status values + `status=any` total + `author={currentUserId}` + `sticky=true`), merged into one `{ filterValue: count }` map.
- The active segment is **derived from the live `view.filters`** (author/sticky take precedence over status), not separate state. Clicking a tab rewrites the status/author/sticky filter while preserving date / categories / format and resetting to page 1. "Mine" is gated on `window.wpAdminShell?.userId`.
- Comments app untouched (its half of #111 is a separate lane).

## #132 (Posts half) — date / category / format filters
- Wires `categories` and `format` (single-select → `is`) plus the `date` `before`/`after` range into the view→REST mapping via the shared `buildQueryArgs(view, QUERY_MAPPING, staticArgs)` + a small supplemental `applyDateFilters` pass (the shared mapper only speaks `is`/`isAny`, so the date operators are wired alongside it).
- Declares the `categories` / `format` / `date` filters in `app.json`'s dataView (`filterBy.operators`). Filter-only by default (not in `defaultView.fields`).
- Media app untouched (its half of #132 is a later PR).

## Docs
- `app.json#documentation` — updated purpose, reads (new query params + Mine/Sticky count read), writes (bulk-update entry), states, interactions, design-system-leakage.
- `app.md` — new "View tabs, Bulk Edit, and column filters (wave 2)" section; revised parity-gap list.

## Validation
- `npm run lint:js src/apps/posts/` — clean
- `npm run test:runtime` — all suites pass (incl. `build-query-args` + `view-tabs-segment-merge` + `dataviews-shared`)
- `npm run build` — compiles (only the pre-existing asset size-limit warnings)
- `npm run test:schema` — `posts/app.json` valid

Part of #107
Part of #111
Part of #132

https://claude.ai/code/session_011C1dy9mVmw7NhLDZbVgimA

---
_Generated by [Claude Code](https://claude.ai/code/session_011C1dy9mVmw7NhLDZbVgimA)_