### PR TITLE
fix: snackbar toasts flush against left viewport edge (#250)

### DIFF
--- a/src/apps/notices-snackbar/index.css
+++ b/src/apps/notices-snackbar/index.css
@@ -5,6 +5,8 @@
 	z-index: 100000;
 	display: flex;
 	flex-direction: column;
+	align-items: flex-end;
+	width: fit-content;
 	gap: var(--wpds-dimension-gap-sm);
 	pointer-events: none;
 }


### PR DESCRIPTION
Adds `width: fit-content` and `align-items: flex-end` to the snackbar container so the existing `right` anchor produces correct bottom-right stacking instead of left-edge flush rendering.

The upstream `@wordpress/components` stylesheet sets `width: 100%` on `.components-snackbar-list`; without an override, the container spans the full viewport width and toasts left-align against the left edge.

Fixes #250

Generated with [Claude Code](https://claude.ai/code)