### PR TITLE
fix: bridge skips slugs claimed by native screens via legacy_path (#252)

### DIFF
--- a/includes/cascade/class-wp-admin-workspaces-classic-menu-bridge.php
+++ b/includes/cascade/class-wp-admin-workspaces-classic-menu-bridge.php
@@ -219,14 +219,20 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 	 *                             // core parent slug → real workspace menu id.
 	 *   }
 	 *
+	 * @param string[] $native_legacy_paths Optional set of wp-admin slugs
+	 *                                       already claimed by native workspace
+	 *                                       screens via `legacy_path`. Entries
+	 *                                       matching these slugs are skipped to
+	 *                                       prevent duplicate nav entries (#252).
 	 * @return array<int, array>
 	 */
-	public static function scan() {
+	public static function scan( $native_legacy_paths = array() ) {
 		// Request-scoped memo. `contribute()` and the cache-signal hook
 		// both call scan(); without the memo we'd walk $GLOBALS twice
 		// per request and dispatch the core-slug filter 30+ times.
 		// The signature snapshot guards against late mutations to the
-		// globals (rare; mainly test harnesses).
+		// globals (rare; mainly test harnesses) and against different
+		// $native_legacy_paths inputs (mainly tests calling scan() directly).
 		static $cache_signature = null;
 		static $cache_result    = null;
 		$menu_globals    = isset( $GLOBALS['menu'] ) && is_array( $GLOBALS['menu'] )
@@ -235,7 +241,7 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 		$submenu_globals = isset( $GLOBALS['submenu'] ) && is_array( $GLOBALS['submenu'] )
 			? $GLOBALS['submenu']
 			: array();
-		$signature = md5( serialize( array( $menu_globals, $submenu_globals ) ) );
+		$signature = md5( serialize( array( $menu_globals, $submenu_globals, $native_legacy_paths ) ) );
 		if ( $cache_signature === $signature && is_array( $cache_result ) ) {
 			return $cache_result;
 		}
@@ -275,7 +281,7 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 			if ( strpos( $css, 'wp-menu-separator' ) !== false ) {
 				continue;
 			}
-			if ( self::is_core_slug( $slug ) ) {
+			if ( self::is_core_slug( $slug ) || in_array( $slug, $native_legacy_paths, true ) ) {
 				continue;
 			}
 
@@ -298,7 +304,7 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 			);
 
 			if ( isset( $submenu[ $slug ] ) && is_array( $submenu[ $slug ] ) ) {
-				$record['children'] = self::scan_children( $submenu[ $slug ] );
+				$record['children'] = self::scan_children( $submenu[ $slug ], $native_legacy_paths );
 			}
 
 			$records[] = $record;
@@ -322,7 +328,7 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 				continue; // Orphan submenu.
 			}
 
-			$ingested_children = self::scan_children( $children_array );
+			$ingested_children = self::scan_children( $children_array, $native_legacy_paths );
 			if ( empty( $ingested_children ) ) {
 				continue;
 			}
@@ -388,12 +394,15 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 	/**
 	 * Walk one submenu array (`$GLOBALS['submenu'][<parent>]`) and
 	 * return ingested child records. Skips entries whose slug matches
-	 * `is_core_slug` so we don't double-bridge wp-admin built-ins.
+	 * `is_core_slug` or whose slug is already claimed by a native
+	 * workspace screen via `legacy_path` (the `$native_legacy_paths` set
+	 * built from the prior-merged doc by `contribute()`).
 	 *
-	 * @param array<int, array> $children The submenu rows under one parent.
+	 * @param array<int, array> $children            The submenu rows under one parent.
+	 * @param string[]          $native_legacy_paths  Slugs already claimed natively.
 	 * @return array<int, array>
 	 */
-	private static function scan_children( $children ) {
+	private static function scan_children( $children, $native_legacy_paths = array() ) {
 		$out = array();
 		foreach ( $children as $child ) {
 			if ( ! is_array( $child ) || ! isset( $child[2] ) ) {
@@ -403,7 +412,7 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 			if ( $slug === '' ) {
 				continue;
 			}
-			if ( self::is_core_slug( $slug ) ) {
+			if ( self::is_core_slug( $slug ) || in_array( $slug, $native_legacy_paths, true ) ) {
 				continue;
 			}
 			$out[] = array(
@@ -595,6 +604,31 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 	}
 
 	/**
+	 * Extract every `legacy_path` string declared by screens in a merged doc.
+	 * Used by `contribute()` to build the dynamic skip set for `scan()`: any
+	 * wp-admin slug already claimed via `legacy_path` by a prior-origin
+	 * screen must not be re-ingested by the bridge (#252).
+	 *
+	 * @param array $merged_doc A partially- or fully-merged workspace.json doc.
+	 * @return string[]
+	 */
+	private static function extract_native_legacy_paths( $merged_doc ) {
+		if ( ! isset( $merged_doc['screens'] ) || ! is_array( $merged_doc['screens'] ) ) {
+			return array();
+		}
+		$paths = array();
+		foreach ( $merged_doc['screens'] as $screen ) {
+			if ( ! is_array( $screen ) ) {
+				continue;
+			}
+			if ( isset( $screen['legacy_path'] ) && is_string( $screen['legacy_path'] ) && $screen['legacy_path'] !== '' ) {
+				$paths[] = $screen['legacy_path'];
+			}
+		}
+		return $paths;
+	}
+
+	/**
 	 * Cascade contribution. Walks `scan()` and merges synthesized
 	 * `screens[<id>]` + `menu.ingested.items[<id>]` entries into the
 	 * plugin-origin workspace.json doc. Idempotent: any entry id already
@@ -604,14 +638,30 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 	 *   - workspace.json declarations at any origin keep authority.
 	 *   - The filter firing twice in one request doesn't duplicate.
 	 *
-	 * @param array $doc Plugin-origin workspace.json doc.
+	 * @param array $doc          Plugin-origin workspace.json doc.
+	 * @param array $prior_merged The merged doc from origins that ran before
+	 *                            plugin (core + engine). Passed as an extra
+	 *                            arg by `resolve_with()` since this fix. Used
+	 *                            to derive the dynamic skip set of legacy_path
+	 *                            slugs already claimed natively, preventing
+	 *                            duplicate nav entries (#252). Defaults to
+	 *                            empty array (graceful degradation in direct
+	 *                            test calls and back-compat callers).
 	 * @return array
 	 */
-	public static function contribute( $doc ) {
+	public static function contribute( $doc, $prior_merged = array() ) {
 		if ( ! is_array( $doc ) ) {
 			$doc = array();
 		}
-		$records = self::scan();
+		// Build the dynamic skip set from screens declared in prior origins.
+		// This catches slugs (e.g. theme-editor.php, plugin-editor.php) that
+		// are absent from the static $CORE_SLUGS list but are already claimed
+		// natively via a screen's `legacy_path` field. Future native screens
+		// with a legacy_path automatically stop regressing into duplicates.
+		$native_legacy_paths = self::extract_native_legacy_paths(
+			is_array( $prior_merged ) ? $prior_merged : array()
+		);
+		$records = self::scan( $native_legacy_paths );
 		if ( empty( $records ) ) {
 			return $doc;
 		}
@@ -940,11 +990,17 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
  * the idempotency guard (first writer wins on entry id) and a plugin
  * author hooking `wp_admin_workspaces_data_plugin` at default priority 10
  * still wins on top.
+ *
+ * Accepts 2 args: the plugin-origin doc (value being filtered) plus the
+ * already-merged core+engine doc passed as an extra arg by `resolve_with()`
+ * since #252. The second arg lets `contribute()` derive which legacy_path
+ * slugs are already claimed natively, preventing duplicate nav entries.
  */
 add_filter(
 	'wp_admin_workspaces_data_plugin',
 	array( 'WP_Admin_Workspaces_Classic_Menu_Bridge', 'contribute' ),
-	6
+	6,
+	2
 );
 
 /**

--- a/includes/cascade/class-wp-admin-workspaces-classic-menu-bridge.php
+++ b/includes/cascade/class-wp-admin-workspaces-classic-menu-bridge.php
@@ -625,7 +625,11 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 				$paths[] = $screen['legacy_path'];
 			}
 		}
-		return $paths;
+		// Dedup: the baseline repeats slugs (e.g. `edit.php`) across screens.
+		// Harmless for `in_array()` membership, but keeps the set tidy and
+		// stabilizes the `serialize()` in `scan()`'s memo signature regardless
+		// of screen ordering.
+		return array_values( array_unique( $paths ) );
 	}
 
 	/**
@@ -642,25 +646,43 @@ class WP_Admin_Workspaces_Classic_Menu_Bridge {
 	 * @param array $prior_merged The merged doc from origins that ran before
 	 *                            plugin (core + engine). Passed as an extra
 	 *                            arg by `resolve_with()` since this fix. Used
-	 *                            to derive the dynamic skip set of legacy_path
-	 *                            slugs already claimed natively, preventing
-	 *                            duplicate nav entries (#252). Defaults to
-	 *                            empty array (graceful degradation in direct
-	 *                            test calls and back-compat callers).
+	 *                            (unioned with `$doc` itself) to derive the
+	 *                            dynamic skip set of legacy_path slugs already
+	 *                            claimed natively, preventing duplicate nav
+	 *                            entries (#252). Defaults to empty array
+	 *                            (graceful degradation in direct test calls and
+	 *                            back-compat callers).
 	 * @return array
 	 */
 	public static function contribute( $doc, $prior_merged = array() ) {
 		if ( ! is_array( $doc ) ) {
 			$doc = array();
 		}
-		// Build the dynamic skip set from screens declared in prior origins.
-		// This catches slugs (e.g. theme-editor.php, plugin-editor.php) that
-		// are absent from the static $CORE_SLUGS list but are already claimed
-		// natively via a screen's `legacy_path` field. Future native screens
-		// with a legacy_path automatically stop regressing into duplicates.
-		$native_legacy_paths = self::extract_native_legacy_paths(
-			is_array( $prior_merged ) ? $prior_merged : array()
+		// Build the dynamic skip set from screens declared in prior origins
+		// AND in the plugin-origin doc being filtered. This catches slugs
+		// (e.g. theme-editor.php, plugin-editor.php) that are absent from the
+		// static $CORE_SLUGS list but are already claimed natively via a
+		// screen's `legacy_path` field. Unioning $doc closes the same #252 bug
+		// class one origin up: a `wp-content/workspace.json` partial override
+		// (plugin slot) that declares its own `legacy_path` screen claiming a
+		// third-party slug would otherwise still get a duplicate `ingested-*`
+		// entry. Future native screens with a legacy_path stop regressing
+		// into duplicates automatically.
+		$native_legacy_paths = array_values(
+			array_unique(
+				array_merge(
+					self::extract_native_legacy_paths(
+						is_array( $prior_merged ) ? $prior_merged : array()
+					),
+					self::extract_native_legacy_paths( $doc )
+				)
+			)
 		);
+		// NOTE: `contribute()` calls `scan( $native_legacy_paths )` while the
+		// cache-signal hook calls `scan()` with no skip set — the two callers
+		// now diverge by design (the cache-signal hook can't see the merged
+		// doc, so it can't build the skip set). scan()'s memo keys on the
+		// $native_legacy_paths signature, so each caller gets its own walk.
 		$records = self::scan( $native_legacy_paths );
 		if ( empty( $records ) ) {
 			return $doc;

--- a/includes/cascade/class-wp-admin-workspaces-resolver.php
+++ b/includes/cascade/class-wp-admin-workspaces-resolver.php
@@ -128,6 +128,13 @@ class WP_Admin_Workspaces_Resolver {
 			if ( ! is_array( $doc ) ) {
 				continue;
 			}
+			// Single-arg by design — the $merged extra arg passed to the
+			// Phase 1 trusted filters is intentionally NOT passed here.
+			// Consumer origins (site/role/user) are shrink-only and don't need
+			// to inspect the prior-merged doc; the only current consumer of the
+			// extra arg (the classic-menu bridge) hooks the trusted plugin
+			// origin. Passing $merged here too would be harmless and
+			// backward-compatible if a future consumer-origin hook wants it.
 			$doc    = apply_filters( "wp_admin_workspaces_data_{$origin}", $doc );
 			$doc    = WP_Admin_Workspaces_Customizable::filter_doc( $merged, $doc, $origin );
 			$doc    = WP_Admin_Workspaces_Permissions::enforce_origin_tier( $doc, $merged, $origin );

--- a/includes/cascade/class-wp-admin-workspaces-resolver.php
+++ b/includes/cascade/class-wp-admin-workspaces-resolver.php
@@ -105,7 +105,12 @@ class WP_Admin_Workspaces_Resolver {
 			if ( ! is_array( $doc ) ) {
 				continue;
 			}
-			$doc    = apply_filters( "wp_admin_workspaces_data_{$origin}", $doc );
+			// Pass $merged as an extra arg so callbacks can inspect which
+			// screens prior origins already declared (e.g. the classic-menu
+			// bridge uses it to skip slugs already claimed via legacy_path).
+			// Extra args are ignored by callbacks that don't declare them,
+			// so this is fully backward-compatible.
+			$doc    = apply_filters( "wp_admin_workspaces_data_{$origin}", $doc, $merged );
 			$tagged = WP_Admin_Workspaces_Merge::tag_origin( $doc, $origin );
 			$merged = WP_Admin_Workspaces_Merge::merge_authoritative( $merged, $tagged );
 		}

--- a/tests/php/run-classic-menu-bridge-tests.php
+++ b/tests/php/run-classic-menu-bridge-tests.php
@@ -1023,6 +1023,38 @@ $T::assert_eq(
 	'ingested-other-plugin'
 );
 
+// A `legacy_path` declared in the plugin-origin $doc being filtered (e.g. a
+// `wp-content/workspace.json` partial override) is also honored — the skip
+// set unions $prior_merged AND $doc, closing the same #252 bug class one
+// origin up.
+wpas_cmb_reset_globals();
+WP_Admin_Workspaces_Classic_Menu_Bridge::reset();
+$GLOBALS['menu'] = array(
+	array( 'Plugins', 'activate_plugins', 'plugins.php', 'Plugins', '', '', 'dashicons-admin-plugins' ),
+);
+$GLOBALS['submenu'] = array(
+	'plugins.php' => array(
+		array( 'Plugin File Editor', 'edit_plugins', 'plugin-editor.php' ),
+	),
+);
+$doc_252d = WP_Admin_Workspaces_Classic_Menu_Bridge::contribute(
+	array(
+		'screens' => array(
+			'my-editor' => array(
+				'label'       => 'Plugin File Editor',
+				'path'        => '/my-editor',
+				'app'         => 'iframe:plugin-editor.php',
+				'legacy_path' => 'plugin-editor.php',
+			),
+		),
+	),
+	array() // No prior-merged; the claim lives in the plugin-origin doc itself.
+);
+$T::assert_true(
+	'#252: legacy_path claimed in the plugin-origin $doc itself is also skipped',
+	! isset( $doc_252d['screens']['ingested-plugin-editor-php'] )
+);
+
 wpas_cmb_reset_globals();
 WP_Admin_Workspaces_Classic_Menu_Bridge::reset();
 

--- a/tests/php/run-classic-menu-bridge-tests.php
+++ b/tests/php/run-classic-menu-bridge-tests.php
@@ -882,6 +882,150 @@ $T::assert_eq(
 wpas_cmb_reset_globals();
 WP_Admin_Workspaces_Classic_Menu_Bridge::reset();
 
+// --- #252: native legacy_path skip — structural fix ----------------------
+// Slugs already claimed by a native workspace screen via `legacy_path` must
+// not be re-ingested by the bridge, even when absent from $CORE_SLUGS.
+// The resolver passes the already-merged core+engine doc as a second arg
+// to the `wp_admin_workspaces_data_plugin` filter; `contribute()` derives
+// the skip set from it.
+
+// theme-editor.php is a submenu of themes.php (Appearance); plugin-editor.php
+// is a submenu of plugins.php (Plugins). Both are absent from $CORE_SLUGS
+// but ARE claimed by native workspace screens via `legacy_path`.
+wpas_cmb_reset_globals();
+WP_Admin_Workspaces_Classic_Menu_Bridge::reset();
+$GLOBALS['menu'] = array(
+	array( 'Appearance', 'switch_themes', 'themes.php', 'Appearance', '', '', 'dashicons-admin-appearance' ),
+	array( 'Plugins', 'activate_plugins', 'plugins.php', 'Plugins', '', '', 'dashicons-admin-plugins' ),
+);
+$GLOBALS['submenu'] = array(
+	'themes.php' => array(
+		array( 'Theme File Editor', 'edit_themes', 'theme-editor.php' ),
+		array( 'Site Editor', 'edit_theme_options', 'site-editor.php' ),
+	),
+	'plugins.php' => array(
+		array( 'Plugin File Editor', 'edit_plugins', 'plugin-editor.php' ),
+	),
+);
+// Simulate the prior-merged doc from the core origin that declares these
+// screens natively with `legacy_path` (mirrors wp-admin-default.json).
+$prior_merged_252 = array(
+	'screens' => array(
+		'theme-editor' => array(
+			'label'       => 'Theme File Editor',
+			'path'        => '/tools/theme-editor',
+			'app'         => 'iframe:theme-editor.php',
+			'legacy_path' => 'theme-editor.php',
+		),
+		'plugin-editor' => array(
+			'label'       => 'Plugin File Editor',
+			'path'        => '/tools/plugin-editor',
+			'app'         => 'iframe:plugin-editor.php',
+			'legacy_path' => 'plugin-editor.php',
+		),
+		'site-editor' => array(
+			'label'       => 'Editor',
+			'path'        => '/site-editor',
+			'app'         => 'core:site-editor',
+			'legacy_path' => 'site-editor.php',
+		),
+	),
+);
+$doc_252 = WP_Admin_Workspaces_Classic_Menu_Bridge::contribute( array(), $prior_merged_252 );
+
+$T::assert_true(
+	'#252: theme-editor.php not ingested when claimed natively via legacy_path',
+	! isset( $doc_252['screens']['ingested-theme-editor-php'] )
+);
+$T::assert_true(
+	'#252: plugin-editor.php not ingested when claimed natively via legacy_path',
+	! isset( $doc_252['screens']['ingested-plugin-editor-php'] )
+);
+$T::assert_true(
+	'#252: site-editor.php not ingested when claimed natively via legacy_path',
+	! isset( $doc_252['screens']['ingested-site-editor-php'] )
+);
+// The ingested containers for themes.php and plugins.php also have no
+// children left (all their relevant children were native) — they should
+// not be emitted at all since `scan_children()` returns empty arrays.
+$themes_php_id  = WP_Admin_Workspaces_Classic_Menu_Bridge::derive_screen_id( 'themes.php' );
+$plugins_php_id = WP_Admin_Workspaces_Classic_Menu_Bridge::derive_screen_id( 'plugins.php' );
+$T::assert_true(
+	'#252: ingested-themes-php container not emitted when all children are native',
+	! isset( $doc_252['menu']['ingested']['items'][ $themes_php_id ] )
+);
+$T::assert_true(
+	'#252: ingested-plugins-php container not emitted when all children are native',
+	! isset( $doc_252['menu']['ingested']['items'][ $plugins_php_id ] )
+);
+
+// Non-native children alongside a native one must still be ingested.
+wpas_cmb_reset_globals();
+WP_Admin_Workspaces_Classic_Menu_Bridge::reset();
+$GLOBALS['menu'] = array(
+	array( 'Plugins', 'activate_plugins', 'plugins.php', 'Plugins', '', '', 'dashicons-admin-plugins' ),
+);
+$GLOBALS['submenu'] = array(
+	'plugins.php' => array(
+		array( 'Plugin File Editor', 'edit_plugins', 'plugin-editor.php' ),
+		array( 'Acme Plugin', 'manage_options', 'acme-plugin-page' ), // Third-party: not native.
+	),
+);
+$prior_merged_252b = array(
+	'screens' => array(
+		'plugin-editor' => array(
+			'legacy_path' => 'plugin-editor.php',
+		),
+	),
+);
+$doc_252b = WP_Admin_Workspaces_Classic_Menu_Bridge::contribute( array(), $prior_merged_252b );
+$T::assert_true(
+	'#252: plugin-editor.php skipped (native) but adjacent third-party child still ingested',
+	! isset( $doc_252b['screens']['ingested-plugin-editor-php'] ) &&
+	isset( $doc_252b['screens']['ingested-acme-plugin-page'] )
+);
+
+// Without $prior_merged the bridge falls back to static-list-only (graceful
+// degradation — direct calls from tests or third-party code still work).
+wpas_cmb_reset_globals();
+WP_Admin_Workspaces_Classic_Menu_Bridge::reset();
+$GLOBALS['menu'] = array(
+	array( 'Plugins', 'activate_plugins', 'plugins.php', 'Plugins', '', '', 'dashicons-admin-plugins' ),
+);
+$GLOBALS['submenu'] = array(
+	'plugins.php' => array(
+		array( 'Acme Plugin', 'manage_options', 'acme-plugin-page' ),
+	),
+);
+$doc_252c = WP_Admin_Workspaces_Classic_Menu_Bridge::contribute( array() ); // No $prior_merged.
+$T::assert_true(
+	'#252: contribute() without $prior_merged still ingests third-party children (static list only)',
+	isset( $doc_252c['screens']['ingested-acme-plugin-page'] )
+);
+
+// scan() with $native_legacy_paths skips a top-level entry whose slug
+// matches a claimed legacy_path.
+wpas_cmb_reset_globals();
+WP_Admin_Workspaces_Classic_Menu_Bridge::reset();
+$GLOBALS['menu'] = array(
+	array( 'My Editor', 'manage_options', 'theme-editor.php', 'My Editor', '', '', 'dashicons-code-standards' ),
+	array( 'Other Plugin', 'manage_options', 'other-plugin', 'Other Plugin', '', '', 'dashicons-admin-tools' ),
+);
+$scan_252 = WP_Admin_Workspaces_Classic_Menu_Bridge::scan( array( 'theme-editor.php' ) );
+$T::assert_eq(
+	'#252: scan() with $native_legacy_paths skips a top-level slug claimed natively',
+	count( $scan_252 ),
+	1
+);
+$T::assert_eq(
+	'#252: scan() surviving record is the non-native plugin (not the claimed slug)',
+	$scan_252[0]['id'],
+	'ingested-other-plugin'
+);
+
+wpas_cmb_reset_globals();
+WP_Admin_Workspaces_Classic_Menu_Bridge::reset();
+
 // --- Restore globals -----------------------------------------------------
 
 $GLOBALS['menu']    = $saved_menu;


### PR DESCRIPTION
Fixes #252.

Theme File Editor and Plugin File Editor appeared twice in navigation because `theme-editor.php` and `plugin-editor.php` were absent from the bridge's static `$CORE_SLUGS` list.

**Structural fix:**
- `resolve_with()` passes the already-merged (core + engine) doc as an extra filter arg
- `contribute()` derives a dynamic skip set from all `legacy_path` values in prior-origin screens
- `scan()` / `scan_children()` skip slugs in that set

Also covers `site-editor.php` (latent same-class gap). Future native screens with `legacy_path` stop regressing automatically.

Generated with [Claude Code](https://claude.ai/code)