### PR TITLE
docs(profile): correct app.json DS-leakage claims

### DIFF
--- a/src/apps/profile/app.json
+++ b/src/apps/profile/app.json
@@ -134,18 +134,14 @@
 				"note": "Manifest declares `core:dirty-state: true`. The app does NOT call `useDirtyState` directly — it relies on `hasEdits` being read by a sibling NavigationGuard. (`block-navigation-on-dirty` is intentionally not set; profile edits are low-stakes.)"
 			},
 			{
-				"concern": "inputcontrol-event-shape",
-				"note": "WPDS `InputControl` onChange takes a DOM event (`e.target.value`), not the raw value. The same applies wherever WPDS form fields are used."
-			},
-			{
 				"concern": "dataform-edit-controls",
 				"note": "The display-name select (`Edit: 'select'`) and the bio textarea (`Edit: { control: 'textarea', rows: 5 }`) are rendered by `DataForm` from their field definitions — they are DataViews-internal controls, NOT direct `@wordpress/components` imports. The app's only direct `@wordpress/components` leakage is `Spinner`."
 			}
 		],
 		"design-system-leakage": [
 			{
-				"import": "@wordpress/ui#Button, InputControl, Stack, Text",
-				"purpose": "Form layout + text + URL + email inputs + save button."
+				"import": "@wordpress/ui#Button, Stack, Text",
+				"purpose": "Form layout + save button. URL + email fields are DataForm field defs (type: 'text'/'email'), not direct InputControl imports — DataViews owns their rendering."
 			},
 			{
 				"import": "@wordpress/components#Spinner",

--- a/src/apps/profile/app.json
+++ b/src/apps/profile/app.json
@@ -138,12 +138,8 @@
 				"note": "WPDS `InputControl` onChange takes a DOM event (`e.target.value`), not the raw value. The same applies wherever WPDS form fields are used."
 			},
 			{
-				"concern": "textarea-fallback",
-				"note": "Uses legacy `TextareaControl` from `@wordpress/components` — WPDS 0.12 has no port."
-			},
-			{
-				"concern": "select-fallback",
-				"note": "Uses legacy `SelectControl` from `@wordpress/components` for the display name (WPDS 0.12 SelectControl has no `__nextHasNoMarginBottom` parity)."
+				"concern": "dataform-edit-controls",
+				"note": "The display-name select (`Edit: 'select'`) and the bio textarea (`Edit: { control: 'textarea', rows: 5 }`) are rendered by `DataForm` from their field definitions — they are DataViews-internal controls, NOT direct `@wordpress/components` imports. The app's only direct `@wordpress/components` leakage is `Spinner`."
 			}
 		],
 		"design-system-leakage": [
@@ -152,8 +148,8 @@
 				"purpose": "Form layout + text + URL + email inputs + save button."
 			},
 			{
-				"import": "@wordpress/components#TextareaControl, SelectControl, Spinner",
-				"purpose": "Bio textarea + display-name select + loading spinner — WPDS 0.12 gaps."
+				"import": "@wordpress/components#Spinner",
+				"purpose": "Loading spinner — no `@wordpress/ui` 0.12 port. The display-name select and bio textarea are `DataForm` `Edit` controls (DataViews-internal), not direct DS imports."
 			}
 		]
 	}


### PR DESCRIPTION
Fixes #208.

`src/apps/profile/app.json`'s documentation block claimed the app imports `SelectControl` and `TextareaControl` directly from `@wordpress/components`, but `index.js` only imports `Spinner`. The display-name select and bio textarea are `DataForm` `Edit` controls (DataViews-internal), not app-level DS leakage.

- Replaced the `textarea-fallback`/`select-fallback` constraints with a single `dataform-edit-controls` constraint.
- Narrowed `design-system-leakage` to `@wordpress/components#Spinner`.

`app.md` needs no change. Consistent with `docs/screens/profile.md` §9.

Generated with [Claude Code](https://claude.ai/code)