### PR TITLE
chore: rename wpas_collect_menu_item_caps to wp_admin_workspaces_ prefix

### DIFF
--- a/wp-admin-workspaces.php
+++ b/wp-admin-workspaces.php
@@ -994,7 +994,7 @@ function wp_admin_workspaces_resolve_capabilities( $config ) {
 	// this, `userCan()` would default-false on inline-permissioned menu
 	// items that have no screen binding.
 	if ( isset( $config['menu'] ) && is_array( $config['menu'] ) ) {
-		wpas_collect_menu_item_caps( $config['menu'], $declared );
+		wp_admin_workspaces_collect_menu_item_caps( $config['menu'], $declared );
 	}
 
 	// Built-in source capability floors (mirrors registry/builtins.js
@@ -1016,7 +1016,7 @@ function wp_admin_workspaces_resolve_capabilities( $config ) {
  * declared on `permissions.capabilities[]`. Mirrors the screen-perms walk
  * for menu items that don't inherit perms from a bound screen.
  */
-function wpas_collect_menu_item_caps( $menu, &$declared ) {
+function wp_admin_workspaces_collect_menu_item_caps( $menu, &$declared ) {
 	if ( ! is_array( $menu ) ) {
 		return;
 	}
@@ -1033,7 +1033,7 @@ function wpas_collect_menu_item_caps( $menu, &$declared ) {
 			}
 		}
 		if ( isset( $item['items'] ) && is_array( $item['items'] ) ) {
-			wpas_collect_menu_item_caps( $item['items'], $declared );
+			wp_admin_workspaces_collect_menu_item_caps( $item['items'], $declared );
 		}
 	}
 }


### PR DESCRIPTION
Follow-up to #82 (closes #91).

Renames the private helper `wpas_collect_menu_item_caps` → `wp_admin_workspaces_collect_menu_item_caps` to align with its already-renamed sibling `wp_admin_workspaces_collect_nav_item_caps`, for prefix consistency before any public-API freeze.

- Renames the definition (line 1019) and both call sites (lines 997, 1036) in `wp-admin-workspaces.php`
- No test/doc references existed; repo-wide grep confirms zero remaining `wpas_collect_menu_item_caps`
- Private helper, so cosmetic only — no behavior change

Generated with [Claude Code](https://claude.ai/code)