### PR TITLE
refactor(tokens): shared is_assoc util, final filter, cascade-order doc

### DIFF
--- a/docs/wp-admin-workspaces-design-spec.md
+++ b/docs/wp-admin-workspaces-design-spec.md
@@ -798,7 +798,14 @@ Authors bring any DTCG-conformant primitive token system in `tokens.json`. WordP
 
 One brand token in tokens.json fans out to three destinations: WPDS surface (admin), legacy admin/components (compat bridge), frontend (`--wp--preset--*`). Re-branding edits one token.
 
-`tokens.json` is a valid W3C DTCG (2025.10) file. Discovery: site root > theme root > plugin root > core baseline. Origins merge via the same cascade as `workspace.json` (§10).
+`tokens.json` is a valid W3C DTCG (2025.10) file. Discovery: site root > theme root > plugin root > core baseline. Origins merge with the same *mechanics* as `workspace.json` (§10) — scalar replace, object deep-merge — but over a **different, intentionally shorter, origin set**.
+
+**Tokens cascade order (and why it deviates from §10).** The token cascade is `core → plugin → theme → site` (loaded low→high, deep-merged), against the workspace.json cascade's `core → engine → plugin → site → role → user`. Two deliberate differences:
+
+- **Tokens insert a `theme` origin between `plugin` and `site`.** Tokens are a design-system primitive the active block theme legitimately owns — a theme's `tokens.json` rebrands the admin to match its front end — so the theme sits above the plugin baseline but below explicit site choices. The workspace.json cascade has no theme origin because workspace *structure* (screens / menu / permissions) is not the theme's concern.
+- **Tokens drop the `engine`, `role`, and `user` origins.** Tokens are pure visual primitives with no security surface and no per-role / per-user authoring path today, so there is nothing to gate or personalize at those tiers. (Per-region / per-app visual overrides live in `workspace.json.styles` — §9.2 — not in `tokens.json`.) These origins can be added later without disturbing the lower ones.
+
+Tokens are **additive, not restrict-only**: a higher origin overrides a value but cannot tombstone a key the baseline ships. The resolved tree is exposed to extensions via the final `wp_admin_workspaces_tokens` filter (symmetric with `workspace.json`'s `wp_admin_workspaces_data`; the per-origin loader hook is `wp_admin_workspaces_plugin_tokens`). Implementation: `WP_Admin_Workspaces_Tokens::resolve()` + `src/runtime/tokens/tokensResolver.mjs`.
 
 ### 9.2 WPDS-native styles
 

--- a/includes/cascade/class-wp-admin-workspaces-data-view-config.php
+++ b/includes/cascade/class-wp-admin-workspaces-data-view-config.php
@@ -418,8 +418,8 @@ class WP_Admin_Workspaces_Data_View_Config {
 				is_array( $value ) &&
 				isset( $out[ $key ] ) &&
 				is_array( $out[ $key ] ) &&
-				self::is_assoc( $value ) &&
-				self::is_assoc( $out[ $key ] )
+				WP_Admin_Workspaces_Util::is_assoc( $value ) &&
+				WP_Admin_Workspaces_Util::is_assoc( $out[ $key ] )
 			) {
 				$out[ $key ] = self::deep_merge_view( $out[ $key ], $value );
 				continue;
@@ -792,18 +792,6 @@ class WP_Admin_Workspaces_Data_View_Config {
 		_doing_it_wrong( __CLASS__, esc_html( $message ), 'v3.0.0' );
 	}
 
-	/**
-	 * Helper — true for assoc array (non-empty, string keys).
-	 *
-	 * @param mixed $arr
-	 * @return bool
-	 */
-	private static function is_assoc( $arr ) {
-		if ( ! is_array( $arr ) || empty( $arr ) ) {
-			return false;
-		}
-		return array_keys( $arr ) !== range( 0, count( $arr ) - 1 );
-	}
 }
 
 // Post-merge so workspace.json (and downstream origins) are authoritative.

--- a/includes/cascade/class-wp-admin-workspaces-merge.php
+++ b/includes/cascade/class-wp-admin-workspaces-merge.php
@@ -344,10 +344,15 @@ class WP_Admin_Workspaces_Merge {
 		return null;
 	}
 
+	/**
+	 * True for a non-empty associative array. Kept as a public method for
+	 * the many cascade callers that reference `WP_Admin_Workspaces_Merge::is_assoc`;
+	 * the logic itself lives once in {@see WP_Admin_Workspaces_Util::is_assoc}.
+	 *
+	 * @param mixed $arr
+	 * @return bool
+	 */
 	public static function is_assoc( $arr ) {
-		if ( ! is_array( $arr ) || empty( $arr ) ) {
-			return false;
-		}
-		return array_keys( $arr ) !== range( 0, count( $arr ) - 1 );
+		return WP_Admin_Workspaces_Util::is_assoc( $arr );
 	}
 }

--- a/includes/class-wp-admin-workspaces-util.php
+++ b/includes/class-wp-admin-workspaces-util.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Shared low-level helpers used across the cascade + tokens engines.
+ *
+ * Deliberately dependency-free and side-effect-free so it can load
+ * before any other plugin class (it is required first in the bootstrap
+ * order). Keep this class a thin home for genuinely shared primitives —
+ * anything domain-specific belongs with its subsystem, not here.
+ *
+ * @package WP_Admin_Workspaces
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+class WP_Admin_Workspaces_Util {
+
+	/**
+	 * True when `$arr` is a non-empty associative array (has at least one
+	 * non-sequential / string key).
+	 *
+	 * This is the canonical implementation. An EMPTY array returns `false`
+	 * here — PHP cannot distinguish `[]` from `{}` after `json_decode`, and
+	 * the merge/tokens cascades treat an empty array as "no override at this
+	 * depth" rather than an empty object. Callers that need the opposite
+	 * empty-is-assoc convention (e.g. `WP_Admin_Workspaces_Modes`, which lets
+	 * a child populate an empty parent) keep their own local helper on
+	 * purpose — do not fold those into this one.
+	 *
+	 * @param mixed $arr Value to test.
+	 * @return bool
+	 */
+	public static function is_assoc( $arr ) {
+		if ( ! is_array( $arr ) || empty( $arr ) ) {
+			return false;
+		}
+		return array_keys( $arr ) !== range( 0, count( $arr ) - 1 );
+	}
+}

--- a/includes/tokens/class-wp-admin-workspaces-tokens.php
+++ b/includes/tokens/class-wp-admin-workspaces-tokens.php
@@ -3,8 +3,11 @@
  * tokens.json discovery + merge (V2.M5 task 2).
  *
  * DTCG (W3C 2025.10) primitives layer for the design system. Loads
- * tokens from four origins in priority order, deep-merges, and ships
- * the merged tree to the runtime alongside the resolved workspace.json:
+ * tokens from four origins and deep-merges them lowest-priority-first,
+ * then ships the merged tree to the runtime alongside the resolved
+ * workspace.json. `resolve()` builds the `$origins` array in priority
+ * order HIGH → LOW for readability, but the merge loop walks it so each
+ * later origin wins; the net effective precedence is:
  *
  *   1. Site origin    — `wp_admin_workspaces_site_tokens` option (highest)
  *   2. Theme origin   — `<stylesheet>/tokens.json`
@@ -16,6 +19,26 @@
  * structure fits naturally — group `$type` declarations cascade into
  * descendants client-side via the JS resolver
  * (`src/runtime/tokens/tokensResolver.mjs`).
+ *
+ * Cascade-ORDER deviation from the workspace.json cascade (documented in
+ * spec §9.1): the workspace.json cascade is
+ * `core → engine → plugin → site → role → user`, whereas tokens is
+ * `core → plugin → theme → site`. Two intentional differences:
+ *
+ *   - Tokens inserts a `theme` origin between `plugin` and `site`. Tokens
+ *     are a design-system primitive that the active block theme legitimately
+ *     owns (a theme's `tokens.json` rebrands the admin to match the front
+ *     end), so the theme sits above the plugin baseline but below explicit
+ *     site choices. The workspace.json cascade has no theme origin because
+ *     workspace *structure* (screens / menu / permissions) is not the
+ *     theme's concern.
+ *   - Tokens drop the `engine`, `role`, and `user` origins. Tokens are pure
+ *     visual primitives with no security surface and no per-role/per-user
+ *     authoring path today; there is nothing to gate or personalize at those
+ *     tiers. They can be added later without breaking the lower origins.
+ *
+ * No tombstones — tokens are additive, not restrict-only (a higher origin
+ * overrides a value but cannot delete a key the baseline ships).
  *
  * Authoring belongs in `tokens.json`; this class never coerces values.
  * Type coercion is the JS resolver's job because that's where the CSS
@@ -56,6 +79,25 @@ class WP_Admin_Workspaces_Tokens {
 			if ( is_array( $origin ) && ! empty( $origin ) ) {
 				$merged = self::deep_merge( $merged, $origin );
 			}
+		}
+
+		/**
+		 * Filter the fully merged DTCG tokens tree before it is cached and
+		 * shipped to the runtime.
+		 *
+		 * Symmetric with the `wp_admin_workspaces_data` final filter on the
+		 * workspace.json cascade: `wp_admin_workspaces_plugin_tokens` is the
+		 * per-origin loader hook (one origin), while this fires once on the
+		 * resolved result. Use it to inject computed values or strip private
+		 * token namespaces. The returned value is cached, so the filter runs
+		 * once per cache lifetime, not per page load.
+		 *
+		 * @param array $merged The merged tokens tree (empty array if no
+		 *                      origin contributed). Return an array.
+		 */
+		$merged = apply_filters( 'wp_admin_workspaces_tokens', $merged );
+		if ( ! is_array( $merged ) ) {
+			$merged = array();
 		}
 
 		wp_cache_set( self::CACHE_KEY, $merged, self::CACHE_GROUP );
@@ -121,8 +163,8 @@ class WP_Admin_Workspaces_Tokens {
 				isset( $base[ $key ] )
 				&& is_array( $base[ $key ] )
 				&& is_array( $value )
-				&& self::is_assoc( $base[ $key ] )
-				&& self::is_assoc( $value )
+				&& WP_Admin_Workspaces_Util::is_assoc( $base[ $key ] )
+				&& WP_Admin_Workspaces_Util::is_assoc( $value )
 			) {
 				$base[ $key ] = self::deep_merge( $base[ $key ], $value );
 			} else {
@@ -132,12 +174,6 @@ class WP_Admin_Workspaces_Tokens {
 		return $base;
 	}
 
-	private static function is_assoc( $arr ) {
-		if ( ! is_array( $arr ) || empty( $arr ) ) {
-			return false;
-		}
-		return array_keys( $arr ) !== range( 0, count( $arr ) - 1 );
-	}
 }
 
 // Defensive cache invalidation. Mirrors WP_Admin_Workspaces_Cache hook list:

--- a/tests/php/run-tokens-tests.php
+++ b/tests/php/run-tokens-tests.php
@@ -49,6 +49,7 @@ $T = 'WPAS_Tokens_Test_Runner';
 function wpas_tokens_reset() {
 	delete_option( 'wp_admin_workspaces_site_tokens' );
 	remove_all_filters( 'wp_admin_workspaces_plugin_tokens' );
+	remove_all_filters( 'wp_admin_workspaces_tokens' );
 	WP_Admin_Workspaces_Tokens::flush();
 }
 
@@ -122,6 +123,31 @@ echo "\n— deep merge keeps unrelated branches —\n";
 		'core size tree preserved (unrelated branch)',
 		isset( $tokens['size']['$type'] )
 	);
+}
+
+echo "\n— final wp_admin_workspaces_tokens filter —\n";
+{
+	wpas_tokens_reset();
+	add_filter( 'wp_admin_workspaces_tokens', function ( $merged ) {
+		$merged['computed'] = array( '$value' => 'injected' );
+		unset( $merged['size'] ); // strip a private namespace
+		return $merged;
+	} );
+	$tokens = WP_Admin_Workspaces_Tokens::resolve();
+	$T::assert_true( 'final filter injected computed value', isset( $tokens['computed']['$value'] ) );
+	$T::assert_eq( 'computed value passed through', 'injected', $tokens['computed']['$value'] );
+	$T::assert_true( 'final filter stripped namespace', ! isset( $tokens['size'] ) );
+	$T::assert_true( 'core color tree survives (only size stripped)', isset( $tokens['color'] ) );
+}
+
+{
+	wpas_tokens_reset();
+	// A filter returning a non-array must not corrupt the cache/runtime.
+	add_filter( 'wp_admin_workspaces_tokens', function () {
+		return 'not-an-array';
+	} );
+	$tokens = WP_Admin_Workspaces_Tokens::resolve();
+	$T::assert_true( 'non-array filter return coerced to array', is_array( $tokens ) );
 }
 
 echo "\n— cache —\n";

--- a/wp-admin-workspaces.php
+++ b/wp-admin-workspaces.php
@@ -192,6 +192,7 @@ add_action( 'init', function () {
 	update_option( 'wp_admin_workspaces_db_version', WP_ADMIN_WORKSPACES_DB_VERSION );
 }, 5 );
 
+require_once WP_ADMIN_WORKSPACES_PATH . 'includes/class-wp-admin-workspaces-util.php';
 require_once WP_ADMIN_WORKSPACES_PATH . 'includes/class-wp-admin-workspaces-can-rest.php';
 require_once WP_ADMIN_WORKSPACES_PATH . 'includes/class-wp-admin-workspaces-prefs-rest.php';
 require_once WP_ADMIN_WORKSPACES_PATH . 'includes/class-wp-admin-workspaces-themes-rest.php';


### PR DESCRIPTION
Closes #70.

Addresses the still-open items:
1. Dedup `is_assoc` → `WP_Admin_Workspaces_Util::is_assoc`. Merge keeps a public delegating alias; tokens + data-view-config drop their byte-identical copies. Modes keeps its own (deliberately empty-is-assoc) helper.
2. Adds the symmetric final `apply_filters( 'wp_admin_workspaces_tokens', $merged )` before the cache write, mirroring `wp_admin_workspaces_data`. Non-array returns coerce to `[]`.
4. Documents the tokens cascade-order deviation (core→plugin→theme→site vs the config cascade) + rationale in spec §9.1 and the class header.

Item 3 (conditional enqueue) was already resolved.

Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJCJhvpAwbc6xwKdufPBAE)_