### PR TITLE
feat(menu): per-item icon override / suppression via icon: null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ canonical in `docs/vocabulary-spec.md`.
   install would silently lose its active-workspace selection and re-enable a
   deliberately-disabled admin takeover. `uninstall.php` sweeps both namespaces.
 
+### Per-item menu icon suppression via `icon: null` (#72)
+
+A menu item bound to a screen can now render with **no icon** while keeping the screen binding, by declaring `icon: null` on the item. `bind_screens` switched from `isset` to `array_key_exists` for the `icon` re-fold, so an explicit `null` blocks inheritance where an absent key still inherits the screen's icon. Origin-sensitive: `null` authored over a lower origin's existing item is a tombstone (key-removal) → the screen icon re-inherits; suppression works only in the origin that first declares the item. See `docs/schema-sketch.md` §Drill-down icon inheritance for the worked before/after.
+
+- **Latent-bug fix / visual diff:** the renderer guard also changed from `icon={ resolveIcon( item.icon ) }` to `icon={ item.icon ? resolveIcon( item.icon ) : undefined }` (`SidebarDrilldownRenderer`). `resolveIcon` returns the engine **fallback** icon for any falsy name, so previously a screen-bound item whose screen had **no** icon rendered the generic fallback glyph; it now renders nothing — matching the documented "items without an icon render no icon" contract. Any item that was silently showing the fallback icon will now show no icon (expected, not a regression).
+- **Known limitation:** `icon: null` suppresses only the named `icon`; a screen that also carries an `iconSource` (the #127 arbitrary-icon escape hatch) still folds that in independently, and renderers prefer `iconSource` over `icon`, so such an item keeps an icon. The two are mutually exclusive in practice. Documented in the schema `icon` description + schema-sketch.
+
 ### Gutenberg dependency version-gated (WordPress 7.0)
 
 The hard Gutenberg requirement is now conditional on the WordPress version. The dependency was never about Gutenberg features — it was about the `wp-private-apis` allowlist: `@wordpress/ui` overlay components transitively opt into private APIs via `__dangerousOptInToUnstableAPIsOnlyForCoreModules`, and WordPress 6.7–6.9 core's allowlist excludes `@wordpress/theme` / `@wordpress/ui` / `@wordpress/dataviews`, so only the Gutenberg plugin's override unlocked them.

--- a/docs/schema-sketch.md
+++ b/docs/schema-sketch.md
@@ -238,6 +238,8 @@ The `detail` slot is engine-declared (a split-view layout). The editor mounts th
 
 Children nested inside a parent menu item do NOT inherit the parent's icon. Each screen renders its own icon; children without an icon render no icon. Authors who want children to look like their parent must declare the icon explicitly.
 
+A menu item that IS bound to a screen inherits the screen's `icon` automatically (folded in by `bind_screens`). To suppress it — render the item with **no icon** while keeping the screen binding — set `icon: null` on the menu item. `bind_screens` checks `array_key_exists` (not `isset`), so an explicit `null` blocks inheritance where an absent key would re-fold the screen icon. Author the `null` in the trust-tier origin where the item is first declared; the cascade treats `null` as a tombstone (key-removal) when it lands over a lower origin's existing item, in which case the key is dropped and the screen icon re-inherits.
+
 ## Modes
 
 Screens declare which engine-defined chrome mode they want. The engine maps each mode to a set of region states (visible / hidden / minimal). This is how an editor screen hides the sidebar and strips the toolbar without each screen having to know which regions exist.

--- a/docs/schema-sketch.md
+++ b/docs/schema-sketch.md
@@ -240,6 +240,24 @@ Children nested inside a parent menu item do NOT inherit the parent's icon. Each
 
 A menu item that IS bound to a screen inherits the screen's `icon` automatically (folded in by `bind_screens`). To suppress it — render the item with **no icon** while keeping the screen binding — set `icon: null` on the menu item. `bind_screens` checks `array_key_exists` (not `isset`), so an explicit `null` blocks inheritance where an absent key would re-fold the screen icon. Author the `null` in the trust-tier origin where the item is first declared; the cascade treats `null` as a tombstone (key-removal) when it lands over a lower origin's existing item, in which case the key is dropped and the screen icon re-inherits.
 
+**Caveat — `iconSource` folds independently.** `icon: null` suppresses only the named `icon`. If the bound screen ALSO carries an `iconSource` (the #127 arbitrary-icon escape hatch — a harvested data-URI / image-URL icon), that folds onto the item independently (its own `isset` guard in `bind_screens`, not gated by the `icon` opt-out), and every nav renderer prefers `iconSource` over `icon`. So an item whose screen declares both still shows an icon despite `icon: null`. In practice the two are mutually exclusive (the harvested-icon path doesn't set a named `icon`), but to *fully* suppress where both exist, also clear `iconSource`.
+
+**Worked example — origin sensitivity (the footgun).** `icon: null` only suppresses in the origin that *first declares* the item; authored over a lower origin's existing item it tombstones the key and the screen icon re-inherits — the opposite of what an author reaching for "strip this baseline icon" expects.
+
+```jsonc
+// core / plugin baseline declares the item (bound to the `posts` screen, which has an icon):
+//   menu.posts = {}                          → bind_screens folds in screen icon → item shows icon
+
+// CASE A — suppress in the SAME origin that declares the item (works):
+//   menu.posts = { "icon": null }            → array_key_exists('icon') is true → screen icon NOT folded → NO icon ✓
+
+// CASE B — override from a HIGHER consumer origin (site/role/user) over the baseline item (does NOT work):
+//   site:   menu.posts = { "icon": null }    → cascade reads null as a TOMBSTONE → removes the `icon` key
+//                                            → merged item has no `icon` key → bind_screens RE-FOLDS the screen icon → icon REAPPEARS ✗
+```
+
+To suppress a baseline item's icon from a higher origin you cannot use `icon: null` (it tombstones, then re-inherits). This is inherent to overloading `null` as both "suppress" (within-origin) and "tombstone" (cross-origin) in one cascade.
+
 ## Modes
 
 Screens declare which engine-defined chrome mode they want. The engine maps each mode to a set of region states (visible / hidden / minimal). This is how an editor screen hides the sidebar and strips the toolbar without each screen having to know which regions exist.

--- a/docs/schemas/workspace.json
+++ b/docs/schemas/workspace.json
@@ -507,9 +507,9 @@
 					"description": "Optional override of the bound screen's label. Required for items not bound to a screen (group containers, external links). When set on an item that is bound to a screen, renames the entry in the menu only — the screen itself is untouched."
 				},
 				"icon": {
-					"type": "string",
+					"type": [ "string", "null" ],
 					"minLength": 1,
-					"description": "Optional override of the bound screen's icon. Required for items not bound to a screen. Children nested inside a parent menu item do NOT inherit the parent's icon — each item renders its own icon, and items without an icon render no icon. See schema-sketch.md §Drill-down icon inheritance."
+					"description": "Optional override of the bound screen's icon. Required for items not bound to a screen. Set to `null` to explicitly suppress the icon on an item that IS bound to a screen — unlike an absent key (which inherits the screen's icon), an explicit `null` renders no icon. (Authored in a trust-tier origin where the item is first declared; setting `null` over a lower origin's existing item tombstones the key, which lets the screen icon re-inherit.) Children nested inside a parent menu item do NOT inherit the parent's icon — each item renders its own icon, and items without an icon render no icon. See schema-sketch.md §Drill-down icon inheritance."
 				},
 				"iconSource": {
 					"$ref": "#/$defs/iconSource",

--- a/docs/schemas/workspace.json
+++ b/docs/schemas/workspace.json
@@ -509,7 +509,7 @@
 				"icon": {
 					"type": [ "string", "null" ],
 					"minLength": 1,
-					"description": "Optional override of the bound screen's icon. Required for items not bound to a screen. Set to `null` to explicitly suppress the icon on an item that IS bound to a screen — unlike an absent key (which inherits the screen's icon), an explicit `null` renders no icon. (Authored in a trust-tier origin where the item is first declared; setting `null` over a lower origin's existing item tombstones the key, which lets the screen icon re-inherit.) Children nested inside a parent menu item do NOT inherit the parent's icon — each item renders its own icon, and items without an icon render no icon. See schema-sketch.md §Drill-down icon inheritance."
+					"description": "Optional override of the bound screen's icon. Required for items not bound to a screen. Set to `null` to explicitly suppress the icon on an item that IS bound to a screen — unlike an absent key (which inherits the screen's icon), an explicit `null` renders no icon. (Authored in a trust-tier origin where the item is first declared; setting `null` over a lower origin's existing item tombstones the key, which lets the screen icon re-inherit.) NOTE: `icon: null` suppresses only the named `icon`; if the bound screen ALSO carries an `iconSource` (the arbitrary-icon escape hatch), that still folds in independently and renderers prefer it over `icon`, so the item keeps an icon — to fully suppress, also clear `iconSource`. Children nested inside a parent menu item do NOT inherit the parent's icon — each item renders its own icon, and items without an icon render no icon. See schema-sketch.md §Drill-down icon inheritance."
 				},
 				"iconSource": {
 					"$ref": "#/$defs/iconSource",

--- a/includes/cascade/class-wp-admin-workspaces-menu-items.php
+++ b/includes/cascade/class-wp-admin-workspaces-menu-items.php
@@ -517,7 +517,11 @@ class WP_Admin_Workspaces_Menu_Items {
 				if ( ! isset( $item['label'] ) && isset( $screen['label'] ) ) {
 					$item['label'] = $screen['label'];
 				}
-				if ( ! isset( $item['icon'] ) && isset( $screen['icon'] ) ) {
+				// `array_key_exists` (not `isset`) so an explicit `icon: null`
+				// on the menu item suppresses inheritance — the author opted
+				// out of the screen icon. `isset` is false for a null value
+				// and would re-fold the screen icon right back (#72).
+				if ( ! array_key_exists( 'icon', $item ) && isset( $screen['icon'] ) ) {
 					$item['icon'] = $screen['icon'];
 				}
 				// Arbitrary-icon escape hatch (#127): a harvested data-URI /

--- a/src/apps/navigation/_renderers/SidebarDrilldownRenderer.js
+++ b/src/apps/navigation/_renderers/SidebarDrilldownRenderer.js
@@ -95,7 +95,9 @@ function renderCollapsedItem( item, index, currentPrimary ) {
 				{ item.iconSource ? (
 					<ArbitraryIcon iconSource={ item.iconSource } size={ 24 } />
 				) : (
-					<Icon icon={ resolveIcon( item.icon ) } size={ 24 } />
+					item.icon && (
+						<Icon icon={ resolveIcon( item.icon ) } size={ 24 } />
+					)
 				) }
 			</a>
 		);
@@ -127,7 +129,7 @@ function renderCollapsedItem( item, index, currentPrimary ) {
 			tone="neutral"
 			variant="minimal"
 			className="wp-admin-workspaces-nav__item"
-			icon={ resolveIcon( item.icon ) }
+			icon={ item.icon ? resolveIcon( item.icon ) : undefined }
 			render={
 				<a
 					href={ item.href }
@@ -318,7 +320,7 @@ function renderRootItem( item, index, currentPrimary, navState ) {
 			<SidebarNavigationItem
 				key={ `screen-${ item.id }` }
 				uid={ `screen-${ item.id }` }
-				icon={ resolveIcon( item.icon ) }
+				icon={ item.icon ? resolveIcon( item.icon ) : undefined }
 				iconSource={ item.iconSource }
 				withChevron
 				isActive={ isActive }
@@ -366,7 +368,7 @@ function renderLeafItem( item, index, currentPrimary ) {
 			<SidebarNavigationItem
 				key={ `ext-${ item.id || index }` }
 				uid={ `ext-${ item.id || index }` }
-				icon={ resolveIcon( item.icon ) }
+				icon={ item.icon ? resolveIcon( item.icon ) : undefined }
 				iconSource={ item.iconSource }
 				href={ item.href }
 				target="_blank"
@@ -392,7 +394,7 @@ function renderLeafItem( item, index, currentPrimary ) {
 		<SidebarNavigationItem
 			key={ item.id || `nav-${ index }` }
 			uid={ `nav-${ item.id || index }` }
-			icon={ resolveIcon( item.icon ) }
+			icon={ item.icon ? resolveIcon( item.icon ) : undefined }
 			iconSource={ item.iconSource }
 			isActive={ isActive }
 			href={ item.href }

--- a/src/apps/navigation/_renderers/SidebarTreeRenderer.js
+++ b/src/apps/navigation/_renderers/SidebarTreeRenderer.js
@@ -150,7 +150,11 @@ function TreeLeaf( { item, index, currentPrimary, depth } ) {
 		return (
 			<SidebarNavigationItem
 				uid={ `ext-${ item.id || index }` }
-				icon={ depth === 0 ? resolveIcon( item.icon ) : undefined }
+				icon={
+					depth === 0 && item.icon
+						? resolveIcon( item.icon )
+						: undefined
+				}
 				iconSource={ depth === 0 ? item.iconSource : undefined }
 				href={ item.href }
 				target="_blank"
@@ -176,7 +180,11 @@ function TreeLeaf( { item, index, currentPrimary, depth } ) {
 	return (
 		<SidebarNavigationItem
 			uid={ `nav-${ item.id || index }` }
-			icon={ depth === 0 ? resolveIcon( item.icon ) : undefined }
+			icon={
+				depth === 0 && item.icon
+					? resolveIcon( item.icon )
+					: undefined
+			}
 			iconSource={ depth === 0 ? item.iconSource : undefined }
 			isActive={ isActive }
 			href={ item.href }

--- a/src/apps/navigation/_renderers/SidebarTreeRenderer.js
+++ b/src/apps/navigation/_renderers/SidebarTreeRenderer.js
@@ -181,9 +181,7 @@ function TreeLeaf( { item, index, currentPrimary, depth } ) {
 		<SidebarNavigationItem
 			uid={ `nav-${ item.id || index }` }
 			icon={
-				depth === 0 && item.icon
-					? resolveIcon( item.icon )
-					: undefined
+				depth === 0 && item.icon ? resolveIcon( item.icon ) : undefined
 			}
 			iconSource={ depth === 0 ? item.iconSource : undefined }
 			isActive={ isActive }

--- a/tests/php/run-menu-route-shims-tests.php
+++ b/tests/php/run-menu-route-shims-tests.php
@@ -548,6 +548,42 @@ WPAS_Shim_Test_Runner::assert_eq(
 	'#/posts/drafts'
 );
 
+// Explicit `icon: null` on a screen-bound menu item suppresses the
+// inherited screen icon (#72). `bind_screens` uses `array_key_exists`,
+// not `isset`, so a present-but-null key blocks the re-fold. The item is
+// first declared in this (plugin) origin, so the null survives the
+// cascade rather than being tombstone-removed.
+WP_Admin_Workspaces_Menu_Items::reset();
+WP_Admin_Workspaces_Resolver::reset_request_memo();
+if ( class_exists( 'WP_Admin_Workspaces_Cache' ) ) {
+	WP_Admin_Workspaces_Cache::flush();
+}
+$plugin_doc_noicon                          = wpas_shim_test_v3_doc();
+$plugin_doc_noicon['menu']['posts']['icon'] = null;
+$origins_noicon                             = array(
+	'core'   => array(),
+	'engine' => array(),
+	'plugin' => $plugin_doc_noicon,
+	'site'   => array(),
+	'role'   => array(),
+	'user'   => array(),
+);
+$resolved_noicon                            = WP_Admin_Workspaces_Resolver::resolve_with( $origins_noicon );
+WPAS_Shim_Test_Runner::assert_true(
+	'screen-binding: explicit null icon survives the cascade',
+	array_key_exists( 'icon', $resolved_noicon['menu']['posts'] )
+);
+WPAS_Shim_Test_Runner::assert_true(
+	'screen-binding: explicit null icon suppresses screen-icon re-fold',
+	$resolved_noicon['menu']['posts']['icon'] === null
+);
+// Control: a sibling item with no icon key still inherits the screen icon.
+WPAS_Shim_Test_Runner::assert_eq(
+	'screen-binding: absent icon key still inherits screen icon',
+	$resolved_noicon['menu']['dashboard']['icon'],
+	'dashboard'
+);
+
 // `hidden: true` on screen propagates to menu item.
 $plugin_doc_hidden                                = wpas_shim_test_v3_doc();
 $plugin_doc_hidden['screens']['posts']['hidden']  = true;


### PR DESCRIPTION
Closes #72.

A menu item bound to a screen inherits the screen icon via `bind_screens`. Authors could not suppress an item's menu icon without touching the screen.

- Schema: `menuItem.icon` accepts `string|null`; null = explicit "no icon".
- `bind_screens`: uses `array_key_exists` (not `isset`) so a present-but-null icon blocks the screen-icon re-fold.
- Renderers: guard `item.icon` before `resolveIcon` in SidebarDrilldown (5 sites) + SidebarTree leaf paths (2 sites).
- Regression test in `run-menu-route-shims-tests.php`.

Note: null over a lower-origin item tombstones the key (cascade key-removal) and the screen icon re-inherits — documented in schema-sketch.md.

Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJCJhvpAwbc6xwKdufPBAE)_