### PR TITLE
Fix cloud-setup so wp-env + screenshots actually work in the sandbox

### DIFF
--- a/docs/cloud-environment.md
+++ b/docs/cloud-environment.md
@@ -34,44 +34,63 @@ aborts the session).
    `|| true` guarantees a clean exit so the session always launches; the script
    then `cd`s to its own repo root internally.
 
-3. **Network access** — the default *Trusted* allowlist already covers Docker
-   Hub, npm, and GitHub, but **not** WordPress.org or the Playwright browser
-   CDN. Choose **Custom** (Trusted + the domains below) or **Full**:
+3. **Network access** — the sandbox egress policy is stricter than it looks,
+   and the setup script is built around what is *actually* reachable
+   (verified empirically, June 2026):
 
-   | Why | Domains to allow |
-   |---|---|
-   | wp-env downloads WP core + the Gutenberg plugin zip | `*.wordpress.org` (covers `downloads.wordpress.org`, `api.wordpress.org`) |
-   | Playwright downloads the Chromium binary | `cdn.playwright.dev`, `playwright.download.prss.microsoft.com` |
+   | Status | Hosts | Used for |
+   |---|---|---|
+   | reachable | `registry-1.docker.io` | Docker Hub **manifests only** |
+   | reachable | `mirror.gcr.io`, `public.ecr.aws` | Docker image **layers** (mirrors of Docker Hub) |
+   | reachable | `downloads.wordpress.org`, `api.wordpress.org` | WP core / plugin zips |
+   | reachable | `cdn.playwright.dev` | Chromium for screenshots |
+   | **blocked** | `production.cloudfront.docker.com` | Docker Hub's layer CDN — direct `docker pull` always 403s mid-pull |
+   | **blocked** | `deb.debian.org`, `security.debian.org`, `dl-cdn.alpinelinux.org` | apt/apk inside image builds |
+   | **blocked** | `getcomposer.org`, `composer.github.io`, `pecl.php.net` | composer / pecl inside image builds |
 
-   Without `*.wordpress.org`, `wp-env start` fails (no WordPress to install).
-   Without the Playwright CDN, screenshots are unavailable but tests still run.
+   The script routes around every blocked host (registry mirror + the
+   `@wordpress/env` patch below), so the default policy works as-is. If
+   screenshots fail, allowlist `cdn.playwright.dev`; if WordPress downloads
+   fail, allowlist `*.wordpress.org`.
 
 That's it. New sessions re-run the setup script automatically. Docker **images**
 are cached between sessions; **containers** start fresh, so `wp-env start` runs
 each session (fast once images are cached).
 
-### Docker Hub pull rate limit (credential-free)
+### How the script routes around the blocked hosts
 
-wp-env pulls four images from Docker Hub: `mariadb:lts`, `phpmyadmin`, and the
-`wordpress` / `wordpress:cli` bases for its WP + CLI service builds. Cloud
-sessions share an egress IP, so the **anonymous** pull limit can trip — it
-surfaces as a `403 Forbidden` mid-pull ("You have reached your unauthenticated
-pull rate limit").
+Two mechanisms, both committed to the repo:
 
-The setup script handles this **without any credentials**:
+- **Registry mirror** — `/etc/docker/daemon.json` gets
+  `"registry-mirrors": ["https://mirror.gcr.io"]` before `dockerd` starts, so
+  every `docker.io` pull (the four wp-env images: `mariadb:lts`, `phpmyadmin`,
+  `wordpress`, `wordpress:cli`) transparently rides Google's mirror instead of
+  Docker Hub's blocked CDN. A per-image fallback retags from
+  `public.ecr.aws/docker/library/*` if the mirror ever misses. No Docker Hub
+  login, token, or secret is required or stored anywhere.
 
-- **Cache-aware** — it skips any image already present in `/var/lib/docker`
-  (which persists between sessions), so a warm session makes *zero* Docker Hub
-  requests. Even a cached re-pull would spend a manifest request against the
-  quota, so skipping matters.
-- **Cold-pull retry** — a first-time pull retries with backoff to ride out
-  transient throttling, then `wp-env start` retries a few times too.
+- **`scripts/wp-env-offline-patch.mjs`** — patches `@wordpress/env` in
+  `node_modules` after `npm ci` (idempotent; exact-match anchors fail loudly if
+  an upstream upgrade reshapes the templates). It fixes two unrelated classes
+  of failure that each hard-block a stock `wp-env start`:
 
-Four pulls is well under the anonymous ceiling, and they only happen once
-(thereafter the cache covers it). The only case the script can't paper over is a
-**fully exhausted shared-IP quota** — that resets with time (~6h); just retry
-`npx wp-env start` in-session later. No Docker Hub login, token, or secret is
-required or stored anywhere.
+  1. *Blocked package CDNs* — wp-env's generated Dockerfiles run
+     `apt-get`/`apk update`, install `$PHPIZE_DEPS` + sudo + git, and download
+     Composer + PHPUnit at build time. All those hosts are blocked, so the
+     build dies on `RUN apk update` (exit 2). The patch drops every
+     network-touching step, keeping the offline-safe parts (user creation,
+     `php.ini` upload limits). Trade-off: no composer/phpunit/sudo inside the
+     containers and no `--xdebug`/`--spx` — none of which this repo's
+     `wp eval-file`-based PHP suites use.
+  2. *Sandbox runs as root (uid 0)* — wp-env maps the host user into its
+     containers, so Apache starts as root and refuses (`AH00526` …
+     "Apache has not been designed to serve pages while running as root"; the
+     `wordpress` services exit 1), and wp-cli rejects every command without
+     `--allow-root`. The patch falls back to `www-data` for
+     `APACHE_RUN_USER`/`GROUP` when the host uid is 0 and bakes
+     `ENV WP_CLI_ALLOW_ROOT=1` into the CLI images. The setup script then
+     `chmod -R a+rwX`s the WordPress `wp-content` trees so `www-data` can
+     still write uploads.
 
 > **`@wordpress/env` is a committed devDependency.** It is otherwise only an
 > *optional* peer dependency of `@wordpress/scripts`, so `npm ci` would skip it
@@ -83,10 +102,13 @@ required or stored anywhere.
 
 | Step | Result |
 |---|---|
-| Start `dockerd` | Docker daemon available for wp-env |
+| Configure registry mirror + start `dockerd` | Docker daemon available, `docker.io` pulls ride `mirror.gcr.io` |
+| Warm image cache | The four wp-env images present (skipped when cached from a prior session) |
 | `npm ci` + `npm run build` | Dependencies installed, plugin built into `build/` |
-| `npx wp-env start --update` | Dev site `http://localhost:8888`, test site `http://localhost:8889` |
-| `playwright install chromium` | Headless browser for screenshots (installed globally) |
+| `node scripts/wp-env-offline-patch.mjs` | `@wordpress/env` patched for offline builds + root sandbox |
+| `npx wp-env start` | Dev site `http://localhost:8888`, test site `http://localhost:8889` |
+| `chmod -R a+rwX` the wp-content trees | Apache (`www-data`) can write uploads despite root-owned files |
+| `playwright install chromium` (no `--with-deps` — apt is blocked) | Headless browser for screenshots |
 
 Sandbox resources: 4 vCPU / 16 GB RAM / 30 GB disk — ample for this stack.
 
@@ -135,17 +157,31 @@ Defaults match wp-env (`admin` / `password` on `:8888`). Override via
 
 ## Troubleshooting
 
-- **`wp-env start` fails with `403 Forbidden` / "unauthenticated pull rate
-  limit"** — Docker Hub throttled the shared egress IP. The setup script skips
-  cached images and retries cold pulls with backoff, so this only bites a cold
-  cache on an already-exhausted IP. Wait for the anonymous limit to reset (~6h),
-  then re-run `npx wp-env start`; once the four images are cached, later sessions
-  don't pull at all.
+- **`docker pull` dies with `403 Forbidden` from
+  `production.cloudfront.docker.com`** — Docker Hub's layer CDN is blocked by
+  the egress policy (manifests resolve, layers don't — this is NOT the
+  anonymous pull rate limit). Confirm `docker info` lists
+  `https://mirror.gcr.io/` under Registry Mirrors; if not, re-run
+  `bash scripts/cloud-setup.sh` (it writes `/etc/docker/daemon.json` and
+  restarts `dockerd`).
+- **`wp-env start` dies building images on `RUN apk update` (exit 2) or
+  `apt-get` errors** — the `@wordpress/env` patch isn't applied (an
+  `npm ci`/`npm install` restores the pristine package). Re-apply:
+  `node scripts/wp-env-offline-patch.mjs && npx wp-env start`.
+- **`wordpress` / `tests-wordpress` containers exit 1 with Apache `AH00526`
+  ("not designed to serve pages while running as root")** — same cause: the
+  patch (which maps `APACHE_RUN_USER` to `www-data` for a root host user)
+  isn't applied. Re-apply as above; wp-env regenerates its docker-compose.yml
+  on every start.
+- **wp-cli refuses with "Please run this again, adding … --allow-root"** —
+  the patched CLI images bake in `WP_CLI_ALLOW_ROOT=1`; re-apply the patch and
+  `npx wp-env start` to rebuild them.
 - **`npx wp-env` errors with `404 Not Found … 'wp-env@*' is not in this
   registry`** — `@wordpress/env` isn't installed. Run `npm ci` (it's a committed
   devDependency); npx 404s because there is no bare `wp-env` npm package.
-- **`wp-env start` hangs or fails** — confirm `*.wordpress.org` is allowlisted
-  and `docker info` succeeds. Re-run `npx wp-env start`.
+- **`wp-env start` hangs or fails some other way** — confirm `docker info`
+  succeeds and `downloads.wordpress.org` is reachable. Re-run
+  `npx wp-env start`.
 - **`wp-cli not reachable`** — the DB container needs a few seconds after start;
   retry the `wp eval-file` command.
 - **Screenshot can't find playwright** — the helper falls back to the global

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -19,21 +19,34 @@
 # self-locates its own repo root (below) and cd's there.
 #
 # What it does, mirroring our local toolchain:
-#   1. Ensures the Docker daemon is running (wp-env needs it).
+#   1. Starts the Docker daemon with mirror.gcr.io as a registry mirror —
+#      Docker Hub's blob CDN (production.cloudfront.docker.com) is BLOCKED by
+#      the sandbox egress policy (manifests resolve, every layer 403s), so all
+#      docker.io pulls must ride Google's mirror.
 #   2. npm ci + production build.
-#   3. `wp-env start` — boots the SAME WordPress stack we use locally
-#      (dev site :8888, test site :8889) so the agent can run every PHP test
-#      and anything that needs a live WP install.
+#   3. Patches @wordpress/env for the sandbox (scripts/wp-env-offline-patch.mjs):
+#      strips apt/apk/composer steps from its generated Dockerfiles (those
+#      package CDNs are blocked too) and fixes the two run-as-root failures
+#      (Apache AH00526, wp-cli --allow-root). Then `wp-env start` boots the
+#      SAME WordPress stack we use locally (dev :8888, test :8889) so the
+#      agent can run every PHP test against a live WP install.
 #   4. Installs headless Chromium so the agent can drive the site with
-#      Playwright and capture screenshots for review.
+#      Playwright and capture screenshots for review. NO --with-deps: that
+#      flag shells out to apt-get (blocked); the sandbox image already has
+#      the shared libraries Chromium needs.
 #
 # Runs as root on Ubuntu 24.04 BEFORE the agent session starts. A non-zero
 # exit makes the whole session fail to launch, so every step is best-effort
 # and we always `exit 0` — the agent diagnoses failures from the logs below.
 #
-# NETWORK: requires egress to *.wordpress.org (WP core + Gutenberg zip) and the
-# Playwright browser CDN. Docker Hub / npm / GitHub are on the default Trusted
-# allowlist. See docs/cloud-environment.md for the exact domains to allow.
+# NETWORK (sandbox egress policy, verified empirically):
+#   reachable: registry-1.docker.io (manifests only), mirror.gcr.io,
+#              public.ecr.aws, downloads.wordpress.org, api.wordpress.org,
+#              cdn.playwright.dev, npm, GitHub
+#   blocked:   production.cloudfront.docker.com (Docker Hub layer CDN),
+#              deb.debian.org, security.debian.org, dl-cdn.alpinelinux.org,
+#              getcomposer.org, composer.github.io, pecl.php.net
+# See docs/cloud-environment.md for the full matrix and what depends on what.
 
 set -uo pipefail
 
@@ -45,8 +58,27 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 log "repo root: $REPO_ROOT"
 
-# --- 1. Docker daemon ------------------------------------------------------
-# Installed in the sandbox but not always started. wp-env is Docker-based.
+# --- 1. Docker daemon with a registry mirror -------------------------------
+# Docker Hub manifest requests succeed but layer downloads redirect to
+# production.cloudfront.docker.com, which the egress policy 403s — a plain
+# `docker pull` therefore always dies mid-pull. mirror.gcr.io serves the same
+# library images and IS reachable, so route all docker.io pulls through it.
+MIRROR_URL="https://mirror.gcr.io"
+if ! grep -qs "$MIRROR_URL" /etc/docker/daemon.json 2>/dev/null; then
+	if [ -s /etc/docker/daemon.json ]; then
+		warn "replacing existing /etc/docker/daemon.json (backup: daemon.json.bak)"
+		cp /etc/docker/daemon.json /etc/docker/daemon.json.bak
+	fi
+	mkdir -p /etc/docker
+	printf '{\n  "registry-mirrors": ["%s"]\n}\n' "$MIRROR_URL" > /etc/docker/daemon.json
+	# A daemon started before the mirror was configured must be restarted.
+	if docker info >/dev/null 2>&1; then
+		log "restarting dockerd to pick up the registry mirror..."
+		pkill dockerd 2>/dev/null
+		sleep 3
+	fi
+fi
+
 if ! docker info >/dev/null 2>&1; then
 	log "starting dockerd in the background..."
 	dockerd >/var/log/dockerd.log 2>&1 &
@@ -56,43 +88,43 @@ if ! docker info >/dev/null 2>&1; then
 	done
 fi
 if docker info >/dev/null 2>&1; then
-	log "docker daemon is up"
+	log "docker daemon is up (mirror: $MIRROR_URL)"
 else
 	warn "docker is not available — wp-env (PHP tests / live WP) will not start"
 fi
 
-# --- Docker Hub images (credential-free, cache-aware) ----------------------
-# wp-env pulls four images from Docker Hub: mariadb:lts, phpmyadmin, and the
-# `wordpress` / `wordpress:cli` bases for its WP + CLI service builds. Cloud
-# sessions share an egress IP, so the ANONYMOUS pull rate limit can trip ("You
-# have reached your unauthenticated pull rate limit" → 403 mid-pull). Two things
-# keep this credential-free:
-#   - Docker images persist in /var/lib/docker between sessions, so we SKIP any
-#     image already cached — a warm session makes ZERO Docker Hub requests (even
-#     a cached re-pull spends a manifest request against the quota).
-#   - A cold pull retries with backoff to ride out transient throttling. A fully
-#     exhausted shared-IP quota only resets with time (~6h); the retry can't beat
-#     that, so we fail soft and let the agent retry the pull in-session later.
+# --- Docker images (mirror-first, cache-aware) ------------------------------
+# wp-env needs four docker.io library images: mariadb:lts, phpmyadmin, and the
+# `wordpress` / `wordpress:cli` bases for its WP + CLI service builds.
+#   - Images persist in /var/lib/docker between sessions, so anything cached
+#     is skipped outright.
+#   - A cold pull rides the registry mirror (above). If the mirror ever fails,
+#     fall back to AWS's Docker Hub mirror (public.ecr.aws) and retag.
 ensure_image() {
 	img="$1"
 	if docker image inspect "$img" >/dev/null 2>&1; then
 		log "image cached, skipping pull: $img"
 		return 0
 	fi
-	for attempt in 1 2 3 4; do
+	for attempt in 1 2; do
 		if docker pull "$img" >/dev/null 2>&1; then
-			log "pulled: $img"
+			log "pulled (via mirror): $img"
 			return 0
 		fi
-		warn "pull failed for $img (attempt ${attempt}/4) — backing off..."
-		sleep $(( attempt * attempt * 3 ))
+		warn "pull failed for $img (attempt ${attempt}/2) — backing off..."
+		sleep $(( attempt * 5 ))
 	done
-	warn "could not pull $img (Docker Hub rate limit?) — wp-env start may fail; retry in-session"
+	ecr="public.ecr.aws/docker/library/$img"
+	if docker pull "$ecr" >/dev/null 2>&1 && docker tag "$ecr" "$img"; then
+		log "pulled (via public.ecr.aws): $img"
+		return 0
+	fi
+	warn "could not pull $img from any reachable registry — wp-env start may fail; retry in-session"
 	return 1
 }
 
 if docker info >/dev/null 2>&1; then
-	log "warming Docker Hub image cache (skips anything already cached)..."
+	log "warming Docker image cache (skips anything already cached)..."
 	for img in mariadb:lts phpmyadmin wordpress wordpress:cli; do
 		ensure_image "$img" || true
 	done
@@ -106,13 +138,18 @@ log "building the plugin (wp-scripts build)..."
 npm run build || warn "build failed — check the log above"
 
 # --- 3. WordPress via wp-env ----------------------------------------------
-# Pulls WP core + the Gutenberg plugin zip from *.wordpress.org and starts the
-# Docker stack. --update keeps core/plugins fresh; falls back to plain start.
-# Images were warmed above, so a healthy run starts containers without pulling.
-log "starting wp-env (first run downloads WordPress + builds containers)..."
+# First patch @wordpress/env for the sandbox (MUST follow npm ci, which
+# restores the pristine package). The patch is idempotent and fails loudly if
+# an @wordpress/env upgrade reshapes the templates it edits. Without it,
+# `wp-env start` dies twice over: image builds hit blocked apt/apk/composer
+# CDNs, and the root sandbox user trips Apache's AH00526 + wp-cli's root guard.
+log "patching @wordpress/env for sandboxed (offline, root) operation..."
+node "$SCRIPT_DIR/wp-env-offline-patch.mjs" || warn "wp-env patch failed — wp-env start will likely fail; see message above"
+
+log "starting wp-env (builds local images, installs WordPress)..."
 wp_env_up=""
 for attempt in 1 2 3; do
-	if npx wp-env start --update || npx wp-env start; then
+	if npx wp-env start; then
 		wp_env_up="yes"
 		break
 	fi
@@ -121,32 +158,36 @@ for attempt in 1 2 3; do
 done
 if [ -n "$wp_env_up" ]; then
 	log "wp-env is up — dev site http://localhost:8888  |  test site http://localhost:8889"
+	# Apache runs as www-data (not the root host user — see the patch), so let
+	# it write uploads/upgrade dirs inside the root-owned WordPress trees.
+	chmod -R a+rwX "$HOME"/.wp-env/*/WordPress/wp-content \
+		"$HOME"/.wp-env/*/tests-WordPress/wp-content 2>/dev/null \
+		|| warn "could not open up wp-content permissions — media uploads may fail"
 	# Sanity check that wp-cli works inside the container (this is how PHP tests run).
 	npx wp-env run cli wp core version 2>/dev/null \
 		&& log "wp-cli reachable inside the container" \
 		|| warn "wp-cli not reachable yet — give the DB a moment, then retry in-session"
 else
 	warn "wp-env start failed. Common causes, in order of likelihood:"
-	warn "  1. Docker Hub pull rate limit (403 'unauthenticated pull rate limit')."
-	warn "     Cached images make this a non-issue after the first successful run;"
-	warn "     a fully exhausted shared-IP quota resets with time (~6h). Retry"
-	warn "     in-session with: npx wp-env start"
-	warn "  2. *.wordpress.org not allowlisted (no WP core / Gutenberg to install)."
+	warn "  1. The @wordpress/env offline patch did not apply (see step 3 above) —"
+	warn "     image builds then hit blocked package CDNs and die on 'apk update'."
+	warn "  2. Docker images missing AND both mirrors unreachable (see pull warnings)."
 	warn "  3. docker daemon not up (see step 1 above)."
+	warn "  Retry in-session with: node scripts/wp-env-offline-patch.mjs && npx wp-env start"
 fi
 
 # --- 4. Headless browser for screenshot review ----------------------------
 # @wordpress/scripts pulls Playwright in as a local (transitive) dependency, and
 # scripts/screenshot.mjs resolves the LOCAL playwright first. Install the browser
-# for THAT exact version via the local binary so versions never skew (a global
-# `playwright` of a different version downloads a mismatched Chromium build the
-# launch then can't find). `--with-deps` adds the OS libraries Chromium needs.
-log "installing Playwright + Chromium for screenshots..."
-if npx --no-install playwright install --with-deps chromium >/dev/null 2>&1 \
-	|| npx --yes playwright install --with-deps chromium >/dev/null 2>&1; then
+# for THAT exact version via the local binary so versions never skew. Do NOT use
+# --with-deps: it shells out to apt-get, which the egress policy blocks, and the
+# sandbox image already ships the shared libraries headless Chromium needs.
+log "installing Playwright Chromium for screenshots..."
+if npx --no-install playwright install chromium \
+	|| npx --yes playwright install chromium; then
 	log "Playwright Chromium ready — use: node scripts/screenshot.mjs <path> [out.png]"
 else
-	warn "Playwright/Chromium install failed — allowlist the Playwright CDN (see docs/cloud-environment.md)"
+	warn "Playwright/Chromium install failed — allowlist cdn.playwright.dev (see docs/cloud-environment.md)"
 fi
 
 log "setup complete."

--- a/scripts/wp-env-offline-patch.mjs
+++ b/scripts/wp-env-offline-patch.mjs
@@ -1,0 +1,170 @@
+/**
+ * Patches @wordpress/env for sandboxed cloud sessions (Claude Code on the web).
+ *
+ * Two classes of problem make a stock `wp-env start` impossible in the cloud
+ * sandbox, and neither can be fixed from .wp-env.json:
+ *
+ * 1. NETWORK — the generated Dockerfiles run `apt-get update`/`apk update`,
+ *    install $PHPIZE_DEPS + sudo + git, and download Composer + PHPUnit at
+ *    image build time. The sandbox egress policy blocks every host those
+ *    steps need (deb.debian.org, security.debian.org, dl-cdn.alpinelinux.org,
+ *    getcomposer.org, composer.github.io, pecl.php.net), so the build dies on
+ *    `RUN apk update` (exit 2). None of those tools matter for this repo's
+ *    workflow: PHP tests run via `wp eval-file` (no phpunit/composer) and
+ *    xdebug/SPX stay off — so the steps are dropped, keeping the offline-safe
+ *    parts (user creation, php.ini upload limits, sudoers entry).
+ *
+ * 2. ROOT — the sandbox runs as uid 0, and wp-env maps the host user into the
+ *    containers. Apache hard-refuses to run as root (AH00526 at startup, the
+ *    wordpress services exit 1), and wp-cli refuses every command without
+ *    --allow-root. So: APACHE_RUN_USER/GROUP falls back to www-data when the
+ *    host uid is 0, and the CLI images get ENV WP_CLI_ALLOW_ROOT=1.
+ *
+ * Idempotent (marker comment short-circuits re-runs). Re-apply after any
+ * `npm ci`/`npm install` — scripts/cloud-setup.sh does this automatically.
+ * Anchors are exact-match on the @wordpress/env source: an upstream upgrade
+ * that reshapes either template fails loudly here instead of silently
+ * generating a config that breaks again.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+const MARKER = '/* cloud-offline-patch applied */';
+const require = createRequire( import.meta.url );
+
+// The package's `exports` map blocks deep subpath resolution, so resolve the
+// package root via its exported package.json and join from there.
+let pkgRoot;
+try {
+	pkgRoot = dirname( require.resolve( '@wordpress/env/package.json' ) );
+} catch {
+	console.error(
+		'[wp-env-offline-patch] @wordpress/env not installed — run npm ci first.'
+	);
+	process.exit( 1 );
+}
+
+/**
+ * Applies exact-match replacements to one file, failing loudly when an anchor
+ * is missing or matches an unexpected number of times.
+ *
+ * @param {string} relPath      Path of the file inside @wordpress/env.
+ * @param {Array}  replacements [anchor, replacement, label, expectedCount][].
+ */
+function patchFile( relPath, replacements ) {
+	const target = join( pkgRoot, relPath );
+	let source = readFileSync( target, 'utf8' );
+
+	if ( source.includes( MARKER ) ) {
+		console.log(
+			`[wp-env-offline-patch] ${ relPath } already patched, skipping.`
+		);
+		return;
+	}
+
+	for ( const [ anchor, replacement, label, count = 1 ] of replacements ) {
+		const found = source.split( anchor ).length - 1;
+		if ( found !== count ) {
+			console.error(
+				`[wp-env-offline-patch] anchor for "${ label }" matched ` +
+					`${ found }x (expected ${ count }x) in ${ relPath } — ` +
+					'@wordpress/env changed; update this patch.'
+			);
+			process.exit( 1 );
+		}
+		source = source.split( anchor ).join( replacement );
+	}
+
+	writeFileSync( target, `${ MARKER }\n${ source }` );
+	console.log( `[wp-env-offline-patch] patched ${ relPath }` );
+}
+
+// --- 1. Dockerfile generation: drop every network-dependent build step. ----
+patchFile( 'lib/runtime/docker/init-config.js', [
+	[
+		// WordPress (debian) service: drop apt-get steps, keep the php.ini
+		// touch (later RUN echo lines append to it) + the sudoers entry.
+		`# Make sure we're working with the latest packages.
+RUN apt-get clean
+RUN apt-get -qy update
+
+# Install some basic PHP dependencies.
+RUN apt-get -qy install $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
+
+# Install git
+RUN apt-get -qy install git
+
+# Set up sudo so they can have root access.
+RUN apt-get -qy install sudo
+RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers\`;`,
+		`# Package installs skipped: apt repos are blocked by the sandbox egress policy.
+RUN touch /usr/local/etc/php/php.ini
+RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers || true\`;`,
+		'wordpress apt block',
+	],
+	[
+		// CLI (alpine) service: drop apk steps. WP_CLI_ALLOW_ROOT keeps
+		// wp-cli from refusing every command when the host user is root.
+		`# Make sure we're working with the latest packages.
+RUN apk update
+
+# Install some basic PHP dependencies.
+RUN apk --no-cache add $PHPIZE_DEPS && touch /usr/local/etc/php/php.ini
+
+# Set up sudo so they can have root access.
+RUN apk --no-cache add sudo linux-headers
+RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers\`;`,
+		`# Package installs skipped: apk repos are blocked by the sandbox egress policy.
+RUN touch /usr/local/etc/php/php.ini
+RUN echo "#$HOST_UID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers || true
+ENV WP_CLI_ALLOW_ROOT=1\`;`,
+		'cli apk block',
+	],
+	[
+		`	// Make sure Composer is available for use in all services.
+	dockerFileContent += \`
+RUN curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
+RUN export COMPOSER_HASH=\\\`curl -sS https://composer.github.io/installer.sig\\\` && php -r "if (hash_file('SHA384', '/tmp/composer-setup.php') === '$COMPOSER_HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('/tmp/composer-setup.php'); } echo PHP_EOL;"
+RUN php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
+RUN rm /tmp/composer-setup.php\`;`,
+		`	// Composer install skipped: getcomposer.org is blocked by the sandbox egress policy.`,
+		'composer installer block',
+	],
+	[
+		`	// Install any Composer packages we might need globally.
+	// Make sure to do this as the user and ensure the binaries are available in the \$PATH.
+	dockerFileContent += \`
+USER $HOST_UID:$HOST_GID
+ENV PATH="\\\${PATH}:/home/$HOST_USERNAME/.composer/vendor/bin"
+RUN composer global require --dev phpunit/phpunit:"^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+USER root\`;`,
+		`	// PHPUnit install skipped: packagist is blocked by the sandbox egress policy.`,
+		'phpunit block',
+	],
+] );
+
+// --- 2. Compose config: Apache cannot run as root (AH00526). ---------------
+// When the host user is root, fall back to the image's stock www-data user.
+// File-permission parity (the reason wp-env matches the host user) doesn't
+// matter in a single-user sandbox; cloud-setup.sh opens up wp-content so
+// www-data can still write uploads.
+patchFile( 'lib/runtime/docker/build-docker-compose-config.js', [
+	[
+		`APACHE_RUN_USER: '#' + hostUser.uid,
+					APACHE_RUN_GROUP: '#' + hostUser.gid,`,
+		`APACHE_RUN_USER:
+						String( hostUser.uid ) === '0'
+							? 'www-data'
+							: '#' + hostUser.uid,
+					APACHE_RUN_GROUP:
+						String( hostUser.gid ) === '0'
+							? 'www-data'
+							: '#' + hostUser.gid,`,
+		'apache run user',
+		2,
+	],
+] );
+
+console.log( '[wp-env-offline-patch] done.' );


### PR DESCRIPTION
The cloud setup script never produced a working wp-env stack. Three
independent blockers, all verified empirically in a live session:

1. Docker Hub layer CDN (production.cloudfront.docker.com) is blocked by
   the sandbox egress policy — manifests resolve but every layer pull
   403s (this is NOT the anonymous rate limit the script assumed).
   Fix: write /etc/docker/daemon.json with mirror.gcr.io as a registry
   mirror before dockerd starts, with a public.ecr.aws retag fallback.

2. wp-env's generated Dockerfiles run apt/apk/composer/pecl at build
   time and every one of those CDNs is blocked, so builds die on
   'RUN apk update'. Fix: new scripts/wp-env-offline-patch.mjs strips
   the network-touching steps from @wordpress/env's templates after
   npm ci (idempotent, exact-match anchors that fail loudly on upstream
   changes). The dropped tools (composer/phpunit/sudo/xdebug) are unused
   by this repo's wp eval-file PHP suites.

3. The sandbox runs as root: wp-env maps the host user into its
   containers, so Apache exits 1 with AH00526 and wp-cli refuses every
   command. Fix (same patch): APACHE_RUN_USER/GROUP fall back to
   www-data when host uid is 0, CLI images bake in WP_CLI_ALLOW_ROOT=1,
   and cloud-setup chmods the wp-content trees so www-data can write.

Also: drop --with-deps from the Playwright install (it shells out to
apt-get, which is blocked, and the sandbox image already has the libs —
this is why Chromium was never installed).

Verified end-to-end on a fresh run of scripts/cloud-setup.sh: wp-env up
in ~15s warm, run-cascade-tests 40/40 PASS, run-alpha-routing-tests
53/53 PASS, wp-admin + front-page screenshots captured via Playwright.
docs/cloud-environment.md rewritten around the real network matrix.

https://claude.ai/code/session_014AtXwP15B6hgQrprX97kw5